### PR TITLE
feat: v2.3.1 — export softcodeService for plugin tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,19 @@ Use `u.util.center(title, 78, "=")` for section headers.
 
 ---
 
+## Escaping `[` and `]` in softcode attributes
+
+Square brackets are reserved by the TinyMUX evaluator as function-call
+delimiters (`[func(args)]`). Storing literal `[` or `]` inside an attribute
+value will be parsed as a function call and either error or produce surprising
+output. To embed literal brackets, use `lit([)` / `lit(])`, or `chr(91)` /
+`chr(93)`, or pick a different delimiter such as `<>` or `<<…>>`. This bites
+format-attr authors most often (`NAMEFORMAT`, `DESCFORMAT`, row templates) —
+write `<<%0>>` or `ROW(%0)` rather than `[%0]` when the brackets must appear
+in output.
+
+---
+
 ## Help file standards (non-negotiable)
 
 Help files live in `src/plugins/<name>/help/*.md` and are served in-game by the help-plugin FileProvider.

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -67,6 +67,10 @@ export { register as registerSoftcodeFunc } from "./src/services/Softcode/stdlib
 export { registerSub as registerSoftcodeSub } from "./src/services/Softcode/stdlib/subRegistry.ts";
 export type { StdlibFn as SoftcodeFn } from "./src/services/Softcode/stdlib/registry.ts";
 export type { SubHandler as SoftcodeSubHandler } from "./src/services/Softcode/stdlib/subRegistry.ts";
+// Softcode evaluator — exposed so plugin integration tests can drive real
+// TinyMUX evaluation against seeded attributes (rather than mocking attr.get).
+export { softcodeService } from "./src/services/Softcode/index.ts";
+export type { SoftcodeContext } from "./src/services/Softcode/index.ts";
 // Lock function registry — register custom lock functions from plugins
 export { registerLockFunc } from "./src/utils/lockFuncs.ts";
 export type { LockFunc } from "./src/utils/lockFuncs.ts";


### PR DESCRIPTION
## Summary
- Export `softcodeService` + `SoftcodeContext` from `mod.ts` so plugin integration tests can drive the real TinyMUX evaluator against seeded attributes instead of mocking the `u.attr.get` failure path.
- Document the `[` / `]` softcode escape gotcha in `CLAUDE.md` (use `lit([)` / `chr(91)` or alternative delimiters like `<<...>>` for literal brackets in attribute values).
- Bump version to 2.3.1.

## Test plan
- [x] `deno check --unstable-kv mod.ts`
- [x] `deno lint` (350 files clean)
- [x] `deno test tests/` — 1116 passed, 0 failed
- [x] `deno test tests/security_*.test.ts` — 141 passed, 0 failed