### PR TITLE
chore: bump self-import to v2.0.0, drop jobs export, fix chargenHooks type

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,6 @@
     "./start": "./src/cli/start.ts",
     "./app": "./src/app.ts",
     "./channels": "./src/services/channel-events.ts",
-    "./jobs": "./src/plugins/jobs/mod.ts",
     "./chargen": "./src/services/Chargen/index.ts"
   },
   "publish": {
@@ -56,7 +55,7 @@
     "lib": ["deno.window", "deno.unstable"]
   },
   "imports": {
-    "@ursamu/ursamu": "jsr:@ursamu/ursamu@^1.9.5",
+    "@ursamu/ursamu": "jsr:@ursamu/ursamu@^2.0.0",
     "@ursamu/ursamu/app": "./src/app.ts",
     "@ursamu/ursamu/channels": "./src/services/channel-events.ts",
     "@ursamu/ursamu/jobs": "./src/plugins/jobs/mod.ts",

--- a/src/services/Chargen/index.ts
+++ b/src/services/Chargen/index.ts
@@ -43,4 +43,4 @@ class ChargenHooks extends EventEmitter {
   }
 }
 
-export const chargenHooks = new ChargenHooks();
+export const chargenHooks: ChargenHooks = new ChargenHooks();


### PR DESCRIPTION
## Summary
- Bumps self-import alias from `^1.9.5` to `^2.0.0` in `deno.json` to match shipped v2.0.0
- Removes the `./jobs` export from `deno.json` (extracted to plugin)
- Adds explicit type annotation on `chargenHooks` in `Chargen/index.ts`