### PR TITLE
User overrides of configuration and plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /ursamu
 ADD deps.ts docker-deps.ts LICENSE README.md pup pup.jsonc ursamu_github_banner.png /ursamu/
 ADD help/ /ursamu/help/
 ADD src/ /ursamu/src/
-RUN mkdir /ursamu/data
 RUN deno run -A deps.ts
 RUN deno run -A docker-deps.ts || true
 

--- a/data-sample/config.json
+++ b/data-sample/config.json
@@ -1,0 +1,40 @@
+{
+  "server": {
+    "plugins": [
+      "src/commands/@js.ts",
+      "src/commands/alias.ts",
+      "src/commands/attrCommands.ts",
+      "src/commands/BBS.ts",
+      "src/commands/building.ts",
+      "src/commands/channels.ts",
+      "src/commands/connect.ts",
+      "src/commands/create.ts",
+      "src/commands/data.ts",
+      "src/commands/desc.ts",
+      "src/commands/examine.ts",
+      "src/commands/finger.ts",
+      "src/commands/flags.ts",
+      "src/commands/help.ts",
+      "src/commands/lock.ts",
+      "src/commands/look.ts",
+      "src/commands/mail.ts",
+      "src/commands/moniker.ts",
+      "src/commands/name.ts",
+      "src/commands/page.ts",
+      "src/commands/pools.ts",
+      "src/commands/pose.ts",
+      "src/commands/quit.ts",
+      "src/commands/restart.ts",
+      "src/commands/roll.ts",
+      "src/commands/say.ts",
+      "src/commands/set.ts",
+      "src/commands/sheet.ts",
+      "src/commands/short.ts",
+      "src/commands/stats.ts",
+      "src/commands/test.ts",
+      "src/commands/think.ts",
+      "src/commands/upgrade.ts",
+      "src/commands/who.ts"
+    ]
+  }
+}

--- a/src/@types/IConfig.ts
+++ b/src/@types/IConfig.ts
@@ -9,6 +9,7 @@ export interface IConfig {
     mail?: string;
     wiki?: string;
     bboard?: string;
+    plugins?: string[];
   };
   game?: {
     name?: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ export const gameConfig = new Config(defaultConfig);
 export const mu = async (cfg?: IConfig, plugs?: IPlugin[] = []) => {
   gameConfig.setConfig({ ...defaultConfig, ...cfg });
 
-  const pluginsList = gameConfig.plugins || path.join(__dirname, "./commands");
+  const pluginsList = gameConfig.server.plugins || path.join(__dirname, "./commands");
   for(const plugin of plugs) {
     pluginsList.append(plugin)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ export const mu = async (cfg?: IConfig, plugs?: IPlugin[] = []) => {
   for(const plugin of plugs) {
     pluginsList.append(plugin)
   }
-  loadPlugins(pluginsList);
+  plugins(pluginsList);
   loadTxtDir(path.join(__dirname, "../text"));
 
   server.listen(gameConfig.server?.ws, async () => {


### PR DESCRIPTION
Setting up a framework for letting the user of a game control the server/MSSP config and the plugins list, and even add new plugins, without altering core and thus having to deal with merging and such.

data/ is even stored outside the docker, so it can be managed entirely separately from the containerized engine.