### PR TITLE
feat: v2.3.2 — expose resolveFormat to sandbox via u.util (closes #132)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/src/@types/UrsamuSDK.ts
+++ b/src/@types/UrsamuSDK.ts
@@ -49,6 +49,18 @@ export interface IUrsamuSDK {
     sprintf(format: string, ...args: unknown[]): string;
     stripSubs(str: string): string;
     parseDesc?(desc: string, actor: IDBObj, target: IDBObj): Promise<string>;
+    /**
+     * Resolve a format-attribute slot on `target`. Priority chain:
+     *   1. softcode attribute on target (evaluated via softcodeService)
+     *   2. plugin-registered handler for the slot
+     *   3. null → caller falls back to its own built-in default rendering
+     *
+     * Available in both native and sandbox contexts. `defaultArg` is exposed
+     * to softcode as `%0`.
+     */
+    resolveFormat?(target: IDBObj, slot: string, defaultArg: string): Promise<string | null>;
+    /** As `resolveFormat`, but returns `fallback` when the resolver yields null. */
+    resolveFormatOr?(target: IDBObj, slot: string, defaultArg: string, fallback: string): Promise<string>;
     [key: string]: unknown;
   };
   db: {

--- a/src/services/SDK/index.ts
+++ b/src/services/SDK/index.ts
@@ -85,6 +85,15 @@ function buildSDKFromContext(ctx: GameContext): IUrsamuSDK {
         const { parseDesc: parseFn } = await import("../../utils/parseDesc.ts");
         return parseFn(desc, actor, target);
       },
+      // u is captured by closure — plugin handlers see the same SDK instance.
+      resolveFormat: async (target: IDBObj, slot: string, defaultArg: string): Promise<string | null> => {
+        const { resolveFormat } = await import("../../utils/resolveFormat.ts");
+        return await resolveFormat(u, target, slot as Parameters<typeof resolveFormat>[2], defaultArg);
+      },
+      resolveFormatOr: async (target: IDBObj, slot: string, defaultArg: string, fallback: string): Promise<string> => {
+        const { resolveFormatOr } = await import("../../utils/resolveFormat.ts");
+        return await resolveFormatOr(u, target, slot as Parameters<typeof resolveFormatOr>[2], defaultArg, fallback);
+      },
     },
 
     db: {

--- a/src/services/Sandbox/SandboxService.ts
+++ b/src/services/Sandbox/SandboxService.ts
@@ -92,6 +92,16 @@ class LocalSandbox {
         if (type === "flags:set")        { await handleFlagsMessage(msg, worker, context); return; }
         if (type === "util:target")      { await handleUtilTargetMessage(msg, worker, context); return; }
         if (type === "util:parseDesc")   { await handleUtilParseDescMessage(msg, worker); return; }
+        if (type === "util:resolveFormat") {
+          const { handleUtilResolveFormatMessage } = await import("./sandbox-handlers-format.ts");
+          await handleUtilResolveFormatMessage(msg, worker);
+          return;
+        }
+        if (type === "util:resolveFormatOr") {
+          const { handleUtilResolveFormatOrMessage } = await import("./sandbox-handlers-format.ts");
+          await handleUtilResolveFormatOrMessage(msg, worker);
+          return;
+        }
         if (type === "trigger:attr")     { await handleTriggerMessage(msg, worker, context); return; }
         if (type.startsWith("events:")) { await handleEventsMessage(msg, worker, context); return; }
 

--- a/src/services/Sandbox/sandbox-handlers-format.ts
+++ b/src/services/Sandbox/sandbox-handlers-format.ts
@@ -1,0 +1,106 @@
+/**
+ * @module sandbox-handlers-format
+ *
+ * Bridges `util:resolveFormat` / `util:resolveFormatOr` messages from sandbox
+ * scripts to the engine-side `resolveFormat` helper.
+ *
+ * Closes the gap from v2.3.0/v2.3.1: those releases exported `resolveFormat`
+ * from `mod.ts` (usable by native commands + external plugin TS code) but did
+ * not plumb it through `u.util.*`, so sandbox scripts (system/scripts/*.ts)
+ * could not consult format-attribute overrides.
+ */
+import type { IDBObj, IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
+import type { FormatSlot } from "../../utils/formatHandlers.ts";
+
+type Msg = Record<string, unknown>;
+
+function respond(worker: Worker, msgId: unknown, data: unknown): void {
+  worker.postMessage({ type: "response", msgId, data });
+}
+
+interface FormatMsg extends Msg {
+  target:     { id: string };
+  slot:       string;
+  defaultArg: string;
+  fallback?:  string;
+  // Identity carried from the sandbox so we can rebuild a thin `u` object
+  // for `resolveFormat` (it reads u.me.id, u.socketId, u.attr.get).
+  actorId?:  string;
+  socketId?: string;
+}
+
+async function buildBoundSDK(actorId: string | undefined, socketId: string | undefined): Promise<IUrsamuSDK> {
+  const { dbojs }  = await import("../Database/index.ts");
+  const { hydrate } = await import("../../utils/evaluateLock.ts");
+  const meRaw = actorId ? await dbojs.queryOne({ id: actorId }) : null;
+  const me    = meRaw
+    ? hydrate(meRaw as unknown as Parameters<typeof hydrate>[0]) as IDBObj
+    : { id: actorId ?? "", name: "", flags: new Set<string>(), state: {}, contents: [] } as unknown as IDBObj;
+
+  // Minimal u stub: resolveFormat only reads u.me.id, u.socketId, u.attr.get.
+  // Plugin handlers receive this same u — they get a real attr accessor.
+  const attrGet = async (id: string, name: string): Promise<string | null> => {
+    const obj = await dbojs.queryOne({ id });
+    if (!obj) return null;
+    const attrs = (obj.data?.attributes as Array<{ name: string; value: string }> | undefined) || [];
+    const found = attrs.find((a) => a.name.toUpperCase() === name.toUpperCase());
+    return found?.value ?? null;
+  };
+
+  return {
+    me,
+    socketId,
+    attr: {
+      get: attrGet,
+      set: () => Promise.resolve(),
+      clear: () => Promise.resolve(false),
+    },
+  } as unknown as IUrsamuSDK;
+}
+
+export async function handleUtilResolveFormatMessage(
+  msg:    Msg,
+  worker: Worker,
+): Promise<void> {
+  const { msgId } = msg;
+  const m = msg as FormatMsg;
+  if (!m.target?.id || !m.slot) { respond(worker, msgId, null); return; }
+
+  const { resolveFormat } = await import("../../utils/resolveFormat.ts");
+  const { dbojs }         = await import("../Database/index.ts");
+  const { hydrate }       = await import("../../utils/evaluateLock.ts");
+
+  const u = await buildBoundSDK(m.actorId, m.socketId);
+  const tarRaw = await dbojs.queryOne({ id: m.target.id });
+  if (!tarRaw) { respond(worker, msgId, null); return; }
+  const target = hydrate(tarRaw as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
+
+  const out = await resolveFormat(u, target, m.slot as FormatSlot, m.defaultArg ?? "");
+  respond(worker, msgId, out);
+}
+
+export async function handleUtilResolveFormatOrMessage(
+  msg:    Msg,
+  worker: Worker,
+): Promise<void> {
+  const { msgId } = msg;
+  const m = msg as FormatMsg;
+  if (!m.target?.id || !m.slot) {
+    respond(worker, msgId, m.fallback ?? "");
+    return;
+  }
+
+  const { resolveFormatOr } = await import("../../utils/resolveFormat.ts");
+  const { dbojs }           = await import("../Database/index.ts");
+  const { hydrate }         = await import("../../utils/evaluateLock.ts");
+
+  const u = await buildBoundSDK(m.actorId, m.socketId);
+  const tarRaw = await dbojs.queryOne({ id: m.target.id });
+  if (!tarRaw) { respond(worker, msgId, m.fallback ?? ""); return; }
+  const target = hydrate(tarRaw as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
+
+  const out = await resolveFormatOr(
+    u, target, m.slot as FormatSlot, m.defaultArg ?? "", m.fallback ?? "",
+  );
+  respond(worker, msgId, out);
+}

--- a/src/services/Sandbox/worker.ts
+++ b/src/services/Sandbox/worker.ts
@@ -291,6 +291,23 @@ self.onmessage = async (e: MessageEvent) => {
         };
         return request<string>("util:parseDesc", { desc, actor: ser(actor), target: ser(target) });
       },
+      resolveFormat: (target: import("../../@types/UrsamuSDK.ts").IDBObj, slot: string, defaultArg: string) =>
+        request<string | null>("util:resolveFormat", {
+          target:     { id: target.id },
+          slot,
+          defaultArg: defaultArg ?? "",
+          actorId:    sdkData.id,
+          socketId:   sdkData.socketId,
+        }),
+      resolveFormatOr: (target: import("../../@types/UrsamuSDK.ts").IDBObj, slot: string, defaultArg: string, fallback: string) =>
+        request<string>("util:resolveFormatOr", {
+          target:     { id: target.id },
+          slot,
+          defaultArg: defaultArg ?? "",
+          fallback:   fallback ?? "",
+          actorId:    sdkData.id,
+          socketId:   sdkData.socketId,
+        }),
       ...sdkData.util
     },
     db: {

--- a/tests/sandbox_resolveFormat.test.ts
+++ b/tests/sandbox_resolveFormat.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Sandbox-side u.util.resolveFormat — closes issue #132.
+ *
+ * Drives the worker bridge end-to-end: seed a target with a softcode attribute,
+ * invoke `u.util.resolveFormat(target, slot, defaultArg)` from inside a sandbox
+ * script via sandboxService.runScript, and assert the rendered softcode result.
+ */
+import { assertEquals } from "@std/assert";
+import { sandboxService } from "../src/services/Sandbox/SandboxService.ts";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { SDKContext } from "../src/services/Sandbox/SDKService.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 20000 };
+
+const ROOM_ID  = "rf_room1";
+const ACTOR_ID = "rf_actor1";
+
+async function cleanup(...ids: string[]) {
+  for (const id of ids) await dbojs.delete({ id }).catch(() => {});
+}
+
+Deno.test("sandbox: u.util.resolveFormat returns softcode-evaluated attr value", { ...OPTS, ...SLOW }, async () => {
+  await dbojs.create({
+    id: ROOM_ID,
+    flags: "room",
+    data: {
+      name: "RFRoom",
+      attributes: [
+        { name: "NAMEFORMAT", value: "<<%0>>", setter: ACTOR_ID, type: "attribute" },
+      ],
+    },
+  });
+  await dbojs.create({
+    id: ACTOR_ID,
+    flags: "player connected",
+    data: { name: "Tester" },
+    location: ROOM_ID,
+  });
+
+  const script = `
+    u.ui = { ...u.ui, layout: () => {}, panel: (o) => o };
+    const room = { id: "${ROOM_ID}", flags: new Set(["room"]), state: {}, contents: [] };
+    const result = await u.util.resolveFormat(room, "NAMEFORMAT", "default-name");
+    return result;
+  `;
+
+  const ctx: SDKContext = {
+    id: ACTOR_ID,
+    state: {},
+    me: { id: ACTOR_ID, name: "Tester", flags: new Set(["player", "connected"]), state: { name: "Tester" }, location: ROOM_ID },
+    here: { id: ROOM_ID, name: "RFRoom", flags: new Set(["room"]), state: {} },
+    cmd: { name: "test", args: [] },
+    socketId: "sock-rf-1",
+  };
+
+  const result = await sandboxService.runScript(script, ctx, SLOW);
+  assertEquals(result, "<<default-name>>");
+
+  await cleanup(ROOM_ID, ACTOR_ID);
+});
+
+Deno.test("sandbox: u.util.resolveFormat returns null when no attr + no handler", { ...OPTS, ...SLOW }, async () => {
+  await dbojs.create({
+    id: ROOM_ID,
+    flags: "room",
+    data: { name: "BareRoom", attributes: [] },
+  });
+  await dbojs.create({
+    id: ACTOR_ID,
+    flags: "player connected",
+    data: { name: "Tester" },
+    location: ROOM_ID,
+  });
+
+  const script = `
+    u.ui = { ...u.ui, layout: () => {}, panel: (o) => o };
+    const room = { id: "${ROOM_ID}", flags: new Set(["room"]), state: {}, contents: [] };
+    const result = await u.util.resolveFormat(room, "NAMEFORMAT", "default");
+    return result === null ? "NULL" : result;
+  `;
+
+  const ctx: SDKContext = {
+    id: ACTOR_ID,
+    state: {},
+    me: { id: ACTOR_ID, name: "Tester", flags: new Set(["player", "connected"]), state: {}, location: ROOM_ID },
+    here: { id: ROOM_ID, name: "BareRoom", flags: new Set(["room"]), state: {} },
+    cmd: { name: "test", args: [] },
+    socketId: "sock-rf-2",
+  };
+
+  const result = await sandboxService.runScript(script, ctx, SLOW);
+  assertEquals(result, "NULL");
+
+  await cleanup(ROOM_ID, ACTOR_ID);
+});
+
+Deno.test("sandbox: u.util.resolveFormatOr returns fallback when null", { ...OPTS, ...SLOW }, async () => {
+  await dbojs.create({
+    id: ROOM_ID,
+    flags: "room",
+    data: { name: "BareRoom", attributes: [] },
+  });
+  await dbojs.create({
+    id: ACTOR_ID,
+    flags: "player connected",
+    data: { name: "Tester" },
+    location: ROOM_ID,
+  });
+
+  const script = `
+    u.ui = { ...u.ui, layout: () => {}, panel: (o) => o };
+    const room = { id: "${ROOM_ID}", flags: new Set(["room"]), state: {}, contents: [] };
+    return await u.util.resolveFormatOr(room, "NAMEFORMAT", "default", "FALLBACK_USED");
+  `;
+
+  const ctx: SDKContext = {
+    id: ACTOR_ID,
+    state: {},
+    me: { id: ACTOR_ID, name: "Tester", flags: new Set(["player", "connected"]), state: {}, location: ROOM_ID },
+    here: { id: ROOM_ID, name: "BareRoom", flags: new Set(["room"]), state: {} },
+    cmd: { name: "test", args: [] },
+    socketId: "sock-rf-3",
+  };
+
+  const result = await sandboxService.runScript(script, ctx, SLOW);
+  assertEquals(result, "FALLBACK_USED");
+
+  await cleanup(ROOM_ID, ACTOR_ID);
+  await DBO.close();
+});


### PR DESCRIPTION
Closes #132.

## Gap
v2.3.0 added `@nameformat`/`@whoformat`/`@psformat` to engine-bundled `look`/`who`/`@ps` and exported `resolveFormat` from `mod.ts`. v2.3.1 exposed `softcodeService`. Neither plumbed the helper through `u.util.*`, so sandbox scripts (`system/scripts/*.ts`) and any code routed through the worker bridge couldn't consult format-attribute overrides.

## Fix

Two new optional methods on `IUrsamuSDK.util`:

\`\`\`ts
util.resolveFormat(target, slot, defaultArg): Promise<string | null>
util.resolveFormatOr(target, slot, defaultArg, fallback): Promise<string>
\`\`\`

Wired in three places:

| Layer | File | Role |
|---|---|---|
| Type | `src/@types/UrsamuSDK.ts` | Interface additions (optional members, backwards-compatible) |
| Native SDK | `src/services/SDK/index.ts` | Closes over the existing `u` so plugin handlers see the original enactor context |
| Sandbox bridge | `src/services/Sandbox/worker.ts` | Posts `util:resolveFormat[Or]` requests with `actorId` + `socketId` so the main thread can rebuild a thin `u` for handlers |
| Sandbox handler | `src/services/Sandbox/sandbox-handlers-format.ts` (new) | Reconstructs `u` from `dbojs`, delegates to the shared `resolveFormat` |
| Dispatch | `src/services/Sandbox/SandboxService.ts` | Routes the two new message types via dynamic import |

## Tests

\`tests/sandbox_resolveFormat.test.ts\` (+3 tests) drives the worker bridge end-to-end:
- softcode attribute set on target → `<<%0>>` evaluates and returns
- no attr + no handler → `null`
- `resolveFormatOr` returns the fallback when null

## Pre-commit gates
- [x] \`deno check --unstable-kv mod.ts\` — clean
- [x] \`deno lint\` — clean (352 files)
- [x] \`deno test tests/\` — **1119 passed / 0 failed**
- [x] \`deno test tests/security_*.test.ts\` — 141 passed / 0 failed

## Version
\`2.3.1\` → \`2.3.2\` (patch — fixes a gap shipped in v2.3.0).