### PR TITLE
fix(softcode): add explicit type to softcodeService for JSR slow-types

### DIFF
--- a/src/services/Softcode/index.ts
+++ b/src/services/Softcode/index.ts
@@ -433,7 +433,7 @@ export class SoftcodeService {
   }
 }
 
-export const softcodeService = SoftcodeService.getInstance();
+export const softcodeService: SoftcodeService = SoftcodeService.getInstance();
 
 // Re-export types consumed by other modules.
 export type { EvalContext, DbAccessor, OutputAccessor } from "./context.ts";


### PR DESCRIPTION
## Summary
- JSR publish for v2.3.1 failed with `missing-explicit-type` on the new `softcodeService` singleton export.
- Annotate it as `SoftcodeService` so slow-type analysis passes.

## Test plan
- [x] `deno check --unstable-kv mod.ts`
- [x] `deno lint`