### PR TITLE
fix(format): explicit return types for JSR slow-types

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -165,19 +165,19 @@ export const threeColumn = (...lists: string[][]) => {
 // these TS forms are multi-line block decorators tailored to native command
 // output (plain `=`/`-` rules with a bold title sandwiched between).
 
-export const header = (string = "", filler = "=", width = 78) => {
+export const header = (string = "", filler = "=", width = 78): string => {
   const rule = filler.repeat(width);
   if (!string) return rule;
   return `${rule}\n${center(`%ch${string}%cn`, width)}\n${rule}`;
 };
 
-export const divider = (string = "", filler = "-", width = 78) => {
+export const divider = (string = "", filler = "-", width = 78): string => {
   const rule = filler.repeat(width);
   if (!string) return rule;
   return `\n%ch${string}%cn\n${rule}`;
 };
 
-export const footer = (string = "", filler = "=", width = 78) => {
+export const footer = (string = "", filler = "=", width = 78): string => {
   const rule = filler.repeat(width);
   if (!string) return rule;
   return `${rule}\n${center(`%ch${string}%cn`, width)}\n${rule}`;


### PR DESCRIPTION
## Summary
JSR's slow-types check rejected the v2.3.0 publish: the public API exports `header`/`divider`/`footer` in `src/utils/format.ts` inferred their `: string` return type instead of declaring it. Added explicit annotations.

## Error from JSR
\`\`\`
error[missing-explicit-return-type]: missing explicit return type in the public API
   --> src/utils/format.ts:168:14
168 | export const header = (string = "", filler = "=", width = 78) => {
\`\`\`

## Fix
\`\`\`diff
-export const header = (string = "", filler = "=", width = 78) => {
+export const header = (string = "", filler = "=", width = 78): string => {
\`\`\`
(same for `divider`, `footer`)

Functionally identical. Once merged, the push-to-main publish workflow re-fires and publishes v2.3.0 to JSR.

## Test plan
- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean
- [x] `deno publish --dry-run --allow-dirty` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)