### PR TITLE
feat: v2.2.0 — lockfunc registry, && / || operators, security hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,33 @@ Examples:
 | Switch + arg | `/^\+cmd(?:\/(\S+))?\s*(.*)/i` | `[0]`=sw, `[1]`=rest |
 | Two parts (=) | `/^@name\s+(.+)=(.+)/i` | `[0]`, `[1]` |
 
+### Catch-all switch pattern — critical gotcha
+
+When a command uses the catch-all switch pattern `/^\+cmd(?:\/(\S+))?\s*(.*)/i`,
+**any more-specific `addCmd` registered for the same prefix will never match**.
+The catch-all pattern consumes `+cmd/anything` before the engine reaches the
+specific pattern.
+
+```typescript
+// WRONG — +cmd/sub addCmd is DEAD CODE; main +cmd handler matches first
+addCmd({ name: "+cmd", pattern: /^\+cmd(?:\/(\S+))?\s*(.*)/i, exec: ... });
+addCmd({ name: "+cmd/sub", pattern: /^\+cmd\/sub$/i, exec: ... }); // never reached
+
+// CORRECT — handle sub-commands as switch branches inside the main exec
+addCmd({
+  name: "+cmd",
+  pattern: /^\+cmd(?:\/(\S+))?\s*(.*)/i,
+  exec: async (u) => {
+    const sw = (u.cmd.args[0] ?? "").toLowerCase().trim();
+    if (sw === "sub") { /* handle sub */ return; }
+    // ...
+  },
+});
+```
+
+Only use separate `addCmd` registrations when the command prefixes are
+**distinct** (e.g. `+jobs` vs `+job` — different command roots).
+
 ### Lock levels
 
 | String | Who can use it |
@@ -104,6 +131,41 @@ Examples:
 | `"connected builder+"` | Builder flag or higher |
 | `"connected admin+"` | Admin flag or higher |
 | `"connected wizard"` | Wizard only |
+
+### Lockfunc system
+
+Lock strings support callable functions: `funcname(arg1, arg2)` combined with
+`&&`, `||`, `!`, and `()` grouping. Legacy `&` / `|` still work.
+
+**Built-in lockfuncs**
+
+| Lockfunc | Example | Passes when |
+|----------|---------|-------------|
+| `flag(name)` | `flag(wizard)` | enactor has the named flag |
+| `attr(name)` | `attr(tribe)` | enactor.state has own-property `name` |
+| `attr(name, val)` | `attr(tribe, glasswaler)` | enactor.state[name] === val |
+| `type(name)` | `type(player)` | enactor has the type flag |
+| `is(#id)` | `is(#5)` | enactor.id === "5" |
+| `holds(#id)` | `holds(#12)` | enactor.contents includes #12 |
+| `perm(level)` | `perm(admin)` | enactor passes privilege check |
+
+**Registering a custom lockfunc (plugins)**
+
+```typescript
+import { registerLockFunc } from "jsr:@ursamu/ursamu";
+
+registerLockFunc("tribe", (enactor, _target, args) =>
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// lock: "tribe(glasswaler)"
+// lock: "attr(mortal) || !tribe(glasswaler)"
+// lock: "connected && perm(builder)"
+```
+
+Built-in names (`flag`, `attr`, `type`, `is`, `holds`, `perm`) are protected
+and cannot be overwritten. Locks are fail-closed: unknown func → false,
+error → false. Max lock string: 4096 chars / 256 tokens.
 
 ---
 
@@ -376,6 +438,7 @@ function mockU(opts: {
 - [ ] DBO collection names prefixed with `<pluginName>.`
 - [ ] REST route handlers return 401 before any work when `userId` is null
 - [ ] `init()` returns `true`
+- [ ] Custom lockfuncs registered via `registerLockFunc` — never overwrite built-in names
 
 ---
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -67,6 +67,10 @@ export { register as registerSoftcodeFunc } from "./src/services/Softcode/stdlib
 export { registerSub as registerSoftcodeSub } from "./src/services/Softcode/stdlib/subRegistry.ts";
 export type { StdlibFn as SoftcodeFn } from "./src/services/Softcode/stdlib/registry.ts";
 export type { SubHandler as SoftcodeSubHandler } from "./src/services/Softcode/stdlib/subRegistry.ts";
+// Lock function registry — register custom lock functions from plugins
+export { registerLockFunc } from "./src/utils/lockFuncs.ts";
+export type { LockFunc } from "./src/utils/lockFuncs.ts";
+export { evaluateLock, validateLock } from "./src/utils/evaluateLock.ts";
 // Plugin lifecycle management — available to external plugins that need to read their config
 export { PluginConfigManager } from "./src/services/Config/plugin.ts";
 export type { IMiddlewareFunction } from "./src/@types/IMiddlewareFunction.ts";

--- a/src/cli/create-templates.ts
+++ b/src/cli/create-templates.ts
@@ -614,6 +614,52 @@ u.send("Message.", target.id);  // optional second arg = recipient socket id
 
 ---
 
+## Lock expressions & lockfuncs
+
+The \`lock:\` field on every \`addCmd\` is evaluated against the acting player before \`exec()\` runs.
+
+**String-level locks (privilege):**
+
+\`\`\`
+""                  login screen (unauthenticated)
+"connected"         any logged-in player
+"connected builder+" builder flag or higher
+"connected admin+"  admin flag or higher
+"connected wizard"  wizard only
+\`\`\`
+
+**Lockfunc expressions** — callable functions combined with \`&&\`, \`||\`, \`!\`, \`()\`:
+
+\`\`\`
+"flag(wizard)"                    enactor has wizard flag
+"attr(tribe, glasswaler)"         enactor.state.tribe === "glasswaler"
+"attr(sphere)"                    enactor has own-property "sphere" in state
+"type(player)"                    enactor has player type flag
+"is(#5)"                          enactor.id === "5"
+"holds(#12)"                      enactor's inventory contains #12
+"perm(admin)"                     enactor passes admin privilege check
+"attr(mortal) || !tribe(glasswaler)"  compound expression
+\`\`\`
+
+**Registering a custom lockfunc in your plugin:**
+
+\`\`\`typescript
+import { registerLockFunc } from "jsr:@ursamu/ursamu";
+
+// Call in your plugin's module scope (alongside addCmd — NOT inside init())
+registerLockFunc("tribe", (enactor, _target, args) =>
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// Now usable anywhere: lock: "connected && tribe(glasswaler)"
+\`\`\`
+
+Built-in names (\`flag\`, \`attr\`, \`type\`, \`is\`, \`holds\`, \`perm\`) are protected and cannot
+be overwritten. Locks are fail-closed: unknown func → false, thrown error → false.
+Max lock string: 4096 chars / 256 tokens.
+
+---
+
 ## Showcase — executes real commands in-process
 
 \`\`\`bash
@@ -700,6 +746,7 @@ Add a \`tests/security/\` directory for exploit→fix tests; one file per bug fo
 - [ ] REST route returns 401 before any work when \`userId\` is null
 - [ ] \`init()\` returns \`true\`
 - [ ] Every \`addCmd\` has \`help:\` with syntax line + examples
+- [ ] Custom lockfuncs use \`registerLockFunc\` — never overwrite built-in names (\`flag\`, \`attr\`, \`type\`, \`is\`, \`holds\`, \`perm\`)
 - [ ] Every help file ≤ 22 content lines
 - [ ] Every help file line ≤ 78 characters
 - [ ] Multi-page topics linked with \`SEE ALSO:\`

--- a/src/utils/evaluateLock.ts
+++ b/src/utils/evaluateLock.ts
@@ -5,6 +5,9 @@ import { flags } from "../services/flags/flags.ts";
 import type { IDBOBJ } from "../@types/IDBObj.ts";
 import type { IDBObj } from "../@types/UrsamuSDK.ts";
 import { Obj } from "../services/DBObjs/DBObjs.ts";
+import { callLockFunc } from "./lockFuncs.ts";
+
+const MAX_LOCK_LENGTH = 4096;
 
 export const evaluateLock = async (
   lockStr: string,
@@ -13,6 +16,7 @@ export const evaluateLock = async (
   depth = 0
 ): Promise<boolean> => {
   if (depth > MAX_LOCK_DEPTH) return false;
+  if (lockStr.length > MAX_LOCK_LENGTH) return false;
   return await parseLock(lockStr, enactor, target, false, depth);
 };
 
@@ -20,7 +24,7 @@ export const validateLock = async (lockStr: string): Promise<boolean> => {
     try {
         await parseLock(lockStr, null, null, true, 0);
         return true;
-    } catch {
+    } catch (_e: unknown) {
         return false;
     }
 };
@@ -35,11 +39,12 @@ const parseLock = async (
   if (!lockStr) return true;
 
   const tokens = tokenize(lockStr);
+  if (tokens.length > 256) return validationMode ? true : false;
   let pos = 0;
 
   const parseOr = async (): Promise<boolean> => {
     let left = await parseAnd();
-    while (pos < tokens.length && tokens[pos] === "|") {
+    while (pos < tokens.length && (tokens[pos] === "|" || tokens[pos] === "||")) {
         pos++;
         const right = await parseAnd();
         if (validationMode) left = true;
@@ -50,7 +55,7 @@ const parseLock = async (
 
   const parseAnd = async (): Promise<boolean> => {
     let left = await parseNot();
-    while (pos < tokens.length && tokens[pos] === "&") {
+    while (pos < tokens.length && (tokens[pos] === "&" || tokens[pos] === "&&")) {
       pos++;
       const right = await parseNot();
       if (validationMode) left = true;
@@ -99,7 +104,7 @@ const parseLock = async (
     // Direct Check (Flag, ID, etc)
     if (validationMode) return true;
     if (!enactor || !target) return false;
-    return checkAtom(token, enactor, target, depth);
+    return checkAtom(token, enactor, target, depth, validationMode);
   };
 
   return await parseOr();
@@ -125,7 +130,38 @@ const tokenize = (str: string): string[] => {
       }
     } else if (depth > 0) {
       current += char;
-    } else if (["&", "|", "!", "(", ")"].includes(char)) {
+    } else if (char === "&" || char === "|") {
+      if (current.trim()) tokens.push(current.trim());
+      if (str[i + 1] === char) {
+        tokens.push(char + char);
+        i++;
+      } else {
+        tokens.push(char);
+      }
+      current = "";
+    } else if (char === "(") {
+      const trimmed = current.trim();
+      if (trimmed && /^[a-z_][a-z0-9_]*$/i.test(trimmed)) {
+        // funcname( — consume until matching ) as a single token
+        current = trimmed + char;
+        let pd = 1;
+        i++;
+        while (i < str.length && pd > 0) {
+          const c = str[i];
+          current += c;
+          if (c === "(") pd++;
+          else if (c === ")") pd--;
+          i++;
+        }
+        i--;
+        tokens.push(current.trim());
+        current = "";
+      } else {
+        if (trimmed) tokens.push(trimmed);
+        tokens.push("(");
+        current = "";
+      }
+    } else if (["!", ")"].includes(char)) {
       if (current.trim()) tokens.push(current.trim());
       tokens.push(char);
       current = "";
@@ -137,9 +173,17 @@ const tokenize = (str: string): string[] => {
   return tokens;
 };
 
-const checkAtom = async (atom: string, enactor: IDBObj, _target: IDBObj, depth: number): Promise<boolean> => {
-  if (depth > 10) return false; // Prevent deep recursion in atom checks
+const checkAtom = async (atom: string, enactor: IDBObj, target: IDBObj, depth: number, validationMode: boolean): Promise<boolean> => {
+  if (depth > 10) return false;
   atom = atom.trim();
+
+  const funcMatch = atom.match(/^([a-z_][a-z0-9_]*)\(([^)]*)\)$/i);
+  if (funcMatch) {
+    if (validationMode) return true;
+    const name = funcMatch[1].toLowerCase();
+    const args = funcMatch[2].split(",").map((s) => s.trim()).filter(Boolean);
+    return callLockFunc(name, enactor, target, args);
+  }
 
   // Power/Flag Check
   if (atom.startsWith("+") || atom.match(/^[a-zA-Z0-9_+]+$/)) { 

--- a/src/utils/lockFuncs.ts
+++ b/src/utils/lockFuncs.ts
@@ -1,0 +1,99 @@
+import type { IDBObj } from "../@types/UrsamuSDK.ts";
+import { flags } from "../services/flags/flags.ts";
+
+/**
+ * A lock function that determines whether an enactor may access a target.
+ * @param enactor - The object attempting access.
+ * @param target - The object being accessed.
+ * @param args - Parsed arguments from the lock expression.
+ * @returns `true` to grant access, `false` to deny.
+ */
+export type LockFunc = (
+  enactor: IDBObj,
+  target: IDBObj,
+  args: string[],
+) => Promise<boolean> | boolean;
+
+const registry = new Map<string, LockFunc>();
+const RESERVED = new Set<string>();
+
+// Internal-only: registers a built-in and marks its name as reserved.
+function registerBuiltin(name: string, fn: LockFunc): void {
+  const key = name.toLowerCase();
+  registry.set(key, fn);
+  RESERVED.add(key);
+}
+
+/**
+ * Registers a custom lock function under the given name.
+ * Built-in names (`flag`, `attr`, `type`, `is`, `holds`, `perm`) are
+ * protected — calls using those names silently no-op.
+ * @param name - Case-insensitive name used in lock expressions.
+ * @param fn - The lock function to register.
+ */
+export function registerLockFunc(name: string, fn: LockFunc): void {
+  const key = name.toLowerCase();
+  if (RESERVED.has(key)) return;
+  registry.set(key, fn);
+}
+
+/**
+ * Invokes a registered lock function by name.
+ * Fail-closed: returns `false` for unknown names and swallows thrown errors.
+ * @param name - The lock function name to look up.
+ * @param enactor - The object attempting access.
+ * @param target - The object being accessed.
+ * @param args - Parsed arguments from the lock expression.
+ * @returns `true` if access is granted, `false` otherwise.
+ */
+export async function callLockFunc(
+  name: string,
+  enactor: IDBObj,
+  target: IDBObj,
+  args: string[],
+): Promise<boolean> {
+  const fn = registry.get(name.toLowerCase());
+  if (!fn) return false;
+  try {
+    return await fn(enactor, target, args);
+  } catch (_e: unknown) {
+    return false;
+  }
+}
+
+/** `flag(<flagname>)` — grants access if the enactor holds the named flag. */
+registerBuiltin("flag", (enactor, _target, args) => {
+  return enactor.flags.has((args[0] ?? "").trim().toLowerCase());
+});
+
+/** `attr(<attr>[=<value>])` — grants access if the enactor has the attribute, optionally matching a value. */
+registerBuiltin("attr", (enactor, _target, args) => {
+  const attrName = (args[0] ?? "").trim();
+  if (!Object.hasOwn(enactor.state, attrName)) return false;
+  if (args.length < 2) return true;
+  return String(enactor.state[attrName]) === args[1].trim();
+});
+
+/** `type(<typename>)` — grants access if the enactor's flags include the named type. */
+registerBuiltin("type", (enactor, _target, args) => {
+  return enactor.flags.has((args[0] ?? "").trim().toLowerCase());
+});
+
+/** `is(<dbref>)` — grants access if the enactor's id matches the given dbref. */
+registerBuiltin("is", (enactor, _target, args) => {
+  const dbref = (args[0] ?? "").trim();
+  return enactor.id === dbref.replace(/^#/, "");
+});
+
+/** `holds(<dbref>)` — grants access if the enactor's inventory contains the given dbref. */
+registerBuiltin("holds", (enactor, _target, args) => {
+  const dbref = (args[0] ?? "").trim().replace(/^#/, "");
+  return enactor.contents.some((c) => c.id === dbref);
+});
+
+/** `perm(<level>)` — grants access if the enactor's flags satisfy the named permission level. */
+registerBuiltin("perm", (enactor, _target, args) => {
+  const permLevel = (args[0] ?? "").trim();
+  const flagStr = Array.from(enactor.flags).join(" ");
+  return flags.check(flagStr, permLevel);
+});

--- a/tests/lockFuncs.test.ts
+++ b/tests/lockFuncs.test.ts
@@ -1,0 +1,310 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+import {
+  callLockFunc,
+  registerLockFunc,
+} from "../src/utils/lockFuncs.ts";
+import { evaluateLock } from "../src/utils/evaluateLock.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function mockPlayer(overrides: Partial<IDBObj> = {}): IDBObj {
+  return {
+    id: "lf_actor1",
+    name: "Tester",
+    flags: new Set(["player", "connected"]),
+    state: {},
+    location: "lf_room1",
+    contents: [],
+    ...overrides,
+  };
+}
+
+// ── callLockFunc built-ins ──────────────────────────────────────────────────
+
+Deno.test("flag(wizard) → true when enactor has wizard flag", OPTS, async () => {
+  const enactor = mockPlayer({ flags: new Set(["player", "connected", "wizard"]) });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("flag", enactor, target, ["wizard"]), true);
+});
+
+Deno.test("flag(wizard) → false when enactor lacks wizard flag", OPTS, async () => {
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("flag", enactor, target, ["wizard"]), false);
+});
+
+Deno.test("attr(tribe) 1-arg → true when state.tribe exists", OPTS, async () => {
+  const enactor = mockPlayer({ state: { tribe: "glasswalker" } });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("attr", enactor, target, ["tribe"]), true);
+});
+
+Deno.test("attr(tribe) 1-arg → false when state.tribe missing", OPTS, async () => {
+  const enactor = mockPlayer({ state: {} });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("attr", enactor, target, ["tribe"]), false);
+});
+
+Deno.test(
+  "attr(tribe, glasswalker) → true when state.tribe === 'glasswalker'",
+  OPTS,
+  async () => {
+    const enactor = mockPlayer({ state: { tribe: "glasswalker" } });
+    const target = mockPlayer({ id: "lf_target1" });
+    assertEquals(
+      await callLockFunc("attr", enactor, target, ["tribe", "glasswalker"]),
+      true,
+    );
+  },
+);
+
+Deno.test(
+  "attr(tribe, glasswalker) → false when state.tribe !== 'glasswalker'",
+  OPTS,
+  async () => {
+    const enactor = mockPlayer({ state: { tribe: "bonegnawer" } });
+    const target = mockPlayer({ id: "lf_target1" });
+    assertEquals(
+      await callLockFunc("attr", enactor, target, ["tribe", "glasswalker"]),
+      false,
+    );
+  },
+);
+
+Deno.test("is(#lf_actor1) → true when enactor.id matches", OPTS, async () => {
+  const enactor = mockPlayer({ id: "lf_actor1" });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("is", enactor, target, ["#lf_actor1"]), true);
+});
+
+Deno.test("is(#other) → false when enactor.id does not match", OPTS, async () => {
+  const enactor = mockPlayer({ id: "lf_actor1" });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("is", enactor, target, ["#other"]), false);
+});
+
+Deno.test("holds(#lf_item1) → true when contents includes id", OPTS, async () => {
+  const item = mockPlayer({ id: "lf_item1", name: "Item" });
+  const enactor = mockPlayer({ contents: [item] });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("holds", enactor, target, ["#lf_item1"]), true);
+});
+
+Deno.test("holds(#lf_item1) → false when contents is empty", OPTS, async () => {
+  const enactor = mockPlayer({ contents: [] });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("holds", enactor, target, ["#lf_item1"]), false);
+});
+
+Deno.test("perm(admin) → true for admin-flagged enactor", OPTS, async () => {
+  const enactor = mockPlayer({ flags: new Set(["player", "connected", "admin"]) });
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("perm", enactor, target, ["admin"]), true);
+});
+
+Deno.test("unknown func → false (fail-closed)", OPTS, async () => {
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(
+    await callLockFunc("noSuchFunc_lf", enactor, target, []),
+    false,
+  );
+});
+
+Deno.test("func that throws → false (fail-closed)", OPTS, async () => {
+  registerLockFunc("lf_throws", () => {
+    throw new Error("boom");
+  });
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("lf_throws", enactor, target, []), false);
+});
+
+// ── registerLockFunc (custom funcs) ────────────────────────────────────────
+
+Deno.test("registered func returning true → evaluates true", OPTS, async () => {
+  registerLockFunc("lf_alwaysTrue", () => true);
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("lf_alwaysTrue", enactor, target, []), true);
+});
+
+Deno.test("registered func returning false → evaluates false", OPTS, async () => {
+  registerLockFunc("lf_alwaysFalse", () => false);
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("lf_alwaysFalse", enactor, target, []), false);
+});
+
+Deno.test("re-registering same name overwrites previous", OPTS, async () => {
+  registerLockFunc("lf_overwrite", () => true);
+  registerLockFunc("lf_overwrite", () => false);
+  const enactor = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await callLockFunc("lf_overwrite", enactor, target, []), false);
+});
+
+// ── evaluateLock integration ───────────────────────────────────────────────
+
+Deno.test('evaluateLock "flag(wizard)" — evaluates correctly', OPTS, async () => {
+  const withWiz = mockPlayer({ flags: new Set(["player", "connected", "wizard"]) });
+  const without = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await evaluateLock("flag(wizard)", withWiz, target), true);
+  assertEquals(await evaluateLock("flag(wizard)", without, target), false);
+});
+
+Deno.test('evaluateLock "flag(wizard) || flag(admin)" — OR with ||', OPTS, async () => {
+  const admin = mockPlayer({ flags: new Set(["player", "connected", "admin"]) });
+  const plain = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await evaluateLock("flag(wizard) || flag(admin)", admin, target), true);
+  assertEquals(await evaluateLock("flag(wizard) || flag(admin)", plain, target), false);
+});
+
+Deno.test(
+  'evaluateLock "flag(wizard) && flag(connected)" — AND with &&',
+  OPTS,
+  async () => {
+    const wizConn = mockPlayer({
+      flags: new Set(["player", "connected", "wizard"]),
+    });
+    const wizOnly = mockPlayer({
+      flags: new Set(["player", "wizard"]),
+    });
+    const target = mockPlayer({ id: "lf_target1" });
+    assertEquals(
+      await evaluateLock("flag(wizard) && flag(connected)", wizConn, target),
+      true,
+    );
+    assertEquals(
+      await evaluateLock("flag(wizard) && flag(connected)", wizOnly, target),
+      false,
+    );
+  },
+);
+
+Deno.test('evaluateLock "flag(wizard) | flag(admin)" — legacy | still works', OPTS, async () => {
+  const admin = mockPlayer({ flags: new Set(["player", "connected", "admin"]) });
+  const plain = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await evaluateLock("flag(wizard) | flag(admin)", admin, target), true);
+  assertEquals(await evaluateLock("flag(wizard) | flag(admin)", plain, target), false);
+});
+
+Deno.test(
+  'evaluateLock "flag(wizard) & flag(connected)" — legacy & still works',
+  OPTS,
+  async () => {
+    const wizConn = mockPlayer({
+      flags: new Set(["player", "connected", "wizard"]),
+    });
+    const wizOnly = mockPlayer({ flags: new Set(["player", "wizard"]) });
+    const target = mockPlayer({ id: "lf_target1" });
+    assertEquals(
+      await evaluateLock("flag(wizard) & flag(connected)", wizConn, target),
+      true,
+    );
+    assertEquals(
+      await evaluateLock("flag(wizard) & flag(connected)", wizOnly, target),
+      false,
+    );
+  },
+);
+
+Deno.test('evaluateLock "!flag(wizard)" — NOT still works', OPTS, async () => {
+  const withWiz = mockPlayer({ flags: new Set(["player", "connected", "wizard"]) });
+  const without = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  assertEquals(await evaluateLock("!flag(wizard)", withWiz, target), false);
+  assertEquals(await evaluateLock("!flag(wizard)", without, target), true);
+});
+
+Deno.test(
+  'evaluateLock "mortal || !flag(wizard)" — mixed bare atom + lockfunc',
+  OPTS,
+  async () => {
+    const mortal = mockPlayer({ flags: new Set(["player", "connected", "mortal"]) });
+    const plain = mockPlayer();
+    const withWiz = mockPlayer({ flags: new Set(["player", "connected", "wizard"]) });
+    const target = mockPlayer({ id: "lf_target1" });
+    // mortal flag present → true via bare atom
+    assertEquals(await evaluateLock("mortal || !flag(wizard)", mortal, target), true);
+    // no mortal, no wizard → true via !flag(wizard)
+    assertEquals(await evaluateLock("mortal || !flag(wizard)", plain, target), true);
+    // wizard present, no mortal flag → false (mortal=false, !wizard=false)
+    assertEquals(
+      await evaluateLock("mortal || !flag(wizard)", withWiz, target),
+      false,
+    );
+  },
+);
+
+Deno.test(
+  'evaluateLock "attr(tribe, glasswalker)" — attr 2-arg in full evaluator',
+  OPTS,
+  async () => {
+    const matching = mockPlayer({ state: { tribe: "glasswalker" } });
+    const notMatching = mockPlayer({ state: { tribe: "bonegnawer" } });
+    const missing = mockPlayer({ state: {} });
+    const target = mockPlayer({ id: "lf_target1" });
+    assertEquals(
+      await evaluateLock("attr(tribe, glasswalker)", matching, target),
+      true,
+    );
+    assertEquals(
+      await evaluateLock("attr(tribe, glasswalker)", notMatching, target),
+      false,
+    );
+    assertEquals(
+      await evaluateLock("attr(tribe, glasswalker)", missing, target),
+      false,
+    );
+  },
+);
+
+// ── Security exploit tests ────────────────────────────────────────────────
+
+Deno.test("H1 exploit: attr(__proto__) must NOT grant access to all enactors", OPTS, async () => {
+  const plain = mockPlayer({ state: {} });
+  const target = mockPlayer({ id: "lf_target1" });
+  // __proto__ and other prototype keys must not leak as truthy own attrs
+  assertEquals(await callLockFunc("attr", plain, target, ["__proto__"]), false);
+  assertEquals(await callLockFunc("attr", plain, target, ["constructor"]), false);
+  assertEquals(await callLockFunc("attr", plain, target, ["toString"]), false);
+  assertEquals(await evaluateLock("attr(__proto__)", plain, target), false);
+});
+
+Deno.test("H2 exploit: registerLockFunc must not overwrite built-in flag/perm", OPTS, () => {
+  // Attacker plugin tries to replace security-critical built-ins with always-true stubs
+  // This must either throw or silently no-op — it must NOT succeed in replacing them
+  registerLockFunc("flag", () => true);
+  registerLockFunc("perm", () => true);
+
+  const plain = mockPlayer(); // no wizard flag
+  const target = mockPlayer({ id: "lf_target1" });
+  // flag(wizard) must still return false for a non-wizard player
+  return callLockFunc("flag", plain, target, ["wizard"]).then((result) => {
+    assertEquals(result, false, "built-in 'flag' was overwritten — privilege escalation");
+  });
+});
+
+Deno.test("M1 exploit: oversized lock string must be rejected (DoS guard)", OPTS, async () => {
+  const plain = mockPlayer();
+  const target = mockPlayer({ id: "lf_target1" });
+  // 5000-char lock string — must not hang and must return false
+  const huge = "flag(connected)||".repeat(300);
+  assertEquals(await evaluateLock(huge, plain, target), false);
+});
+
+Deno.test("M2 exploit: excessive token count must be rejected (DoS guard)", OPTS, async () => {
+  const plain = mockPlayer({ flags: new Set(["player", "connected"]) });
+  const target = mockPlayer({ id: "lf_target1" });
+  // Register an always-true custom func so the expression would naturally be true
+  registerLockFunc("lf_ok", () => true);
+  // 300 lf_ok() tokens joined by && → 599 tokens, 2698 chars (under 4096 string limit)
+  // Without a token cap this returns true; with the cap it must return false
+  const manyTokens = Array(300).fill("lf_ok()").join("&&");
+  assertEquals(await evaluateLock(manyTokens, plain, target), false);
+});

--- a/tests/lockFuncs_e2e.test.ts
+++ b/tests/lockFuncs_e2e.test.ts
@@ -1,0 +1,180 @@
+/**
+ * E2E tests for the lockfunc registry through the full command pipeline.
+ *
+ * Flow: registerLockFunc → addCmd(lock) → matchNativeCmd → evaluateLock → handler
+ *
+ * These tests use real DB objects (dbojs.create) and call matchNativeCmd
+ * directly, which is the same gate the WebSocket layer hits for every command.
+ */
+import { assertEquals } from "jsr:@std/assert@^1";
+import { dbojs } from "../src/services/Database/index.ts";
+import { DBO } from "../src/services/Database/database.ts";
+import { Obj } from "../src/services/DBObjs/DBObjs.ts";
+import { matchNativeCmd } from "../src/services/commands/pipeline-stages.ts";
+import { registerLockFunc } from "../src/utils/lockFuncs.ts";
+import type { ICmd } from "../src/@types/ICmd.ts";
+import type { IContext } from "../src/@types/IContext.ts";
+import type { IUrsamuSDK } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+// ── Minimal socket mock ────────────────────────────────────────────────────
+
+function mockSocket(id: string): IContext["socket"] {
+  return {
+    id,
+    cid: id,
+    join: () => {},
+    leave: () => {},
+    disconnect: () => {},
+    on: () => {},
+    send: () => {},
+  } as unknown as IContext["socket"];
+}
+
+function mockCtx(socketId: string): IContext {
+  return { socket: mockSocket(socketId) };
+}
+
+// ── Test command builder ───────────────────────────────────────────────────
+
+function makeCmd(lock: string, received: string[]): ICmd {
+  return {
+    name: "+e2e-tribe",
+    pattern: /^\+e2e-tribe$/i,
+    lock,
+    category: "Test",
+    exec: (u: IUrsamuSDK) => { received.push(u.me.id); },
+  };
+}
+
+// ── DB player helpers ──────────────────────────────────────────────────────
+
+async function createTestPlayer(
+  id: string,
+  extraData: Record<string, unknown> = {},
+): Promise<Obj> {
+  await dbojs.create({
+    id,
+    flags: "player connected",
+    data: { name: `E2EPlayer_${id}`, ...extraData },
+  });
+  const raw = await dbojs.queryOne({ id });
+  if (!raw) throw new Error(`Failed to create test player ${id}`);
+  return new Obj(raw);
+}
+
+async function destroyTestPlayer(id: string): Promise<void> {
+  await dbojs.delete({ id });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+Deno.test(
+  "e2e: custom tribe() lockfunc — player WITH tribe passes, player WITHOUT is denied",
+  OPTS,
+  async () => {
+    // Register the game-specific lockfunc (simulates a WoD plugin doing this)
+    registerLockFunc("tribe", (enactor, _target, args) => {
+      const expected = (args[0] ?? "").trim().toLowerCase();
+      const actual = String(enactor.state.tribe ?? "").toLowerCase();
+      return actual === expected;
+    });
+
+    const withTribe = await createTestPlayer("e2e_p1", { tribe: "glasswaler" });
+    const noTribe = await createTestPlayer("e2e_p2");
+
+    const received: string[] = [];
+    const cmds: ICmd[] = [makeCmd("tribe(glasswaler)", received)];
+
+    // Player with matching tribe — command should execute
+    const hitWith = await matchNativeCmd(
+      mockCtx("e2e_p1"),
+      withTribe,
+      "+e2e-tribe",
+      cmds,
+    );
+    assertEquals(hitWith, true, "matchNativeCmd should return true for allowed player");
+    assertEquals(received.includes("e2e_p1"), true, "exec should have fired for e2e_p1");
+
+    // Player without tribe — command should be denied by lock
+    const hitWithout = await matchNativeCmd(
+      mockCtx("e2e_p2"),
+      noTribe,
+      "+e2e-tribe",
+      cmds,
+    );
+    assertEquals(hitWithout, false, "matchNativeCmd should return false for denied player");
+    assertEquals(received.includes("e2e_p2"), false, "exec must NOT fire for e2e_p2");
+
+    await destroyTestPlayer("e2e_p1");
+    await destroyTestPlayer("e2e_p2");
+  },
+);
+
+Deno.test(
+  "e2e: built-in attr() lockfunc — allows player with matching state attr",
+  OPTS,
+  async () => {
+    const withSphere = await createTestPlayer("e2e_p3", { sphere: "vampire" });
+    const wrongSphere = await createTestPlayer("e2e_p4", { sphere: "mage" });
+
+    const received: string[] = [];
+    const cmds: ICmd[] = [makeCmd("attr(sphere, vampire)", received)];
+
+    const hitMatch = await matchNativeCmd(
+      mockCtx("e2e_p3"),
+      withSphere,
+      "+e2e-tribe",
+      cmds,
+    );
+    assertEquals(hitMatch, true);
+    assertEquals(received.includes("e2e_p3"), true);
+
+    const hitWrong = await matchNativeCmd(
+      mockCtx("e2e_p4"),
+      wrongSphere,
+      "+e2e-tribe",
+      cmds,
+    );
+    assertEquals(hitWrong, false);
+    assertEquals(received.includes("e2e_p4"), false);
+
+    await destroyTestPlayer("e2e_p3");
+    await destroyTestPlayer("e2e_p4");
+  },
+);
+
+Deno.test(
+  "e2e: compound lockfunc expression — mortal || !tribe(glasswaler)",
+  OPTS,
+  async () => {
+    const mortal = await createTestPlayer("e2e_p5", { mortal: true });
+    const glasswaler = await createTestPlayer("e2e_p6", { tribe: "glasswaler" });
+    const plain = await createTestPlayer("e2e_p7");
+
+    const received: string[] = [];
+    // mortal attr present OR not a glasswaler
+    const cmds: ICmd[] = [makeCmd("attr(mortal) || !tribe(glasswaler)", received)];
+
+    // mortal → passes via attr(mortal)
+    await matchNativeCmd(mockCtx("e2e_p5"), mortal, "+e2e-tribe", cmds);
+    assertEquals(received.includes("e2e_p5"), true, "mortal player should pass");
+
+    // glasswaler + no mortal → fails (!tribe(glasswaler) is false, attr(mortal) is false)
+    await matchNativeCmd(mockCtx("e2e_p6"), glasswaler, "+e2e-tribe", cmds);
+    assertEquals(received.includes("e2e_p6"), false, "glasswaler-only player should be denied");
+
+    // plain player (no tribe, no mortal) → passes via !tribe(glasswaler)
+    await matchNativeCmd(mockCtx("e2e_p7"), plain, "+e2e-tribe", cmds);
+    assertEquals(received.includes("e2e_p7"), true, "plain player passes via !tribe(glasswaler)");
+
+    await destroyTestPlayer("e2e_p5");
+    await destroyTestPlayer("e2e_p6");
+    await destroyTestPlayer("e2e_p7");
+  },
+);
+
+Deno.test("e2e: cleanup DB", OPTS, async () => {
+  await DBO.close();
+});


### PR DESCRIPTION
## Summary

- **Lockfunc registry** — `registerLockFunc(name, fn)` lets plugins register callable lock functions (`tribe(glasswaler)`, `sphere(vampire)`, etc.) usable in any `addCmd` lock string or object lock
- **`&&` / `||` operators** — standard boolean operators in lock strings; legacy `&` / `|` still work
- **Six built-ins** — `flag()`, `attr()`, `type()`, `is()`, `holds()`, `perm()` — all protected from overwrite
- **Security hardening** — `attr()` uses `Object.hasOwn()` (closes prototype confusion bypass H1), 4096-char + 256-token limits (DoS guards M1/M2), built-in name protection (H2)
- **Exports** — `registerLockFunc`, `LockFunc`, `evaluateLock`, `validateLock` now exported from `mod.ts`

## New lock string examples

```
"tribe(glasswaler)"
"attr(mortal) || !tribe(glasswaler)"
"type(player) && attr(sphere, vampire)"
"connected && perm(builder)"
```

## Test plan

- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean (337 files)
- [x] `deno test tests/ --allow-all --unstable-kv --no-check` — 1040 passed, 0 failed
- [x] `deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check` — 126 passed, 0 failed
- [x] 5 exploit→patch TDD tests (H1 prototype confusion, H2 built-in overwrite, M1/M2 DoS, L1 style)
- [x] 3 e2e tests through `matchNativeCmd` with real DB players