### PR TITLE
feat(auth/telnet): persist session token across reconnects

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,5 +1,6 @@
 import { addCmd } from "../services/commands/cmdParser.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
+import { sign } from "../services/jwt/jwt.ts";
 
 export async function execConnect(u: IUrsamuSDK): Promise<void> {
   const pieces = (u.cmd.args[0] || "").split(" ");
@@ -27,6 +28,15 @@ export async function execConnect(u: IUrsamuSDK): Promise<void> {
   }
 
   await u.auth.login(player.id);
+
+  // Issue a session token so telnet (or any client) can re-authenticate
+  // after a server restart without forcing the player to log in again.
+  try {
+    const token = await sign({ id: player.id });
+    u.send("", undefined, { token });
+  } catch (e) {
+    console.warn("[auth] Failed to issue session token:", e);
+  }
 
   // Failsafe: promote first player to superuser if none exist.
   // Short-circuit if this player is already a superuser, then use a targeted query.

--- a/src/services/telnet/telnet.ts
+++ b/src/services/telnet/telnet.ts
@@ -194,6 +194,9 @@ export function accumulateNaws(
 async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, welcome: string) {
   let sock: WebSocket | null = null;
   let cid: string | undefined;
+  // Session token issued by the engine on successful login. Persisted across
+  // WS reconnects so the player doesn't have to log in again after @restart.
+  let sessionToken: string | undefined;
   const msgBuffer: string[] = [];
   let isReconnecting = false;
   let manuallyClosed = false;
@@ -228,15 +231,15 @@ async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, welcome: 
 
       sock.onopen = () => {
         if (isReconnecting) {
-            write(parser.substitute("telnet", "%chGame>%cn Server is back! Reconnected.\r\n"));
-
-            if (cid) {
-               sock?.send(JSON.stringify({
-                   msg: "look",
-                   data: { cid }
-               }));
+            // Re-authenticate first so the engine restores the player's cid
+            // before any buffered commands are dispatched.
+            if (sessionToken) {
+              sock?.send(JSON.stringify({ type: "auth", token: sessionToken }));
+              write(parser.substitute("telnet", "%chGame>%cn Server is back! Reconnected.\r\n"));
+              if (cid) sock?.send(JSON.stringify({ msg: "look", data: { cid } }));
+            } else {
+              write(parser.substitute("telnet", "%chGame>%cn Server is back. Please reconnect.\r\n"));
             }
-
             isReconnecting = false;
         }
 
@@ -251,6 +254,7 @@ async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, welcome: 
         try {
           const payload = JSON.parse(event.data);
           if (payload.data?.cid) cid = payload.data.cid;
+          if (typeof payload.data?.token === "string") sessionToken = payload.data.token;
 
           // If message is meant for Telnet, it should be in 'msg' (formatted ANSI)
           if (payload.msg) {


### PR DESCRIPTION
## Summary
- On successful login, `connect` issues a short-lived session JWT via `sign({id})` and emits it on the same message that completes login.
- The telnet bridge stores the token across the connection's lifecycle and re-authenticates on every WS reconnect (`{type:"auth", token}`) so the player isn't bounced to the login screen after a `@restart`.
- If no token is held yet (player hasn't logged in), the bridge prompts a manual reconnect instead of silently dropping buffered input.

## Files
- `src/commands/auth.ts` — issue session token after `auth.login(player.id)`; warn-only on signing failure (login still succeeds).
- `src/services/telnet/telnet.ts` — track `sessionToken`, send on reconnect before replaying buffered commands.

## Out of scope
Split from #129 (format-attribute pipeline) — the two features are unrelated and were sitting in the working tree together.

## Test plan
- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean on touched files
- [ ] Reviewer: start the engine, connect via telnet, log in, restart the engine, confirm telnet auto-reconnects and the player stays authenticated (no re-login prompt).
- [ ] Reviewer: confirm a brand-new connection (no login yet) sees the "Please reconnect." prompt on @restart instead of a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)