### PR TITLE
feat: v2.3.0 — format-attribute pipeline, softcode layout helpers, DoS hardening

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -71,6 +71,20 @@ export type { SubHandler as SoftcodeSubHandler } from "./src/services/Softcode/s
 export { registerLockFunc } from "./src/utils/lockFuncs.ts";
 export type { LockFunc } from "./src/utils/lockFuncs.ts";
 export { evaluateLock, validateLock } from "./src/utils/evaluateLock.ts";
+// Format handlers — register plugin-level NAMEFORMAT/DESCFORMAT/CONFORMAT/EXITFORMAT
+// fallbacks (priority: softcode attr > plugin handler > built-in default)
+export {
+  registerFormatHandler,
+  unregisterFormatHandler,
+} from "./src/utils/formatHandlers.ts";
+export type { FormatHandler, FormatSlot } from "./src/utils/formatHandlers.ts";
+// Native layout helpers (TS-side) — block-style header/divider/footer rules for
+// command output. Distinct from the inline softcode helpers of the same name
+// registered in src/services/Softcode/stdlib/string.ts.
+export { header, divider, footer } from "./src/utils/format.ts";
+// resolveFormat — shared helper for commands that want format-attr / plugin-handler /
+// built-in default rendering (used by `look`; reusable by `who`, `@ps`, external plugins).
+export { resolveFormat, resolveFormatOr } from "./src/utils/resolveFormat.ts";
 // Plugin lifecycle management — available to external plugins that need to read their config
 export { PluginConfigManager } from "./src/services/Config/plugin.ts";
 export type { IMiddlewareFunction } from "./src/@types/IMiddlewareFunction.ts";

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -1,13 +1,10 @@
 // deno-lint-ignore-file require-await
 import { addCmd } from "../services/commands/cmdParser.ts";
+import { divider, footer, header } from "../utils/format.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-const HR = "=".repeat(78);
-const hr = "-".repeat(78);
-
-function section(title: string): string {
-  return `\n%ch${title}%cn\n${hr}`;
-}
+const HR = footer();
+const section = (title: string): string => divider(title);
 
 function fmtSecs(secs: number): string {
   const d = Math.floor(secs / 86400);
@@ -24,9 +21,7 @@ async function demoOverview(u: IUrsamuSDK) {
   const me = u.me;
   const name = (me.state.moniker as string) || me.name || "Unknown";
   const uptime = await u.sys.uptime();
-  let out = `${HR}\n`;
-  out += u.util.center("%ch UrsaMU Script Engine Demo %cn", 78) + "\n";
-  out += `${HR}\n`;
+  let out = header(" UrsaMU Script Engine Demo ") + "\n";
   out += `\nYou are: %ch${name}%cn  (#${me.id})`;
   out += `\nHere:    %ch${u.here.name ?? "Void"}%cn  (#${u.here.id})`;
   out += `\nUptime:  ${fmtSecs(uptime)}`;

--- a/src/commands/look.ts
+++ b/src/commands/look.ts
@@ -1,5 +1,6 @@
 import { addCmd } from "../services/commands/cmdParser.ts";
 import type { IUrsamuSDK, IDBObj } from "../@types/UrsamuSDK.ts";
+import { resolveFormat } from "../utils/resolveFormat.ts";
 
 export async function execLook(u: IUrsamuSDK): Promise<void> {
   const actor = u.me;
@@ -27,7 +28,7 @@ export async function execLook(u: IUrsamuSDK): Promise<void> {
   const showContents = !isOpaque || canEditTarget;
 
   const rawDesc = (target.state.description as string) || "You see nothing special.";
-  const description = u.util.parseDesc
+  const parsedDesc = u.util.parseDesc
     ? await (u.util.parseDesc as (d: string, a: IDBObj, t: IDBObj) => Promise<string>)(rawDesc, actor, target)
     : rawDesc;
 
@@ -40,26 +41,55 @@ export async function execLook(u: IUrsamuSDK): Promise<void> {
   );
   const exits = contents.filter((obj) => obj.flags.has("exit"));
 
-  const nameStr = canEditTarget
+  // Section spacing rule: overrides are emitted exactly as produced — any
+  // blank lines must come from the attr/handler itself. Built-in defaults
+  // carry their own trailing/leading newlines to preserve historical layout.
+
+  // NAMEFORMAT — replaces the header line. %0 = default rendered name.
+  const defaultName = canEditTarget
     ? `${u.util.displayName(target, actor)}(#${target.id})`
     : u.util.displayName(target, actor);
-  let out = `%ch${nameStr}%cn\n${description}\n`;
+  const nameOverride = await resolveFormat(u, target, "NAMEFORMAT", defaultName);
+  const nameBlock = nameOverride != null ? nameOverride : `%ch${defaultName}%cn\n`;
 
+  // DESCFORMAT — wraps/replaces the description. %0 = post-parseDesc text.
+  const descOverride = await resolveFormat(u, target, "DESCFORMAT", parsedDesc);
+  const descBlock = descOverride != null ? descOverride : `${parsedDesc}\n`;
+
+  let out = nameBlock + descBlock;
+
+  // CONFORMAT — replaces combined characters+objects block. %0 = space-separated #ids.
   if (showContents) {
-    if (characters.length > 0) {
-      out += "\n%chCharacters:%cn\n";
-      for (const c of characters) out += `  ${u.util.displayName(c, actor)}\n`;
-    }
-    if (objects.length > 0) {
-      out += "\n%chContents:%cn\n";
-      for (const o of objects) out += `  ${u.util.displayName(o, actor)}\n`;
+    const visible = [...characters, ...objects];
+    if (visible.length > 0) {
+      const idList = visible.map((o) => `#${o.id}`).join(" ");
+      const conOverride = await resolveFormat(u, target, "CONFORMAT", idList);
+      if (conOverride != null) {
+        out += conOverride;
+      } else {
+        if (characters.length > 0) {
+          out += "\n%chCharacters:%cn\n";
+          for (const c of characters) out += `  ${u.util.displayName(c, actor)}\n`;
+        }
+        if (objects.length > 0) {
+          out += "\n%chContents:%cn\n";
+          for (const o of objects) out += `  ${u.util.displayName(o, actor)}\n`;
+        }
+      }
     }
   }
 
+  // EXITFORMAT — replaces the exits block. %0 = space-separated exit #ids.
   if (exits.length > 0) {
-    out += "\n%chExits:%cn\n";
-    const exitNames = exits.map((e) => ((e.state.name as string) || e.name || "").split(";")[0]);
-    out += `  ${exitNames.join("  ")}\n`;
+    const idList = exits.map((e) => `#${e.id}`).join(" ");
+    const exitOverride = await resolveFormat(u, target, "EXITFORMAT", idList);
+    if (exitOverride != null) {
+      out += exitOverride;
+    } else {
+      const exitNames = exits.map((e) => ((e.state.name as string) || e.name || "").split(";")[0]);
+      out += "\n%chExits:%cn\n";
+      out += `  ${exitNames.join("  ")}\n`;
+    }
   }
 
   u.send(out);

--- a/src/commands/ps.ts
+++ b/src/commands/ps.ts
@@ -3,36 +3,31 @@ import { isStaff } from "../utils/index.ts";
 import { queue } from "../services/Queue/index.ts";
 import { dbojs } from "../services/Database/index.ts";
 import { send } from "../services/broadcast/index.ts";
+import { resolveFormat } from "../utils/resolveFormat.ts";
+import { hydrate } from "../utils/evaluateLock.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
+import type { FormatSlot } from "../utils/formatHandlers.ts";
 
 /**
- * @ps — list queued processes on the time-delay and semaphore queues.
- * Switches: /brief (default), /long, /summary, /all
+ * Two-tier format lookup: check `#0` (root) for game-wide skin first, then
+ * the enactor (`u.me`) for per-player skin. Returns null if neither yields
+ * a non-null override.
  */
-export default () =>
-  addCmd({
-    name: "@ps",
-    pattern: /^@ps(?:\/([\w]+))?\s*(.*)?/i,
-    lock: "connected",
-    category: "Softcode",
-    help: `@ps[/<switch>] [<object>]
+async function resolveGlobalFormat(
+  u: IUrsamuSDK,
+  slot: FormatSlot,
+  defaultArg: string,
+): Promise<string | null> {
+  const root = await dbojs.queryOne({ id: "0" });
+  if (root) {
+    const rootObj = hydrate(root as unknown as Parameters<typeof hydrate>[0]);
+    const out = await resolveFormat(u, rootObj, slot, defaultArg);
+    if (out != null) return out;
+  }
+  return await resolveFormat(u, u.me, slot, defaultArg);
+}
 
-List commands queued on the time-delay and semaphore queues.
-Without an argument, shows your own queued commands.
-With <object> (admin+), shows that object's queued commands.
-
-Switches:
-  /brief    (default) PID, wait remaining, executor dbref, command
-  /long     Also shows enactor dbref
-  /summary  Totals only — no individual entries
-  /all      Show every process on the server (admin+)
-
-Examples:
-  @ps                 List your own queued commands.
-  @ps/all             List all queued commands (admin+).
-  @ps/summary         Show queue totals only.
-  @ps #5              Show queued commands for object #5 (admin+).`,
-    exec: async (u: IUrsamuSDK) => {
+export async function execPs(u: IUrsamuSDK): Promise<void> {
       const sw  = (u.cmd.args[0] ?? "").toLowerCase().trim();
       const ref = (u.cmd.args[1] ?? "").trim();
       const staff = isStaff(u.me.flags);
@@ -72,28 +67,84 @@ Examples:
       }
 
       const now = Date.now();
-      u.send(u.util.center(" Process Queue ", 78, "-"));
+
+      // Build rows. Each row's default text is " <pid> <wait> <executor> <cmd> ".
+      type Row = { defaultText: string; pid: number };
+      const rows: Row[] = [];
 
       for (const e of timeEntries) {
         const secs = Math.max(0, Math.ceil((e.scheduledAt - now) / 1000));
         const cmd  = e.command.length > 50 ? e.command.slice(0, 47) + "..." : e.command;
-        if (wantLong) {
-          u.send(`%chPID:%cn ${e.pid}  %ch[%cn${secs}s%ch]%cn  exec:#${e.executor}  enact:#${e.enactor}  ${cmd}`);
-        } else {
-          u.send(`%chPID:%cn ${e.pid}  %ch[%cn${secs}s%ch]%cn  #${e.executor}: ${cmd}`);
-        }
+        const defaultText = wantLong
+          ? `%chPID:%cn ${e.pid}  %ch[%cn${secs}s%ch]%cn  exec:#${e.executor}  enact:#${e.enactor}  ${cmd}`
+          : `%chPID:%cn ${e.pid}  %ch[%cn${secs}s%ch]%cn  #${e.executor}: ${cmd}`;
+        rows.push({ defaultText, pid: e.pid });
       }
 
       for (const e of semEntries) {
         const cmd = e.command.length > 50 ? e.command.slice(0, 47) + "..." : e.command;
-        if (wantLong) {
-          u.send(`%chPID:%cn ${e.pid}  %ch[SEM:#${e.semaphoreId}]%cn  exec:#${e.executor}  enact:#${e.enactor}  ${cmd}`);
-        } else {
-          u.send(`%chPID:%cn ${e.pid}  %ch[SEM:#${e.semaphoreId}]%cn  #${e.executor}: ${cmd}`);
-        }
+        const defaultText = wantLong
+          ? `%chPID:%cn ${e.pid}  %ch[SEM:#${e.semaphoreId}]%cn  exec:#${e.executor}  enact:#${e.enactor}  ${cmd}`
+          : `%chPID:%cn ${e.pid}  %ch[SEM:#${e.semaphoreId}]%cn  #${e.executor}: ${cmd}`;
+        rows.push({ defaultText, pid: e.pid });
       }
 
-      u.send(u.util.ljust("", 78, "-"));
-      u.send(`%chTotal:%cn ${timeEntries.length} time-delayed, ${semEntries.length} semaphore-blocked`);
-    },
+      // Per-row format override.
+      const renderedRows: string[] = [];
+      for (const r of rows) {
+        const rowOverride = await resolveGlobalFormat(u, "PSROWFORMAT", r.defaultText);
+        renderedRows.push(rowOverride != null ? rowOverride : r.defaultText);
+      }
+
+      const headerLine = u.util.center(" Process Queue ", 78, "-");
+      const footerLine = u.util.ljust("", 78, "-");
+      const totalLine = `%chTotal:%cn ${timeEntries.length} time-delayed, ${semEntries.length} semaphore-blocked`;
+
+      // Default-rendered full block, used as %0 for PSFORMAT.
+      const defaultBlock = [headerLine, ...renderedRows, footerLine, totalLine].join("\n");
+
+      const blockOverride = await resolveGlobalFormat(u, "PSFORMAT", defaultBlock);
+      if (blockOverride != null) {
+        u.send(blockOverride);
+        return;
+      }
+
+      u.send(headerLine);
+      for (const line of renderedRows) u.send(line);
+      u.send(footerLine);
+      u.send(totalLine);
+}
+
+/**
+ * @ps — list queued processes on the time-delay and semaphore queues.
+ * Switches: /brief (default), /long, /summary, /all
+ */
+export default () =>
+  addCmd({
+    name: "@ps",
+    pattern: /^@ps(?:\/([\w]+))?\s*(.*)?/i,
+    lock: "connected",
+    category: "Softcode",
+    help: `@ps[/<switch>] [<object>]
+
+List commands queued on the time-delay and semaphore queues.
+Without an argument, shows your own queued commands.
+With <object> (admin+), shows that object's queued commands.
+
+Switches:
+  /brief    (default) PID, wait remaining, executor dbref, command
+  /long     Also shows enactor dbref
+  /summary  Totals only — no individual entries
+  /all      Show every process on the server (admin+)
+
+Format hooks: set @psformat / @psrowformat on #0 (game-wide) or self.
+
+Examples:
+  @ps                 List your own queued commands.
+  @ps/all             List all queued commands (admin+).
+  @ps/summary         Show queue totals only.
+  @ps #5              Show queued commands for object #5 (admin+).`,
+    exec: execPs,
   });
+
+export { resolveGlobalFormat };

--- a/src/commands/social.ts
+++ b/src/commands/social.ts
@@ -1,5 +1,33 @@
 import { addCmd } from "../services/commands/cmdParser.ts";
-import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
+import type { IUrsamuSDK, IDBObj } from "../@types/UrsamuSDK.ts";
+import { resolveFormat, type FormatSlot } from "../utils/resolveFormat.ts";
+import { dbojs } from "../services/Database/database.ts";
+import { hydrate } from "../utils/evaluateLock.ts";
+
+/**
+ * Two-tier lookup for global-list format slots (e.g. WHO):
+ *   1. attr on #0 (game-wide skin) — wins if set.
+ *   2. attr on the enactor (per-player skin).
+ *   3. null → caller renders built-in default.
+ *
+ * Mirrors TinyMUX/PennMUSH precedent for WHO-style commands. Kept inline
+ * here until a third caller appears; then promote to src/utils/.
+ */
+async function resolveGlobalFormat(
+  u: IUrsamuSDK,
+  slot: FormatSlot,
+  defaultArg: string,
+): Promise<string | null> {
+  // Only consult #0 if it actually exists — otherwise plugin handlers would
+  // be invoked with a phantom target.id="0" (latent bug, M1 in TDD audit).
+  const root = await dbojs.queryOne({ id: "0" });
+  if (root) {
+    const rootObj = hydrate(root as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
+    const onRoot = await resolveFormat(u, rootObj, slot, defaultArg);
+    if (onRoot != null) return onRoot;
+  }
+  return await resolveFormat(u, u.me, slot, defaultArg);
+}
 
 export async function execWho(u: IUrsamuSDK): Promise<void> {
   const players = (await u.db.search({ flags: /connected/i }))
@@ -17,18 +45,31 @@ export async function execWho(u: IUrsamuSDK): Promise<void> {
     return `${Math.floor(hrs / 24)}d`;
   };
 
-  let telnet = `%chWho's Online%cn\n`;
-  telnet += `${"Player".padEnd(24)}${"Idle".padEnd(8)}Doing\n`;
-  telnet += `${"-".repeat(width)}\n`;
-  for (const p of players) {
+  const renderRow = (p: IDBObj): string => {
     const pName = (p.state.moniker as string) || (p.state.name as string) || p.name || "Unknown";
     const idle = formatIdle(p.state.lastCommand);
     const doing = (p.state.doing as string) || "";
-    telnet += `${pName.padEnd(24)}${idle.padEnd(8)}${doing}\n`;
+    return `${pName.padEnd(24)}${idle.padEnd(8)}${doing}`;
+  };
+
+  // Build per-player rows, with optional WHOROWFORMAT override.
+  const rows: string[] = [];
+  for (const p of players) {
+    const defaultRow = renderRow(p);
+    const rowOverride = await resolveGlobalFormat(u, "WHOROWFORMAT", defaultRow);
+    rows.push(rowOverride != null ? rowOverride : defaultRow);
   }
-  telnet += `${"-".repeat(width)}\n`;
-  telnet += `${players.length} player${players.length === 1 ? "" : "s"} online.\n`;
-  u.send(telnet);
+
+  // Default block — used both as the fallback output and as %0 for WHOFORMAT.
+  let defaultBlock = `%chWho's Online%cn\n`;
+  defaultBlock += `${"Player".padEnd(24)}${"Idle".padEnd(8)}Doing\n`;
+  defaultBlock += `${"-".repeat(width)}\n`;
+  for (const r of rows) defaultBlock += `${r}\n`;
+  defaultBlock += `${"-".repeat(width)}\n`;
+  defaultBlock += `${players.length} player${players.length === 1 ? "" : "s"} online.\n`;
+
+  const blockOverride = await resolveGlobalFormat(u, "WHOFORMAT", defaultBlock);
+  u.send(blockOverride != null ? blockOverride : defaultBlock);
 }
 
 export function execScore(u: IUrsamuSDK): void {
@@ -109,6 +150,10 @@ export default () => {
     lock: "",
     category: "Information",
     help: `who  — List all connected players.
+
+Override hooks (attr on #0 first, else enactor):
+  @whoformat     Replaces the entire WHO block; %0 = default block.
+  @whorowformat  Replaces one player row; %0 = default rendered row.
 
 Examples:
   who`,

--- a/src/services/Softcode/stdlib/string.ts
+++ b/src/services/Softcode/stdlib/string.ts
@@ -2,6 +2,12 @@
 import { register } from "./registry.ts";
 import { int, stripAnsi } from "./helpers.ts";
 
+// Hard cap on any softcode-controlled width / repeat-count to prevent DoS
+// via memory blowup (e.g. `[repeat(x,99999999)]`). 10 000 chars is well
+// above any sane terminal width (max ~250) yet bounded to ~10 KB per call.
+const MAX_LEN = 10_000;
+const clampLen = (n: number) => Math.min(Math.max(0, n | 0), MAX_LEN);
+
 // ── concatenation ─────────────────────────────────────────────────────────
 
 register("cat",    async (a) => a.join(" "));
@@ -58,38 +64,68 @@ register("strtrunc", async (a) => {
 // ── padding / justification ───────────────────────────────────────────────
 
 register("ljust",  async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]); const fill = a[2]?.[0] ?? " ";
+  const s = a[0] ?? ""; const w = clampLen(int(a[1])); const fill = a[2]?.[0] ?? " ";
   return s.padEnd(w, fill).slice(0, Math.max(w, s.length));
 });
 register("rjust",  async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]); const fill = a[2]?.[0] ?? " ";
+  const s = a[0] ?? ""; const w = clampLen(int(a[1])); const fill = a[2]?.[0] ?? " ";
   return s.padStart(w, fill).slice(-Math.max(w, s.length));
 });
 register("center", async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]); const fill = a[2]?.[0] ?? " ";
+  const s = a[0] ?? ""; const w = clampLen(int(a[1])); const fill = a[2]?.[0] ?? " ";
   const total = Math.max(w - s.length, 0);
   const left  = Math.floor(total / 2);
   const right = total - left;
   return fill.repeat(left) + s + fill.repeat(right);
 });
 register("lpad", async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]); const fill = a[2]?.[0] ?? " ";
+  const s = a[0] ?? ""; const w = clampLen(int(a[1])); const fill = a[2]?.[0] ?? " ";
   return s.padStart(w, fill);
 });
 register("rpad", async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]); const fill = a[2]?.[0] ?? " ";
+  const s = a[0] ?? ""; const w = clampLen(int(a[1])); const fill = a[2]?.[0] ?? " ";
   return s.padEnd(w, fill);
 });
 register("cpad", async (a) => {
-  const s = a[0] ?? ""; const w = int(a[1]);
+  const s = a[0] ?? ""; const w = clampLen(int(a[1]));
   const total = Math.max(w - s.length, 0);
   return " ".repeat(Math.floor(total/2)) + s + " ".repeat(total - Math.floor(total/2));
 });
 
+// ── header / divider / footer ─────────────────────────────────────────────
+// Layout helpers so attribute authors can write [header(The Void)] instead
+// of [ljust(===== %0 ,78,=)]. Shape: 5 fill + space + title + space + pad.
+
+register("header", async (a) => {
+  const title = a[0] ?? "";
+  const width = clampLen(int(a[1] ?? "78") || 78);
+  const fill  = (a[2] ?? "=")[0] || "=";
+  if (title.length === 0) return fill.repeat(width);
+  const prefix = fill.repeat(5) + " " + title + " ";
+  return prefix.length >= width ? prefix.slice(0, width)
+    : prefix + fill.repeat(width - prefix.length);
+});
+
+register("divider", async (a) => {
+  const title = a[0] ?? "";
+  const width = clampLen(int(a[1] ?? "78") || 78);
+  const fill  = (a[2] ?? "-")[0] || "-";
+  if (title.length === 0) return fill.repeat(width);
+  const prefix = fill.repeat(5) + " " + title + " ";
+  return prefix.length >= width ? prefix.slice(0, width)
+    : prefix + fill.repeat(width - prefix.length);
+});
+
+register("footer", async (a) => {
+  const width = clampLen(int(a[0] ?? "78") || 78);
+  const fill  = (a[1] ?? "=")[0] || "=";
+  return fill.repeat(width);
+});
+
 // ── space / repeat ────────────────────────────────────────────────────────
 
-register("space",  async (a) => " ".repeat(Math.max(0, int(a[0]))));
-register("repeat", async (a) => (a[0] ?? "").repeat(Math.max(0, int(a[1]))));
+register("space",  async (a) => " ".repeat(clampLen(int(a[0]))));
+register("repeat", async (a) => (a[0] ?? "").repeat(clampLen(int(a[1]))));
 
 // ── reverse ───────────────────────────────────────────────────────────────
 

--- a/src/services/Softcode/ursamu-engine.ts
+++ b/src/services/Softcode/ursamu-engine.ts
@@ -220,7 +220,9 @@ const SKIP_NAMES = new Set([
 
   // Pure string — new lib covers these exactly
   "strlen", "mid", "left", "right", "trim",
-  "ljust", "rjust", "center", "ucstr", "lcstr", "capstr", "cat", "space", "repeat",
+  "ucstr", "lcstr", "capstr", "cat",
+  // NOTE: ljust/rjust/center/space/repeat NOT skipped — UrsaMU's versions
+  // clamp width/count to MAX_LEN to prevent DoS (see stdlib/string.ts).
 
   // Pure comparison — new lib covers these exactly
   "eq", "neq", "gt", "gte", "lt", "lte",

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -159,18 +159,26 @@ export const threeColumn = (...lists: string[][]) => {
   return output;
 };
 
-export const header = (string = "", filler = "%cr=%cn", width = 78) => {
-  return center(`%cy[%cn %ch${string}%cn %cy]%cn`, width, filler);
+// NOTE: TS header/divider/footer diverge from the softcode versions in
+// src/services/Softcode/stdlib/string.ts. The softcode forms are inline
+// single-line layouts (e.g. `===== Title ===…`) for use in attribute strings;
+// these TS forms are multi-line block decorators tailored to native command
+// output (plain `=`/`-` rules with a bold title sandwiched between).
+
+export const header = (string = "", filler = "=", width = 78) => {
+  const rule = filler.repeat(width);
+  if (!string) return rule;
+  return `${rule}\n${center(`%ch${string}%cn`, width)}\n${rule}`;
 };
 
-export const divider = (string = "", filler = "%cr-%cn", width = 78) => {
-  return center(` %ch${string}%cn `, width, filler);
+export const divider = (string = "", filler = "-", width = 78) => {
+  const rule = filler.repeat(width);
+  if (!string) return rule;
+  return `\n%ch${string}%cn\n${rule}`;
 };
 
-export const footer = (string = "", filler = "%cr=%cn", width = 78) => {
-  if (string) {
-    return center(`%cy[%cn %ch${string}%cn %cy]%cn`, width, filler);
-  }
-
-  return repeatString(filler, width);
+export const footer = (string = "", filler = "=", width = 78) => {
+  const rule = filler.repeat(width);
+  if (!string) return rule;
+  return `${rule}\n${center(`%ch${string}%cn`, width)}\n${rule}`;
 };

--- a/src/utils/formatHandlers.ts
+++ b/src/utils/formatHandlers.ts
@@ -1,0 +1,75 @@
+/**
+ * Pluggable format handlers for look-side display attributes
+ * (NAMEFORMAT / DESCFORMAT / CONFORMAT / EXITFORMAT).
+ *
+ * Resolution priority inside `execLook`:
+ *   1. Softcode attribute on the target (e.g. `@nameformat`) — highest.
+ *   2. Plugin-registered handler for the slot — middle.
+ *   3. Built-in default rendering — lowest.
+ *
+ * Plugins call `registerFormatHandler(slot, fn)` from their `init()` and
+ * `unregisterFormatHandler(slot, fn)` from their `remove()`.
+ */
+import type { IUrsamuSDK, IDBObj } from "../@types/UrsamuSDK.ts";
+
+export type FormatSlot =
+  | "NAMEFORMAT"
+  | "DESCFORMAT"
+  | "CONFORMAT"
+  | "EXITFORMAT"
+  | "WHOFORMAT"
+  | "WHOROWFORMAT"
+  | "PSFORMAT" | "PSROWFORMAT";
+
+/**
+ * Plugin handler signature.
+ * Return a string to override the default rendering; return null to fall through.
+ */
+export type FormatHandler = (
+  u: IUrsamuSDK,
+  target: IDBObj,
+  defaultArg: string,
+) => Promise<string | null> | string | null;
+
+const registry = new Map<FormatSlot, FormatHandler[]>();
+
+export function registerFormatHandler(slot: FormatSlot, fn: FormatHandler): void {
+  const list = registry.get(slot) ?? [];
+  list.push(fn);
+  registry.set(slot, list);
+}
+
+export function unregisterFormatHandler(slot: FormatSlot, fn: FormatHandler): void {
+  const list = registry.get(slot);
+  if (!list) return;
+  const idx = list.indexOf(fn);
+  if (idx >= 0) list.splice(idx, 1);
+}
+
+/** First registered handler that returns a non-null string wins. */
+export async function runPluginFormatHandlers(
+  slot: FormatSlot,
+  u: IUrsamuSDK,
+  target: IDBObj,
+  defaultArg: string,
+): Promise<string | null> {
+  const list = registry.get(slot);
+  if (!list || list.length === 0) return null;
+  for (const fn of list) {
+    try {
+      const out = await fn(u, target, defaultArg);
+      if (out != null) return out;
+    } catch (e: unknown) {
+      // Handler error → fall through to next handler / built-in. We log so
+      // operators can see plugin bugs (silent swallowing was L1 in TDD audit).
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[format-handler ${slot}] plugin handler threw: ${msg}`);
+    }
+  }
+  return null;
+}
+
+/** Test-only: drop all registered handlers. */
+export function _clearFormatHandlers(): void {
+  registry.clear();
+}

--- a/src/utils/resolveFormat.ts
+++ b/src/utils/resolveFormat.ts
@@ -1,0 +1,59 @@
+/**
+ * Resolve a format slot in priority order:
+ *   1. Softcode attribute on the target (e.g. `@nameformat`) — evaluated via
+ *      softcodeService.runSoftcode.
+ *   2. Plugin-registered handler for the slot
+ *      (see `runPluginFormatHandlers`).
+ *   3. null → caller falls back to its own built-in default rendering.
+ *
+ * Failures are fail-closed: a softcode throw falls through to the plugin
+ * handler chain; a plugin handler throw is swallowed by
+ * `runPluginFormatHandlers` and the next handler runs.
+ */
+import type { IDBObj, IUrsamuSDK } from "../@types/UrsamuSDK.ts";
+import { softcodeService } from "../services/Softcode/index.ts";
+import { runPluginFormatHandlers, type FormatSlot } from "./formatHandlers.ts";
+
+export type { FormatSlot } from "./formatHandlers.ts";
+
+export async function resolveFormat(
+  u: IUrsamuSDK,
+  target: IDBObj,
+  slot: FormatSlot,
+  defaultArg: string,
+): Promise<string | null> {
+  // 1. softcode attribute
+  if (u.attr?.get) {
+    try {
+      const raw = await u.attr.get(target.id, slot);
+      if (raw != null) {
+        return await softcodeService.runSoftcode(raw, {
+          actorId:    u.me.id,
+          executorId: target.id,
+          args:       [defaultArg],
+          socketId:   u.socketId,
+        });
+      }
+    } catch (e: unknown) {
+      // Softcode failure → fall through to plugin handler. We log so attribute
+      // authors can discover broken softcode (silent swallowing was L2 in
+      // TDD audit).
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[resolveFormat ${slot}] softcode eval failed on #${target.id}: ${msg}`);
+    }
+  }
+
+  // 2. plugin handler
+  return await runPluginFormatHandlers(slot, u, target, defaultArg);
+}
+
+/** Resolve a format slot or return the supplied fallback string. */
+export async function resolveFormatOr(
+  u: IUrsamuSDK,
+  target: IDBObj,
+  slot: FormatSlot,
+  defaultArg: string,
+  fallback: string,
+): Promise<string> {
+  return (await resolveFormat(u, target, slot, defaultArg)) ?? fallback;
+}

--- a/tests/demo_format.test.ts
+++ b/tests/demo_format.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { divider, footer, header } from "../src/utils/format.ts";
+import { center } from "../src/utils/format.ts";
+
+// Snapshot the byte-for-byte output that the demo command previously built
+// inline (HR / hr / section). The TS layout helpers in src/utils/format.ts
+// must produce the same strings, otherwise the demo output changes visibly.
+
+const HR = "=".repeat(78);
+const hr = "-".repeat(78);
+const oldSection = (title: string) => `\n%ch${title}%cn\n${hr}`;
+const oldOverviewBlock = (title: string) =>
+  `${HR}\n${center(`%ch${title}%cn`, 78)}\n${HR}`;
+
+Deno.test("format.footer() matches old HR rule", () => {
+  assertEquals(footer(), HR);
+});
+
+Deno.test("format.divider(title) matches old section()", () => {
+  assertEquals(divider("BASICS — Actor"), oldSection("BASICS — Actor"));
+  assertEquals(divider("FORMAT — util.sprintf"), oldSection("FORMAT — util.sprintf"));
+});
+
+Deno.test("format.header(title) matches old HR-title-HR block", () => {
+  const title = " UrsaMU Script Engine Demo ";
+  assertEquals(header(title), oldOverviewBlock(title));
+});
+
+Deno.test("format.header() with no title is a plain rule", () => {
+  assertEquals(header(), HR);
+});
+
+Deno.test("format.divider() with no title is a plain dash rule", () => {
+  assertEquals(divider(), hr);
+});

--- a/tests/look_formats.test.ts
+++ b/tests/look_formats.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for look-side format resolution.
+ *
+ * Strategy: drive the priority chain via the plugin-handler registry, which
+ * fires only when no softcode attribute is set. The softcode-attr path is
+ * covered by tests/look_formats_integration.test.ts (real worker).
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+import { execLook } from "../src/commands/look.ts";
+import {
+  registerFormatHandler,
+  unregisterFormatHandler,
+  _clearFormatHandlers,
+  type FormatSlot,
+  type FormatHandler,
+} from "../src/utils/formatHandlers.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function makeMock(opts: {
+  contents?: IDBObj[];
+  opaque?: boolean;
+  canEdit?: boolean;
+  blind?: boolean;
+} = {}) {
+  const flags = new Set<string>(["room"]);
+  if (opts.opaque) flags.add("opaque");
+  const room = {
+    id: "r1",
+    flags,
+    state: { name: "TestRoom", description: "A bare room." },
+    location: "0",
+    contents: opts.contents ?? [],
+  } as unknown as IDBObj;
+
+  const player = {
+    id: "p1",
+    flags: new Set<string>(opts.blind ? ["player", "connected", "blind"] : ["player", "connected"]),
+    state: { name: "Alice" },
+    contents: [],
+  } as unknown as IDBObj;
+
+  const sent: string[] = [];
+  // attr.get always returns null → no softcode attr → handler path exercised
+  const u = {
+    me: player,
+    here: room,
+    cmd: { name: "look", args: [""], switches: [] },
+    send: (m: string) => { sent.push(m); },
+    ui: { panel: (o: unknown) => o, layout: () => {} },
+    canEdit: () => Promise.resolve(opts.canEdit ?? true),
+    db: { search: () => Promise.resolve([]) },
+    attr: { get: () => Promise.resolve(null) },
+    util: {
+      displayName: (o: { state?: { name?: string }; name?: string }) =>
+        o.state?.name || o.name || "Unknown",
+      parseDesc: undefined,
+    },
+  };
+  return { u: u as unknown as IUrsamuSDK, sent };
+}
+
+function withHandler(slot: FormatSlot, fn: FormatHandler, body: () => Promise<void>) {
+  registerFormatHandler(slot, fn);
+  return body().finally(() => unregisterFormatHandler(slot, fn));
+}
+
+Deno.test("look: no attrs and no handlers — default rendering", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  await execLook(u);
+  assertStringIncludes(sent[0], "%chTestRoom(#r1)%cn");
+  assertStringIncludes(sent[0], "A bare room.");
+});
+
+Deno.test("look: plugin NAMEFORMAT handler overrides header", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  await withHandler("NAMEFORMAT", (_u, _t, arg) => `<<N:${arg}>>`, async () => {
+    await execLook(u);
+  });
+  assertStringIncludes(sent[0], "<<N:TestRoom(#r1)>>");
+  assertEquals(sent[0].includes("%chTestRoom(#r1)%cn"), false);
+});
+
+Deno.test("look: plugin DESCFORMAT handler wraps description", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  await withHandler("DESCFORMAT", (_u, _t, arg) => `>>${arg}<<`, async () => {
+    await execLook(u);
+  });
+  assertStringIncludes(sent[0], ">>A bare room.<<");
+});
+
+Deno.test("look: plugin CONFORMAT receives space-separated id list as defaultArg", OPTS, async () => {
+  _clearFormatHandlers();
+  const alice = { id: "p9", flags: new Set(["player", "connected"]), state: { name: "Bob" }, contents: [] } as unknown as IDBObj;
+  const ball = { id: "o1", flags: new Set(["thing"]), state: { name: "ball" }, contents: [] } as unknown as IDBObj;
+  let seen = "";
+  const { u, sent } = makeMock({ contents: [alice, ball] });
+  await withHandler("CONFORMAT", (_u, _t, arg) => { seen = arg; return `HERE: ${arg}`; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(seen, "#p9 #o1");
+  assertStringIncludes(sent[0], "HERE: #p9 #o1");
+  assertEquals(sent[0].includes("%chCharacters:%cn"), false);
+});
+
+Deno.test("look: CONFORMAT handler skipped when no visible contents", OPTS, async () => {
+  _clearFormatHandlers();
+  let called = false;
+  const { u, sent } = makeMock({ contents: [] });
+  await withHandler("CONFORMAT", () => { called = true; return "X"; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(called, false);
+  assertEquals(sent[0].includes("X"), false);
+});
+
+Deno.test("look: CONFORMAT skipped when opaque and no edit perm", OPTS, async () => {
+  _clearFormatHandlers();
+  const ball = { id: "o1", flags: new Set(["thing"]), state: { name: "ball" }, contents: [] } as unknown as IDBObj;
+  let called = false;
+  const { u, sent } = makeMock({ contents: [ball], opaque: true, canEdit: false });
+  await withHandler("CONFORMAT", () => { called = true; return "X"; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(called, false);
+  assertEquals(sent[0].includes("ball"), false);
+});
+
+Deno.test("look: plugin EXITFORMAT receives exit id list", OPTS, async () => {
+  _clearFormatHandlers();
+  const ex = { id: "e1", flags: new Set(["exit"]), state: { name: "North;n" }, contents: [] } as unknown as IDBObj;
+  let seen = "";
+  const { u, sent } = makeMock({ contents: [ex] });
+  await withHandler("EXITFORMAT", (_u, _t, arg) => { seen = arg; return `OUT: ${arg}`; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(seen, "#e1");
+  assertStringIncludes(sent[0], "OUT: #e1");
+});
+
+Deno.test("look: handler returning null falls through to built-in default", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  await withHandler("NAMEFORMAT", () => null, async () => {
+    await execLook(u);
+  });
+  assertStringIncludes(sent[0], "%chTestRoom(#r1)%cn");
+});
+
+Deno.test("look: first non-null handler wins; later handlers don't run", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  let secondRan = false;
+  const first: FormatHandler = () => "FIRST";
+  const second: FormatHandler = () => { secondRan = true; return "SECOND"; };
+  registerFormatHandler("NAMEFORMAT", first);
+  registerFormatHandler("NAMEFORMAT", second);
+  try {
+    await execLook(u);
+  } finally {
+    unregisterFormatHandler("NAMEFORMAT", first);
+    unregisterFormatHandler("NAMEFORMAT", second);
+  }
+  assertStringIncludes(sent[0], "FIRST");
+  assertEquals(secondRan, false);
+});
+
+Deno.test("look: handler throw is swallowed, falls through to default", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  await withHandler("DESCFORMAT", () => { throw new Error("boom"); }, async () => {
+    await execLook(u);
+  });
+  assertStringIncludes(sent[0], "A bare room.");
+});
+
+Deno.test("look: unregisterFormatHandler removes the registration", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock();
+  const fn: FormatHandler = () => "REMOVED";
+  registerFormatHandler("NAMEFORMAT", fn);
+  unregisterFormatHandler("NAMEFORMAT", fn);
+  await execLook(u);
+  assertEquals(sent[0].includes("REMOVED"), false);
+  assertStringIncludes(sent[0], "%chTestRoom(#r1)%cn");
+});
+
+Deno.test("look: blind player short-circuits — no handler invoked", OPTS, async () => {
+  _clearFormatHandlers();
+  let called = false;
+  const { u, sent } = makeMock({ blind: true });
+  await withHandler("NAMEFORMAT", () => { called = true; return "X"; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(called, false);
+  assertEquals(sent[0], "You can't see anything!");
+});
+
+Deno.test("look: non-editable target — NAMEFORMAT arg is bare name (no #id)", OPTS, async () => {
+  _clearFormatHandlers();
+  let seen = "";
+  const { u } = makeMock({ canEdit: false });
+  await withHandler("NAMEFORMAT", (_u, _t, arg) => { seen = arg; return ""; }, async () => {
+    await execLook(u);
+  });
+  assertEquals(seen, "TestRoom");
+});

--- a/tests/look_formats_integration.test.ts
+++ b/tests/look_formats_integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration test: format attributes evaluated through the REAL TinyMUX
+ * softcode engine (softcodeService.runSoftcode), not the JS sandbox.
+ *
+ * %0 is the default rendered string passed in by execLook.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { createNativeSDK } from "../src/services/SDK/index.ts";
+import { execLook } from "../src/commands/look.ts";
+import { hydrate } from "../src/utils/evaluateLock.ts";
+import { _clearFormatHandlers } from "../src/utils/formatHandlers.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 15000 };
+
+// Numeric ids so softcode #N dbref resolution (name(%i0), etc.) works.
+const ROOM = "900001";
+const ACTOR = "900002";
+const NPC = "900003";
+const THING = "900004";
+const EXIT = "900005";
+
+async function cleanup() {
+  for (const id of [ROOM, ACTOR, NPC, THING, EXIT]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+async function seed(opts: { attrs?: Record<string, string>; withContents?: boolean; withExit?: boolean } = {}) {
+  await cleanup();
+  _clearFormatHandlers();
+  const attributes = Object.entries(opts.attrs ?? {}).map(([name, value]) => ({
+    name, value, setter: ACTOR, type: "attribute",
+  }));
+  await dbojs.create({
+    id: ROOM,
+    flags: "room",
+    data: { name: "LFI Room", description: "A test room.", attributes },
+  });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected wizard",
+    data: { name: "Alice" },
+    location: ROOM,
+  });
+  if (opts.withContents) {
+    await dbojs.create({
+      id: NPC,
+      flags: "player connected",
+      data: { name: "Bob" },
+      location: ROOM,
+    });
+    await dbojs.create({
+      id: THING,
+      flags: "thing",
+      data: { name: "ball" },
+      location: ROOM,
+    });
+  }
+  if (opts.withExit) {
+    await dbojs.create({
+      id: EXIT,
+      flags: "exit",
+      data: { name: "North;n" },
+      location: ROOM,
+    });
+  }
+}
+
+async function runLook(): Promise<string> {
+  const u = await createNativeSDK("lfi-sock", ACTOR, { name: "look", original: "look", args: [""], switches: [] });
+  const roomChildren = await dbojs.find({ location: ROOM });
+  (u.here as unknown as { contents: IDBObj[] }).contents = roomChildren
+    .filter((c) => c.id !== ACTOR)
+    .map((c) => hydrate(c));
+  const sent: string[] = [];
+  u.send = (m: string) => { sent.push(m); };
+  (u.here as unknown as { broadcast: (m: string) => void }).broadcast = () => {};
+  await execLook(u);
+  return sent.join("\n");
+}
+
+Deno.test("softcode: no attrs — default rendering", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const out = await runLook();
+  assertStringIncludes(out, "LFI Room");
+  assertStringIncludes(out, "A test room.");
+  await cleanup();
+});
+
+Deno.test("softcode: @nameformat with %0 wraps the default name", { ...OPTS, ...SLOW }, async () => {
+  await seed({ attrs: { NAMEFORMAT: "<<%0>>" } });
+  const out = await runLook();
+  assertStringIncludes(out, "<<LFI Room(#" + ROOM + ")>>");
+  assertEquals(out.includes("%chLFI Room"), false);
+  await cleanup();
+});
+
+Deno.test("softcode: @descformat with %0 wraps the description", { ...OPTS, ...SLOW }, async () => {
+  await seed({ attrs: { DESCFORMAT: ">> %0 <<" } });
+  const out = await runLook();
+  assertStringIncludes(out, ">> A test room. <<");
+  await cleanup();
+});
+
+Deno.test("softcode: @conformat — %0 carries id list, iter() resolves names", { ...OPTS, ...SLOW }, async () => {
+  // iter(%0, name(%i0)) — for each id in %0, look up its name. TinyMUX idiom.
+  await seed({
+    withContents: true,
+    attrs: { CONFORMAT: "Here: [iter(%0,name(%i0))]" },
+  });
+  const out = await runLook();
+  // Both content names should appear in the resolved listing
+  assertStringIncludes(out, "Here:");
+  assertStringIncludes(out, "Bob");
+  assertStringIncludes(out, "ball");
+  assertEquals(out.includes("%chCharacters:%cn"), false);
+  await cleanup();
+});
+
+Deno.test("softcode: @exitformat — iter() over exit ids", { ...OPTS, ...SLOW }, async () => {
+  await seed({
+    withExit: true,
+    attrs: { EXITFORMAT: "Exits: [iter(%0,name(%i0))]" },
+  });
+  const out = await runLook();
+  assertStringIncludes(out, "Exits:");
+  assertStringIncludes(out, "North");
+  assertEquals(out.includes("%chExits:%cn"), false);
+  await cleanup();
+});
+
+Deno.test("softcode: priority — @nameformat attr wins over plugin handler", { ...OPTS, ...SLOW }, async () => {
+  const { registerFormatHandler, unregisterFormatHandler } = await import(
+    "../src/utils/formatHandlers.ts"
+  );
+  await seed({ attrs: { NAMEFORMAT: "ATTR:%0" } });
+  const handler = () => "HANDLER";
+  registerFormatHandler("NAMEFORMAT", handler);
+  try {
+    const out = await runLook();
+    assertStringIncludes(out, "ATTR:LFI Room");
+    assertEquals(out.includes("HANDLER"), false);
+  } finally {
+    unregisterFormatHandler("NAMEFORMAT", handler);
+    await cleanup();
+  }
+});
+
+Deno.test("softcode: priority — plugin handler runs when no attr set", { ...OPTS, ...SLOW }, async () => {
+  const { registerFormatHandler, unregisterFormatHandler } = await import(
+    "../src/utils/formatHandlers.ts"
+  );
+  await seed();
+  const handler = (_u: unknown, _t: unknown, arg: string) => `PLUGIN[${arg}]`;
+  registerFormatHandler("DESCFORMAT", handler);
+  try {
+    const out = await runLook();
+    assertStringIncludes(out, "PLUGIN[A test room.]");
+  } finally {
+    unregisterFormatHandler("DESCFORMAT", handler);
+    await cleanup();
+  }
+});
+
+Deno.test("softcode: priority — built-in default when no attr, no handler", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const out = await runLook();
+  assertStringIncludes(out, "%chLFI Room(#" + ROOM + ")%cn");
+  await cleanup();
+  await DBO.close();
+});

--- a/tests/look_void_render.test.ts
+++ b/tests/look_void_render.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Render demo: "The Void" — exercises NAMEFORMAT/DESCFORMAT/CONFORMAT/EXITFORMAT
+ * via real softcode against a fully-seeded room. Prints the captured look output.
+ *
+ * Demonstrates:
+ *   - Multi-line description wrapped to 78 cols via softcode wrap()
+ *   - Multiple players with role badges (Wizard / Admin / Player)
+ *   - Things rendered in a separate "Objects" section
+ *   - Exits with name;alias convention rendered as "[<alias>] <name>"
+ */
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { createNativeSDK } from "../src/services/SDK/index.ts";
+import { execLook } from "../src/commands/look.ts";
+import { hydrate } from "../src/utils/evaluateLock.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false, timeout: 20000 };
+
+const ROOM   = "800200";
+const ALICE  = "800201"; // viewer (won't appear in own Players list)
+const DIABLE = "800202"; // admin
+const MORPH  = "800203"; // wizard
+const LYRA   = "800204"; // plain player
+const ORB    = "800205"; // thing
+const TOME   = "800206"; // thing
+const E_NORTH  = "800207"; // exit  North;n
+const E_DOOR   = "800208"; // exit  Crystal Door;cd;door
+const E_PORTAL = "800209"; // exit  Portal;p
+
+// execLook no longer inserts auto-spacing between sections — each format
+// attribute controls its own surrounding whitespace via explicit %r.
+
+// NAMEFORMAT — top border + newline. Using new `header()` softcode helper.
+const NAMEFORMAT = `[header(%0)]%r`;
+
+// DESCFORMAT — blank line, wrapped desc, blank line after.
+const DESCFORMAT = `%r[wrap(%0,78)]%r%r`;
+
+// ── CONFORMAT — two sub-sections (Players, Objects) iterated over %0 ─────────
+//   For each id we switch on type(%i0): PLAYER builds a player row, THING
+//   builds an object row, anything else evaluates to empty (suppressed by
+//   filterbool-style switch default).
+const PLAYER_ROW =
+  `%b[ljust(name(%i0),22)]` +
+  `[ljust(switch(1,hasflag(%i0,wizard),(Wizard),hasflag(%i0,admin),(Admin),(Player)),12)]` +
+  `[rjust(default(%i0/IDLE,0),2)]s  ` +
+  `[default(%i0/SHORT-DESC,)]`;
+
+const OBJECT_ROW =
+  `%b[ljust(name(%i0),22)][default(%i0/SHORT-DESC,)]`;
+
+// Build filtered id lists into registers q0 (players) and q1 (things) first,
+// then iter just those — keeps per-row %r separators clean.
+const CONFORMAT =
+  `[setq(0,squish(iter(%0,switch(type(%i0),PLAYER,%i0,))))]` +
+  `[setq(1,squish(iter(%0,switch(type(%i0),THING,%i0,))))]` +
+  `[divider(Players)]%r` +
+  `[iter(%q0,${PLAYER_ROW},,%r)]%r` +
+  `[divider(Objects)]%r` +
+  `[iter(%q1,${OBJECT_ROW},,%r)]%r`;
+
+// ── EXITFORMAT — "[<alias>] <name>" per exit, plus 78-char footer ────────────
+//   name(%i0) returns "Crystal Door;cd;door" — before(...,;) is the
+//   display name, after(...,;) is the alias list; before(after(...),;) is
+//   the first alias.
+// Each exit cell: "<alias> Name" padded to 25 cols (3 cells per 78-col row).
+// `<` / `>` are literal; only `[` / `]` are softcode meta-characters here.
+// After every 3rd item, emit %r to break the row.
+const EXIT_CELL =
+  `[ljust(<[before(after(name(%i0),;),;)]> [before(name(%i0),;)],25)]`;
+
+// Explicit counter in %q9: inc each iter, emit %r every 3rd cell.
+const EXITFORMAT =
+  `[divider(Exits)]%r` +
+  `[setq(9,0)]` +
+  `[iter(%0,${EXIT_CELL}[setq(9,inc(%q9))][switch(mod(%q9,3),0,%r,)],,)]` +
+  `[switch(mod(%q9,3),0,,%r)]` +
+  `[footer()]`;
+
+async function cleanup() {
+  for (const id of [ROOM, ALICE, DIABLE, MORPH, LYRA, ORB, TOME, E_NORTH, E_DOOR, E_PORTAL]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+Deno.test("render demo: The Void (multi-player, objects, exits)", OPTS, async () => {
+  await cleanup();
+
+  const longDesc =
+    "A featureless void, stretching endlessly in all directions. The very fabric " +
+    "of reality seems thin here, as though one might step through into something " +
+    "else entirely. A faint, pulsing hum emanates from somewhere beyond perception, " +
+    "and motes of pale light drift past on currents that obey no physics you know.";
+
+  await dbojs.create({
+    id: ROOM,
+    flags: "room",
+    data: {
+      name: "The Void",
+      description: longDesc,
+      attributes: [
+        { name: "NAMEFORMAT", value: NAMEFORMAT, setter: ALICE, type: "attribute" },
+        { name: "DESCFORMAT", value: DESCFORMAT, setter: ALICE, type: "attribute" },
+        { name: "CONFORMAT",  value: CONFORMAT,  setter: ALICE, type: "attribute" },
+        { name: "EXITFORMAT", value: EXITFORMAT, setter: ALICE, type: "attribute" },
+      ],
+    },
+  });
+
+  // Viewer
+  await dbojs.create({ id: ALICE, flags: "player connected", data: { name: "Alice" }, location: ROOM });
+
+  // Players — softcode `get` reads data[<lowercase>], so attrs are flat.
+  await dbojs.create({
+    id: DIABLE,
+    flags: "player connected admin",
+    data: { name: "Diablerie", "short-desc": "Some awesome dude!", "idle": "0" },
+    location: ROOM,
+  });
+  await dbojs.create({
+    id: MORPH,
+    flags: "player connected wizard",
+    data: { name: "Morphic", "short-desc": "Cloaked in shifting shadow.", "idle": "12" },
+    location: ROOM,
+  });
+  await dbojs.create({
+    id: LYRA,
+    flags: "player connected",
+    data: { name: "Lyra", "short-desc": "Tall, with a wary stance.", "idle": "3" },
+    location: ROOM,
+  });
+
+  // Objects
+  await dbojs.create({
+    id: ORB,
+    flags: "thing",
+    data: { name: "A glowing orb", "short-desc": "humming softly." },
+    location: ROOM,
+  });
+  await dbojs.create({
+    id: TOME,
+    flags: "thing",
+    data: { name: "A weathered tome", "short-desc": "bound in cracked leather." },
+    location: ROOM,
+  });
+
+  // Exits with name;alias[;alias...]
+  await dbojs.create({ id: E_NORTH,  flags: "exit", data: { name: "North;n" },             location: ROOM });
+  await dbojs.create({ id: E_DOOR,   flags: "exit", data: { name: "Crystal Door;cd;door" }, location: ROOM });
+  await dbojs.create({ id: E_PORTAL, flags: "exit", data: { name: "Portal;p" },            location: ROOM });
+
+  const u = await createNativeSDK("void-sock", ALICE, { name: "look", original: "look", args: [""], switches: [] });
+  const children = await dbojs.find({ location: ROOM });
+  (u.here as unknown as { contents: IDBObj[] }).contents = children
+    .filter((c) => c.id !== ALICE)
+    .map((c) => hydrate(c));
+
+  const sent: string[] = [];
+  u.send = (m: string) => { sent.push(m); };
+  (u.here as unknown as { broadcast: (m: string) => void }).broadcast = () => {};
+
+  await execLook(u);
+
+  const rendered = sent.join("");
+  const stripped = rendered
+    .replace(/%c[a-z]/gi, "")
+    .replace(/%[rR]/g, "\n")
+    .replace(/%b/g, " ")
+    .replace(/%t/g, "\t");
+
+  console.log("\n===== RENDERED =====");
+  console.log(stripped);
+  console.log("===== END =====\n");
+
+  await cleanup();
+  await DBO.close();
+});

--- a/tests/ps_formats.test.ts
+++ b/tests/ps_formats.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for PSFORMAT / PSROWFORMAT — mirrors who_formats.test.ts.
+ *
+ * Unit-style tests drive the plugin-handler registry (softcode attr path
+ * returns null when `u.attr.get` is stubbed to null).
+ * Integration tests use real dbojs + softcodeService via the two-tier
+ * `resolveGlobalFormat` lookup (#0 then enactor).
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+import { execPs } from "../src/commands/ps.ts";
+import { queue } from "../src/services/Queue/index.ts";
+import {
+  registerFormatHandler,
+  unregisterFormatHandler,
+  _clearFormatHandlers,
+  type FormatHandler,
+} from "../src/utils/formatHandlers.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 15000 };
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+function makeActor(id: string, name: string, staff = false): IDBObj {
+  const flags = new Set(["player", "connected"]);
+  if (staff) flags.add("admin");
+  return {
+    id,
+    name,
+    flags,
+    state: { name },
+    location: "0",
+    contents: [],
+  } as unknown as IDBObj;
+}
+
+function makeMock(actor: IDBObj, attrGet?: (id: string, name: string) => Promise<string | null>) {
+  const sent: string[] = [];
+  const u = {
+    me: actor,
+    here: { id: "r1", flags: new Set(["room"]), state: {}, contents: [], broadcast: () => {} },
+    cmd: { name: "@ps", original: "@ps", args: ["", ""], switches: [] },
+    socketId: "sock-1",
+    send: (m: string) => { sent.push(m); },
+    db: { search: () => Promise.resolve([]) },
+    attr: { get: attrGet ?? (() => Promise.resolve(null)) },
+    util: {
+      displayName: (o: IDBObj) => o.name ?? "Unknown",
+      center: (s: string, w: number, fill: string) => {
+        const pad = Math.max(0, w - s.length);
+        const left = Math.floor(pad / 2);
+        return fill.repeat(left) + s + fill.repeat(pad - left);
+      },
+      ljust: (s: string, w: number, fill = " ") => s + fill.repeat(Math.max(0, w - s.length)),
+    },
+  };
+  return { u: u as unknown as IUrsamuSDK, sent };
+}
+
+// Track PIDs created in tests so we can clean them up.
+const createdPids: number[] = [];
+
+async function enqueueFor(executor: string): Promise<number> {
+  const pid = await queue.enqueue({ command: "think hi", executor, enactor: executor }, 30_000);
+  createdPids.push(pid);
+  return pid;
+}
+
+async function cleanupQueue() {
+  for (const pid of createdPids.splice(0)) {
+    await queue.cancel(pid).catch(() => {});
+  }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+Deno.test("ps: no attr + no handler — default rendering", OPTS, async () => {
+  _clearFormatHandlers();
+  const actor = makeActor("999101", "Alice");
+  await enqueueFor(actor.id);
+  try {
+    const { u, sent } = makeMock(actor);
+    await execPs(u);
+    const out = sent.join("\n");
+    assertStringIncludes(out, "Process Queue");
+    assertStringIncludes(out, `#${actor.id}`);
+    assertStringIncludes(out, "%chTotal:%cn");
+  } finally {
+    await cleanupQueue();
+  }
+});
+
+Deno.test("ps: PSFORMAT handler overrides full block", OPTS, async () => {
+  _clearFormatHandlers();
+  const actor = makeActor("999102", "Alice");
+  await enqueueFor(actor.id);
+  try {
+    const fn: FormatHandler = (_u, _t, arg) => `BLOCK<<${arg.length}>>`;
+    registerFormatHandler("PSFORMAT", fn);
+    const { u, sent } = makeMock(actor);
+    try {
+      await execPs(u);
+    } finally {
+      unregisterFormatHandler("PSFORMAT", fn);
+    }
+    const out = sent.join("\n");
+    assertStringIncludes(out, "BLOCK<<");
+    assertEquals(out.includes("Process Queue "), false);
+  } finally {
+    await cleanupQueue();
+  }
+});
+
+Deno.test("ps: PSROWFORMAT handler overrides per-row", OPTS, async () => {
+  _clearFormatHandlers();
+  const actor = makeActor("999103", "Alice");
+  await enqueueFor(actor.id);
+  await enqueueFor(actor.id);
+  try {
+    const fn: FormatHandler = (_u, _t, arg) => `ROW[${arg.split(/\s+/).slice(0, 3).join("|")}]`;
+    registerFormatHandler("PSROWFORMAT", fn);
+    const { u, sent } = makeMock(actor);
+    try {
+      await execPs(u);
+    } finally {
+      unregisterFormatHandler("PSROWFORMAT", fn);
+    }
+    const out = sent.join("\n");
+    assertStringIncludes(out, "ROW[");
+    // Header & footer still rendered because PSFORMAT not set.
+    assertStringIncludes(out, "Process Queue");
+    assertStringIncludes(out, "%chTotal:%cn");
+  } finally {
+    await cleanupQueue();
+  }
+});
+
+Deno.test("ps: handler returning null falls through to default", OPTS, async () => {
+  _clearFormatHandlers();
+  const actor = makeActor("999104", "Alice");
+  await enqueueFor(actor.id);
+  try {
+    const fn: FormatHandler = () => null;
+    registerFormatHandler("PSFORMAT", fn);
+    const { u, sent } = makeMock(actor);
+    try {
+      await execPs(u);
+    } finally {
+      unregisterFormatHandler("PSFORMAT", fn);
+    }
+    const out = sent.join("\n");
+    assertStringIncludes(out, "Process Queue");
+    assertStringIncludes(out, `#${actor.id}`);
+  } finally {
+    await cleanupQueue();
+  }
+});
+
+Deno.test("ps: handler throw is swallowed; default rendering wins", OPTS, async () => {
+  _clearFormatHandlers();
+  const actor = makeActor("999105", "Alice");
+  await enqueueFor(actor.id);
+  try {
+    const fn: FormatHandler = () => { throw new Error("boom"); };
+    registerFormatHandler("PSFORMAT", fn);
+    const { u, sent } = makeMock(actor);
+    try {
+      await execPs(u);
+    } finally {
+      unregisterFormatHandler("PSFORMAT", fn);
+    }
+    const out = sent.join("\n");
+    assertStringIncludes(out, "Process Queue");
+  } finally {
+    await cleanupQueue();
+  }
+});
+
+// ── Integration tests (real softcode + dbojs) ─────────────────────────────
+
+const { dbojs, DBO } = await import("../src/services/Database/database.ts");
+const { createNativeSDK } = await import("../src/services/SDK/index.ts");
+
+const ROOT = "0";
+const ACTOR = "920001";
+
+async function dbCleanup() {
+  for (const id of [ROOT, ACTOR]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+async function seed(opts: { rootAttrs?: Record<string, string>; actorAttrs?: Record<string, string> } = {}) {
+  await dbCleanup();
+  _clearFormatHandlers();
+  const mkAttrs = (m: Record<string, string>) =>
+    Object.entries(m).map(([name, value]) => ({ name, value, setter: ACTOR, type: "attribute" }));
+  await dbojs.create({
+    id: ROOT,
+    flags: "room",
+    data: { name: "Root", attributes: mkAttrs(opts.rootAttrs ?? {}) },
+  });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected wizard",
+    data: { name: "Alice", attributes: mkAttrs(opts.actorAttrs ?? {}) },
+    location: ROOT,
+  });
+  await enqueueFor(ACTOR);
+}
+
+async function runPs(): Promise<string> {
+  const u = await createNativeSDK("ps-sock", ACTOR, {
+    name: "@ps", original: "@ps", args: ["", ""], switches: [],
+  });
+  const sent: string[] = [];
+  u.send = (m: string) => { sent.push(m); };
+  await execPs(u);
+  return sent.join("\n");
+}
+
+Deno.test("softcode: @psformat on #0 wraps the default block", { ...OPTS, ...SLOW }, async () => {
+  await seed({ rootAttrs: { PSFORMAT: "<<<%0>>>" } });
+  try {
+    const out = await runPs();
+    assertStringIncludes(out, "<<<");
+    assertStringIncludes(out, ">>>");
+    assertStringIncludes(out, "Process Queue");
+  } finally {
+    await cleanupQueue();
+    await dbCleanup();
+  }
+});
+
+Deno.test("softcode: @psrowformat on #0 overrides each row", { ...OPTS, ...SLOW }, async () => {
+  await seed({ rootAttrs: { PSROWFORMAT: "ROW:[trim(%0)]" } });
+  try {
+    const out = await runPs();
+    assertStringIncludes(out, "ROW:");
+    // Header still renders because PSFORMAT not set.
+    assertStringIncludes(out, "Process Queue");
+  } finally {
+    await cleanupQueue();
+    await dbCleanup();
+  }
+});
+
+Deno.test("softcode: priority — #0 attr wins over enactor attr", { ...OPTS, ...SLOW }, async () => {
+  await seed({
+    rootAttrs:  { PSFORMAT: "ROOT-WINS" },
+    actorAttrs: { PSFORMAT: "ENACTOR" },
+  });
+  try {
+    const out = await runPs();
+    assertStringIncludes(out, "ROOT-WINS");
+    assertEquals(out.includes("ENACTOR"), false);
+  } finally {
+    await cleanupQueue();
+    await dbCleanup();
+  }
+});
+
+Deno.test("softcode: priority — enactor attr used when #0 absent", { ...OPTS, ...SLOW }, async () => {
+  await seed({ actorAttrs: { PSFORMAT: "FROM-ENACTOR-%0" } });
+  // Wipe PSFORMAT off #0 by removing #0 entirely so two-tier falls to enactor.
+  await dbojs.delete({ id: ROOT }).catch(() => {});
+  try {
+    const out = await runPs();
+    assertStringIncludes(out, "FROM-ENACTOR-");
+    assertStringIncludes(out, "Process Queue");
+  } finally {
+    await cleanupQueue();
+    await dbCleanup();
+  }
+});
+
+Deno.test("softcode: priority — neither set, default renders", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  try {
+    const out = await runPs();
+    assertStringIncludes(out, "Process Queue");
+    assertStringIncludes(out, "%chTotal:%cn");
+  } finally {
+    await cleanupQueue();
+    await dbCleanup();
+    await DBO.close();
+  }
+});

--- a/tests/resolveFormat.test.ts
+++ b/tests/resolveFormat.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for src/utils/resolveFormat.ts — the lifted format-resolution helper.
+ *
+ * Resolution order:
+ *   1. softcode attribute on target (evaluated through softcodeService)
+ *   2. plugin-registered handlers (first non-null wins)
+ *   3. null fallback (caller renders default)
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { createNativeSDK } from "../src/services/SDK/index.ts";
+import { resolveFormat, resolveFormatOr } from "../src/utils/resolveFormat.ts";
+import {
+  _clearFormatHandlers,
+  registerFormatHandler,
+} from "../src/utils/formatHandlers.ts";
+import { hydrate } from "../src/utils/evaluateLock.ts";
+import type { IDBObj, IUrsamuSDK } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 15000 };
+
+const ROOM = "910001";
+const ACTOR = "910002";
+const TARGET = "910003";
+
+async function cleanup() {
+  for (const id of [ROOM, ACTOR, TARGET]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+async function seed(attrs: Record<string, string> = {}) {
+  await cleanup();
+  _clearFormatHandlers();
+  const attributes = Object.entries(attrs).map(([name, value]) => ({
+    name, value, setter: ACTOR, type: "attribute",
+  }));
+  await dbojs.create({
+    id: ROOM,
+    flags: "room",
+    data: { name: "RF Room" },
+  });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected wizard",
+    data: { name: "Alice" },
+    location: ROOM,
+  });
+  await dbojs.create({
+    id: TARGET,
+    flags: "thing",
+    data: { name: "Widget", attributes },
+    location: ROOM,
+  });
+}
+
+async function makeContext(): Promise<{ u: IUrsamuSDK; target: IDBObj }> {
+  const u = await createNativeSDK("rf-sock", ACTOR, {
+    name: "test", original: "test", args: [], switches: [],
+  });
+  const raw = await dbojs.queryOne({ id: TARGET }) as unknown as IDBObj;
+  const target = hydrate(raw);
+  return { u, target };
+}
+
+Deno.test("resolveFormat: softcode attribute wins", { ...OPTS, ...SLOW }, async () => {
+  await seed({ NAMEFORMAT: "<<%0>>" });
+  const { u, target } = await makeContext();
+  const out = await resolveFormat(u, target, "NAMEFORMAT", "Widget");
+  assertEquals(out, "<<Widget>>");
+  await cleanup();
+});
+
+Deno.test("resolveFormat: no attr, registered handler used", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  registerFormatHandler("DESCFORMAT", (_u, _t, arg) => `H[${arg}]`);
+  const { u, target } = await makeContext();
+  const out = await resolveFormat(u, target, "DESCFORMAT", "hi");
+  assertEquals(out, "H[hi]");
+  _clearFormatHandlers();
+  await cleanup();
+});
+
+Deno.test("resolveFormat: handler returns null → falls through to null", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  registerFormatHandler("CONFORMAT", () => null);
+  const { u, target } = await makeContext();
+  const out = await resolveFormat(u, target, "CONFORMAT", "x");
+  assertEquals(out, null);
+  _clearFormatHandlers();
+  await cleanup();
+});
+
+Deno.test("resolveFormat: no attr, no handler → null", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const { u, target } = await makeContext();
+  const out = await resolveFormat(u, target, "EXITFORMAT", "x");
+  assertEquals(out, null);
+  await cleanup();
+});
+
+Deno.test("resolveFormat: softcode throw falls through to plugin handler", { ...OPTS, ...SLOW }, async () => {
+  await seed({ NAMEFORMAT: "<<%0>>" });
+  const { u, target } = await makeContext();
+  // Force softcode path to throw — attr.get throws.
+  u.attr.get = () => { throw new Error("boom"); };
+  registerFormatHandler("NAMEFORMAT", (_u, _t, arg) => `HANDLER[${arg}]`);
+  const out = await resolveFormat(u, target, "NAMEFORMAT", "Widget");
+  assertEquals(out, "HANDLER[Widget]");
+  _clearFormatHandlers();
+  await cleanup();
+});
+
+Deno.test("resolveFormat: first non-null handler wins; later handlers don't run", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  let secondCalls = 0;
+  registerFormatHandler("CONFORMAT", () => "first");
+  registerFormatHandler("CONFORMAT", () => { secondCalls++; return "second"; });
+  const { u, target } = await makeContext();
+  const out = await resolveFormat(u, target, "CONFORMAT", "x");
+  assertEquals(out, "first");
+  assertEquals(secondCalls, 0);
+  _clearFormatHandlers();
+  await cleanup();
+});
+
+Deno.test("resolveFormatOr: returns fallback when resolver yields null", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const { u, target } = await makeContext();
+  const out = await resolveFormatOr(u, target, "EXITFORMAT", "x", "FALLBACK");
+  assertEquals(out, "FALLBACK");
+  await cleanup();
+  await DBO.close();
+});

--- a/tests/security_format_silent_errors.test.ts
+++ b/tests/security_format_silent_errors.test.ts
@@ -1,0 +1,139 @@
+/**
+ * L1 + L2 — Silent error swallowing.
+ *   L1: `runPluginFormatHandlers` catches plugin handler throws and emits
+ *       nothing. Plugin bugs become invisible.
+ *   L2: `resolveFormat` catches softcode eval throws and emits nothing.
+ *       Broken @nameformat/@whoformat/etc. silently route to the next
+ *       fallback with no debug hint.
+ *
+ * Fix: log a warning to stderr on each swallowed error so operators can
+ * diagnose. Default behavior remains the same (don't crash the caller).
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import {
+  registerFormatHandler,
+  _clearFormatHandlers,
+  runPluginFormatHandlers,
+} from "../src/utils/formatHandlers.ts";
+import { resolveFormat } from "../src/utils/resolveFormat.ts";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false, timeout: 15000 };
+
+const ACTOR = "720001";
+
+function captureWarn(): { logs: string[]; restore: () => void } {
+  const logs: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  return { logs, restore: () => { console.warn = orig; } };
+}
+
+function mockTarget(): IDBObj {
+  return {
+    id: ACTOR, name: "T",
+    flags: new Set<string>(), state: {}, location: "", contents: [],
+  } as unknown as IDBObj;
+}
+
+function mockU(): IUrsamuSDK {
+  return {
+    me: mockTarget(),
+    here: mockTarget(),
+    socketId: "s",
+    cmd: { name: "", args: [], switches: [] },
+    send: () => {},
+    canEdit: () => Promise.resolve(true),
+    attr: {
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+      clear: () => Promise.resolve(false),
+    },
+    util: { displayName: () => "T", stripSubs: (s: string) => s },
+  } as unknown as IUrsamuSDK;
+}
+
+Deno.test("L1: plugin handler throw logs a warning", OPTS, async () => {
+  _clearFormatHandlers();
+  const cap = captureWarn();
+  try {
+    registerFormatHandler("NAMEFORMAT", () => { throw new Error("plugin broke"); });
+    await runPluginFormatHandlers("NAMEFORMAT", mockU(), mockTarget(), "x");
+  } finally {
+    cap.restore();
+    _clearFormatHandlers();
+  }
+  const matched = cap.logs.some((l) => l.includes("plugin broke") || /format.*handler/i.test(l));
+  assertEquals(matched, true, `Expected warn about plugin handler throw. Got: ${JSON.stringify(cap.logs)}`);
+});
+
+Deno.test("L1: handler still falls through after logged throw", OPTS, async () => {
+  _clearFormatHandlers();
+  const cap = captureWarn();
+  let nextCalled = false;
+  try {
+    registerFormatHandler("NAMEFORMAT", () => { throw new Error("boom"); });
+    registerFormatHandler("NAMEFORMAT", () => { nextCalled = true; return "OK"; });
+    const out = await runPluginFormatHandlers("NAMEFORMAT", mockU(), mockTarget(), "x");
+    assertEquals(out, "OK");
+  } finally {
+    cap.restore();
+    _clearFormatHandlers();
+  }
+  assertEquals(nextCalled, true);
+});
+
+Deno.test("L2: softcode eval failure in resolveFormat logs a warning", OPTS, async () => {
+  // Force a softcode failure by setting an attr to syntactically broken code,
+  // then call resolveFormat directly.
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected",
+    data: {
+      name: "Mallory",
+      attributes: [
+        { name: "NAMEFORMAT", value: "[u(", setter: ACTOR, type: "attribute" },
+      ],
+    },
+    location: ACTOR,
+  });
+
+  const cap = captureWarn();
+  let out: string | null = "untouched";
+  try {
+    const u = {
+      me: { id: ACTOR, name: "Mallory", flags: new Set(["player", "connected"]),
+            state: {}, location: ACTOR, contents: [] } as unknown as IDBObj,
+      socketId: "s",
+      cmd: { name: "", args: [], switches: [] },
+      send: () => {},
+      canEdit: () => Promise.resolve(true),
+      attr: {
+        get: async (id: string, n: string) => {
+          const o = await dbojs.queryOne({ id });
+          if (!o) return null;
+          const attrs = (o.data?.attributes as Array<{ name: string; value: string }>) ?? [];
+          return attrs.find((a) => a.name.toUpperCase() === n.toUpperCase())?.value ?? null;
+        },
+        set: () => Promise.resolve(), clear: () => Promise.resolve(false),
+      },
+      util: { displayName: () => "Mallory" },
+    } as unknown as IUrsamuSDK;
+    out = await resolveFormat(u, u.me, "NAMEFORMAT", "default-name");
+  } finally {
+    cap.restore();
+    await dbojs.delete({ id: ACTOR }).catch(() => {});
+  }
+
+  // Function must still return null (graceful fallthrough), AND must have warned.
+  assertEquals(out, null);
+  const matched = cap.logs.some((l) => /softcode|format/i.test(l));
+  assertEquals(matched, true, `Expected warn about softcode failure. Got: ${JSON.stringify(cap.logs)}`);
+});
+
+Deno.test("L1+L2: cleanup", OPTS, async () => {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await DBO.close();
+});

--- a/tests/security_softcode_layout_dos.test.ts
+++ b/tests/security_softcode_layout_dos.test.ts
@@ -1,0 +1,107 @@
+/**
+ * H1 — DoS via unbounded width/count in layout softcode helpers.
+ *
+ * Any softcode author (i.e. any player who can set an attribute on
+ * themselves) can write `[repeat(x,99999999)]` to allocate ~100 MB strings
+ * per evaluation. The softcode timeout doesn't stop the allocation —
+ * `String.prototype.repeat` returns in a single call.
+ *
+ * Fix: clamp width/count to a sane ceiling.
+ */
+import { assertEquals } from "@std/assert";
+import { softcodeService } from "../src/services/Softcode/index.ts";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false, timeout: 15000 };
+
+const ACTOR = "700001";
+const MAX = 10_000; // expected clamp ceiling
+
+async function seedActor() {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected",
+    data: { name: "Mallory" },
+    location: ACTOR,
+  });
+}
+
+async function evalCode(code: string): Promise<string> {
+  return await softcodeService.runSoftcode(code, {
+    actorId:    ACTOR,
+    executorId: ACTOR,
+    args:       [],
+  });
+}
+
+Deno.test("H1: repeat() clamps count to safe ceiling", OPTS, async () => {
+  await seedActor();
+  const out = await evalCode("[repeat(x,99999999)]");
+  // Must NOT have produced a giant string.
+  if (out.length > MAX) {
+    throw new Error(`repeat() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: space() clamps count", OPTS, async () => {
+  const out = await evalCode("[space(50000000)]");
+  if (out.length > MAX) {
+    throw new Error(`space() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: header() clamps width", OPTS, async () => {
+  const out = await evalCode("[header(Title,99999999)]");
+  if (out.length > MAX) {
+    throw new Error(`header() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: divider() clamps width", OPTS, async () => {
+  const out = await evalCode("[divider(Title,99999999)]");
+  if (out.length > MAX) {
+    throw new Error(`divider() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: footer() clamps width", OPTS, async () => {
+  const out = await evalCode("[footer(99999999)]");
+  if (out.length > MAX) {
+    throw new Error(`footer() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: ljust() clamps width (pre-existing helper, same risk)", OPTS, async () => {
+  const out = await evalCode("[ljust(x,99999999,.)]");
+  if (out.length > MAX) {
+    throw new Error(`ljust() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: rjust() clamps width", OPTS, async () => {
+  const out = await evalCode("[rjust(x,99999999,.)]");
+  if (out.length > MAX) {
+    throw new Error(`rjust() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: center() clamps width", OPTS, async () => {
+  const out = await evalCode("[center(x,99999999,.)]");
+  if (out.length > MAX) {
+    throw new Error(`center() produced ${out.length} chars — exceeds ${MAX} clamp`);
+  }
+  assertEquals(out.length, MAX);
+});
+
+Deno.test("H1: cleanup", OPTS, async () => {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await DBO.close();
+});

--- a/tests/security_who_synthetic_zero.test.ts
+++ b/tests/security_who_synthetic_zero.test.ts
@@ -1,0 +1,113 @@
+/**
+ * M1 — `resolveGlobalFormat` in social.ts constructs a synthetic IDBObj for
+ * `#0` without verifying that object exists. When #0 doesn't exist, plugin
+ * handlers are still invoked with target.id="0" (a phantom target).
+ *
+ * Inconsistent with ps.ts which checks `dbojs.queryOne({ id: "0" })` first.
+ * Functionally safe today because softcode attr lookup also fails on
+ * non-existent objects, but the phantom-target leak through to plugin
+ * handlers is a latent bug.
+ *
+ * Fix: only resolve against #0 when #0 actually exists in the DB.
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { execWho } from "../src/commands/social.ts";
+import {
+  registerFormatHandler,
+  unregisterFormatHandler,
+  _clearFormatHandlers,
+  type FormatHandler,
+} from "../src/utils/formatHandlers.ts";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false, timeout: 15000 };
+
+const ACTOR = "710001";
+
+async function setup() {
+  _clearFormatHandlers();
+  await dbojs.delete({ id: "0" }).catch(() => {});  // ensure #0 absent
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected",
+    data: { name: "Alice" },
+    location: ACTOR,
+  });
+}
+
+function makeMockSDK(): { u: IUrsamuSDK; sent: string[] } {
+  const sent: string[] = [];
+  const me = {
+    id: ACTOR,
+    name: "Alice",
+    flags: new Set(["player", "connected"]),
+    state: { name: "Alice" },
+    location: ACTOR,
+    contents: [],
+  } as unknown as IDBObj;
+  const u = {
+    me,
+    here: me,
+    socketId: "sock-m1",
+    cmd: { name: "who", original: "who", args: [], switches: [] },
+    send: (m: string) => { sent.push(m); },
+    canEdit: () => Promise.resolve(true),
+    db: {
+      search: () => Promise.resolve([me]),
+      modify: () => Promise.resolve(),
+      create: () => Promise.resolve(me),
+      destroy: () => Promise.resolve(),
+    },
+    attr: {
+      get: async (id: string, n: string) => {
+        const o = await dbojs.queryOne({ id });
+        if (!o) return null;
+        const attrs = (o.data?.attributes as Array<{ name: string; value: string }>) || [];
+        return attrs.find((a) => a.name.toUpperCase() === n.toUpperCase())?.value ?? null;
+      },
+      set: () => Promise.resolve(),
+      clear: () => Promise.resolve(false),
+    },
+    util: {
+      displayName: (o: { name?: string }) => o.name ?? "Unknown",
+      stripSubs: (s: string) => s,
+      center: (s: string) => s,
+      ljust: (s: string, w: number) => s.padEnd(w),
+      rjust: (s: string, w: number) => s.padStart(w),
+    },
+  } as unknown as IUrsamuSDK;
+  return { u, sent };
+}
+
+Deno.test("M1: WHO handler must NOT be invoked with phantom target.id='0' when #0 absent", OPTS, async () => {
+  await setup();
+
+  const seenIds: string[] = [];
+  const probe: FormatHandler = (_u, target) => {
+    seenIds.push(target.id);
+    return null;  // fall through so default renders
+  };
+  registerFormatHandler("WHOFORMAT", probe);
+  try {
+    const { u } = makeMockSDK();
+    await execWho(u);
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", probe);
+  }
+
+  // Today (pre-fix), this list includes "0" because social.ts synthesizes a
+  // phantom #0 target unconditionally. After the fix it should only contain
+  // the enactor id (ACTOR).
+  assertEquals(
+    seenIds.includes("0"),
+    false,
+    `Plugin handler was invoked with phantom target.id="0" even though #0 doesn't exist. seenIds=${JSON.stringify(seenIds)}`,
+  );
+});
+
+Deno.test("M1: cleanup", OPTS, async () => {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await DBO.close();
+});

--- a/tests/softcode_layout.test.ts
+++ b/tests/softcode_layout.test.ts
@@ -1,0 +1,128 @@
+/**
+ * tests/softcode_layout.test.ts
+ *
+ * Tests for header() / divider() / footer() softcode layout helpers.
+ * Exercises them through the real UrsaMU softcode engine.
+ */
+import { assertEquals } from "@std/assert";
+import { runSoftcode, softcodeEngine } from "../src/services/Softcode/ursamu-engine.ts";
+import type { UrsaEvalContext } from "../src/services/Softcode/ursamu-context.ts";
+import type { DbAccessor, OutputAccessor } from "../src/services/Softcode/context.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+function makeActor(overrides: Partial<IDBObj> = {}): IDBObj {
+  return {
+    id: "1",
+    name: "Tester",
+    flags: new Set(["player", "connected"]),
+    location: "0",
+    state: {},
+    contents: [],
+    ...overrides,
+  };
+}
+
+function makeDb(overrides: Partial<DbAccessor> = {}): DbAccessor {
+  return {
+    queryById:        () => Promise.resolve(null),
+    queryByName:      () => Promise.resolve(null),
+    lcon:             () => Promise.resolve([]),
+    lwho:             () => Promise.resolve([]),
+    lattr:            () => Promise.resolve([]),
+    getAttribute:     () => Promise.resolve(null),
+    getTagById:       () => Promise.resolve(null),
+    getPlayerTagById: () => Promise.resolve(null),
+    lsearch:          () => Promise.resolve([]),
+    children:         () => Promise.resolve([]),
+    lchannels:        () => Promise.resolve(""),
+    channelsFor:      () => Promise.resolve(""),
+    mailCount:        () => Promise.resolve(0),
+    queueLength:      () => Promise.resolve(0),
+    getIdleSecs:      () => Promise.resolve(0),
+    getUserFn:        () => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+const noOutput: OutputAccessor = {
+  send:          () => {},
+  roomBroadcast: () => {},
+  broadcast:     () => {},
+};
+
+function makeCtx(overrides: Partial<UrsaEvalContext> = {}): UrsaEvalContext {
+  const actor = makeActor();
+  return {
+    enactor:      actor.id,
+    executor:     actor,
+    caller:       null,
+    actor,
+    args:         [],
+    registers:    new Map(),
+    iterStack:    [],
+    depth:        0,
+    maxDepth:     50,
+    maxOutputLen: 65_536,
+    deadline:     Date.now() + 5000,
+    db:           makeDb(),
+    output:       noOutput,
+    _engine:      softcodeEngine,
+    ...overrides,
+  };
+}
+
+const run = (code: string) => runSoftcode(code, makeCtx());
+
+// ── header ─────────────────────────────────────────────────────────────────
+
+Deno.test("header — default width 78 and fill '='", async () => {
+  const r = await run("[header(The Void)]");
+  assertEquals(r.length, 78);
+  assertEquals(r.startsWith("===== The Void "), true);
+  assertEquals(r.endsWith("="), true);
+});
+
+Deno.test("header — custom width and fill", async () => {
+  const r = await run("[header(Players,40,*)]");
+  assertEquals(r.length, 40);
+  assertEquals(r.startsWith("***** Players "), true);
+  assertEquals(r.endsWith("*"), true);
+});
+
+Deno.test("header — empty title becomes fill x width", async () => {
+  const r = await run("[header(,20,=)]");
+  assertEquals(r, "=".repeat(20));
+});
+
+// ── divider ────────────────────────────────────────────────────────────────
+
+Deno.test("divider — default fill '-'", async () => {
+  const r = await run("[divider(Players)]");
+  assertEquals(r.length, 78);
+  assertEquals(r.startsWith("----- Players "), true);
+  assertEquals(r.endsWith("-"), true);
+});
+
+// ── footer ─────────────────────────────────────────────────────────────────
+
+Deno.test("footer — default 78 chars of '='", async () => {
+  const r = await run("[footer()]");
+  assertEquals(r, "=".repeat(78));
+});
+
+Deno.test("footer — custom width and fill", async () => {
+  const r = await run("[footer(10,-)]");
+  assertEquals(r, "-".repeat(10));
+});
+
+// ── composition via iter() ─────────────────────────────────────────────────
+
+Deno.test("header — composes inside iter()", async () => {
+  // iter joins each iteration's output with osep (default " "). With two
+  // items of width 20, total length should be 20 + 1 + 20 = 41.
+  const r = await run("[iter(a b,[header(##,20,=)])]");
+  assertEquals(r.length, 41);
+  assertEquals(r.slice(0, 20).startsWith("===== a "), true);
+  assertEquals(r.slice(21, 41).startsWith("===== b "), true);
+  assertEquals(r[20], " ");
+});

--- a/tests/who_formats.test.ts
+++ b/tests/who_formats.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for WHOFORMAT / WHOROWFORMAT — mirrors look_formats[_integration].
+ *
+ * Unit-style tests drive the priority chain via the plugin-handler registry
+ * (softcode attr path returns null when `u.attr.get` is stubbed to null).
+ * Integration-style tests use the real dbojs + softcodeService.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+import { execWho } from "../src/commands/social.ts";
+import {
+  registerFormatHandler,
+  unregisterFormatHandler,
+  _clearFormatHandlers,
+  type FormatHandler,
+} from "../src/utils/formatHandlers.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 15000 };
+
+// ── Unit mocks ────────────────────────────────────────────────────────────
+
+function makePlayer(id: string, name: string, doing?: string): IDBObj {
+  return {
+    id,
+    name,
+    flags: new Set(["player", "connected"]),
+    state: { name, doing: doing ?? "" },
+    location: "0",
+    contents: [],
+  } as unknown as IDBObj;
+}
+
+function makeMock(players: IDBObj[], attrGet?: (id: string, name: string) => Promise<string | null>) {
+  const me = makePlayer("p1", "Alice");
+  const sent: string[] = [];
+  const u = {
+    me,
+    here: { id: "r1", flags: new Set(["room"]), state: {}, contents: [], broadcast: () => {} },
+    cmd: { name: "who", original: "who", args: [], switches: [] },
+    socketId: "sock-1",
+    send: (m: string) => { sent.push(m); },
+    db: { search: () => Promise.resolve(players) },
+    attr: { get: attrGet ?? (() => Promise.resolve(null)) },
+    util: { displayName: (o: IDBObj) => o.name ?? "Unknown" },
+  };
+  return { u: u as unknown as IUrsamuSDK, sent };
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────
+
+Deno.test("who: no attr + no handler — default rendering", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock([makePlayer("p2", "Bob", "Adventuring")]);
+  await execWho(u);
+  assertStringIncludes(sent[0], "%chWho's Online%cn");
+  assertStringIncludes(sent[0], "Bob");
+  assertStringIncludes(sent[0], "Adventuring");
+  assertStringIncludes(sent[0], "1 player online.");
+});
+
+Deno.test("who: WHOFORMAT handler overrides full block", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock([makePlayer("p2", "Bob")]);
+  const fn: FormatHandler = (_u, _t, arg) => `BLOCK<<${arg.length}>>`;
+  registerFormatHandler("WHOFORMAT", fn);
+  try {
+    await execWho(u);
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", fn);
+  }
+  assertStringIncludes(sent[0], "BLOCK<<");
+  assertEquals(sent[0].includes("%chWho's Online%cn"), false);
+});
+
+Deno.test("who: WHOROWFORMAT handler overrides per-row", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock([
+    makePlayer("p2", "Bob"),
+    makePlayer("p3", "Carol"),
+  ]);
+  const fn: FormatHandler = (_u, _t, arg) => `ROW[${arg.trim().split(/\s+/)[0]}]`;
+  registerFormatHandler("WHOROWFORMAT", fn);
+  try {
+    await execWho(u);
+  } finally {
+    unregisterFormatHandler("WHOROWFORMAT", fn);
+  }
+  assertStringIncludes(sent[0], "ROW[Bob]");
+  assertStringIncludes(sent[0], "ROW[Carol]");
+  // Header/footer of the default block still present (WHOFORMAT not set).
+  assertStringIncludes(sent[0], "%chWho's Online%cn");
+});
+
+Deno.test("who: handler returning null falls through to default", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock([makePlayer("p2", "Bob")]);
+  const fn: FormatHandler = () => null;
+  registerFormatHandler("WHOFORMAT", fn);
+  try {
+    await execWho(u);
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", fn);
+  }
+  assertStringIncludes(sent[0], "%chWho's Online%cn");
+  assertStringIncludes(sent[0], "Bob");
+});
+
+Deno.test("who: handler throw is swallowed; default rendering wins", OPTS, async () => {
+  _clearFormatHandlers();
+  const { u, sent } = makeMock([makePlayer("p2", "Bob")]);
+  const fn: FormatHandler = () => { throw new Error("boom"); };
+  registerFormatHandler("WHOFORMAT", fn);
+  try {
+    await execWho(u);
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", fn);
+  }
+  assertStringIncludes(sent[0], "%chWho's Online%cn");
+});
+
+// ── Integration tests (real softcode + dbojs) ─────────────────────────────
+
+const { dbojs, DBO } = await import("../src/services/Database/database.ts");
+const { createNativeSDK } = await import("../src/services/SDK/index.ts");
+
+const ROOT = "0";
+const ACTOR = "910001";
+const PEER = "910002";
+
+async function cleanup() {
+  for (const id of [ROOT, ACTOR, PEER]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+async function seed(opts: { rootAttrs?: Record<string, string>; actorAttrs?: Record<string, string> } = {}) {
+  await cleanup();
+  _clearFormatHandlers();
+  const mkAttrs = (m: Record<string, string>) =>
+    Object.entries(m).map(([name, value]) => ({ name, value, setter: ACTOR, type: "attribute" }));
+  await dbojs.create({
+    id: ROOT,
+    flags: "room",
+    data: { name: "Root", attributes: mkAttrs(opts.rootAttrs ?? {}) },
+  });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected wizard",
+    data: { name: "Alice", attributes: mkAttrs(opts.actorAttrs ?? {}) },
+    location: ROOT,
+  });
+  await dbojs.create({
+    id: PEER,
+    flags: "player connected",
+    data: { name: "Bob", doing: "Adventuring" },
+    location: ROOT,
+  });
+}
+
+async function runWho(): Promise<string> {
+  const u = await createNativeSDK("who-sock", ACTOR, {
+    name: "who", original: "who", args: [], switches: [],
+  });
+  const sent: string[] = [];
+  u.send = (m: string) => { sent.push(m); };
+  await execWho(u);
+  return sent.join("\n");
+}
+
+Deno.test("softcode: @whoformat on #0 wraps the default block", { ...OPTS, ...SLOW }, async () => {
+  await seed({ rootAttrs: { WHOFORMAT: "<<<%0>>>" } });
+  const out = await runWho();
+  assertStringIncludes(out, "<<<");
+  assertStringIncludes(out, ">>>");
+  assertStringIncludes(out, "Bob");
+  await cleanup();
+});
+
+Deno.test("softcode: @whorowformat on #0 overrides each row", { ...OPTS, ...SLOW }, async () => {
+  await seed({ rootAttrs: { WHOROWFORMAT: "ROW:[trim(%0)]" } });
+  const out = await runWho();
+  assertStringIncludes(out, "ROW:");
+  assertStringIncludes(out, "Bob");
+  // The default WHO header still renders because WHOFORMAT isn't set.
+  assertStringIncludes(out, "Who's Online");
+  await cleanup();
+});
+
+Deno.test("softcode: priority — #0 attr wins over enactor attr", { ...OPTS, ...SLOW }, async () => {
+  await seed({
+    rootAttrs:  { WHOFORMAT: "ROOT-WINS" },
+    actorAttrs: { WHOFORMAT: "ENACTOR" },
+  });
+  const out = await runWho();
+  assertStringIncludes(out, "ROOT-WINS");
+  assertEquals(out.includes("ENACTOR"), false);
+  await cleanup();
+});
+
+Deno.test("softcode: priority — enactor attr used when #0 absent", { ...OPTS, ...SLOW }, async () => {
+  await seed({ actorAttrs: { WHOFORMAT: "FROM-ENACTOR-%0" } });
+  const out = await runWho();
+  assertStringIncludes(out, "FROM-ENACTOR-");
+  // The default header text is the %0 payload, so it should appear inside the wrap.
+  assertStringIncludes(out, "Who's Online");
+  await cleanup();
+});
+
+Deno.test("softcode: priority — neither set, default renders", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const out = await runWho();
+  assertStringIncludes(out, "%chWho's Online%cn");
+  assertStringIncludes(out, "Bob");
+  await cleanup();
+  await DBO.close();
+});


### PR DESCRIPTION
## Summary
- **Format-attribute pipeline** — TinyMUX-style `@nameformat`/`@whoformat`/`@psformat` overrides on `look`, `who`, `@ps`. Priority: softcode attr on target → plugin handler → built-in default. New `resolveFormat`/`resolveFormatOr` exported from `mod.ts` for plugins to adopt the same pattern.
- **Plugin handler registry** — `registerFormatHandler`/`unregisterFormatHandler` exported. First non-null handler wins; throws are logged and swallowed.
- **Softcode layout helpers** — `header(title)`, `divider(title)`, `footer()` registered in stdlib. Replaces `[ljust(===== %0 ,78,=)]` idioms.
- **Native TS layout helpers** — `header`/`divider`/`footer` block-style rules exported from `mod.ts` for TypeScript command code.
- **Refactors** — `look.ts` uses `resolveFormat` (drops local `evalFormat`); `demo.ts` drops local `HR`/`hr`/`section()` in favor of shared helpers.
- **Security hardening (TDD-audited)** — see below.

## Slots wired
| Command | Slots |
|---|---|
| `look` | `NAMEFORMAT` / `DESCFORMAT` / `CONFORMAT` / `EXITFORMAT` |
| `who`  | `WHOFORMAT` / `WHOROWFORMAT` (two-tier: `#0` → enactor) |
| `@ps`  | `PSFORMAT` / `PSROWFORMAT` (two-tier: `#0` → enactor) |

## Security (Red-Green-Refactor)

| ID | Sev | Issue | Fix |
|---|---|---|---|
| H1 | HIGH | `repeat`/`space`/`ljust`/`rjust`/`center`/`lpad`/`rpad`/`cpad`/`header`/`divider`/`footer` allocated unbounded strings (`[repeat(x,99999999)]` → ~100 MB) | Clamp to `MAX_LEN=10_000`; removed override from `SKIP_NAMES` so clamped versions win |
| M1 | MED | `social.ts` synthesized phantom `#0` target without verifying existence (plugin handlers fired with `target.id="0"` even when #0 absent) | Query `dbojs.queryOne({id:"0"})` first; parity with `ps.ts` |
| L1 | LOW | Plugin handler throws silently swallowed | `console.warn` on catch in `runPluginFormatHandlers` |
| L2 | LOW | Softcode eval failures silently swallowed | `console.warn` on catch in `resolveFormat` |

## Render demo
```
===== The Void ===============================================================

A featureless void, stretching endlessly in all directions. The very fabric of
reality seems thin here, as though one might step through into something else
entirely. A faint, pulsing hum emanates from somewhere beyond perception, and
motes of pale light drift past on currents that obey no physics you know.

----- Players ----------------------------------------------------------------
 Diablerie             (Admin)      0s  Some awesome dude!
 Morphic               (Wizard)    12s  Cloaked in shifting shadow.
 Lyra                  (Player)     3s  Tall, with a wary stance.
----- Objects ----------------------------------------------------------------
 A glowing orb         humming softly.
 A weathered tome      bound in cracked leather.
----- Exits ------------------------------------------------------------------
<n> North                <cd> Crystal Door        <p> Portal
==============================================================================
```

## Test plan
- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean across 350 files
- [x] `deno test tests/` — **1116 passed / 0 failed**
- [x] `deno test tests/security_*.test.ts` — 141 passed / 0 failed
- [x] TDD audit — 4/4 findings remediated with exploit tests
- [ ] Reviewer: pull the branch and run the void render demo: `deno test tests/look_void_render.test.ts --allow-all --unstable-kv --no-check`

## Out of scope
The session-token persistence work in `auth.ts`/`telnet.ts` is unrelated drift from before this branch — left uncommitted for a separate PR.