### PR TITLE
feat: v2.3.3 — promote resolveGlobalFormat to src/utils + sandbox bridge

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -89,6 +89,9 @@ export { header, divider, footer } from "./src/utils/format.ts";
 // resolveFormat — shared helper for commands that want format-attr / plugin-handler /
 // built-in default rendering (used by `look`; reusable by `who`, `@ps`, external plugins).
 export { resolveFormat, resolveFormatOr } from "./src/utils/resolveFormat.ts";
+// resolveGlobalFormat — two-tier lookup (#0 → enactor) for global-list commands
+// (WHO, @ps, +event/list, +mail, +bb, etc.) that aren't bound to a specific target.
+export { resolveGlobalFormat, resolveGlobalFormatOr } from "./src/utils/resolveGlobalFormat.ts";
 // Plugin lifecycle management — available to external plugins that need to read their config
 export { PluginConfigManager } from "./src/services/Config/plugin.ts";
 export type { IMiddlewareFunction } from "./src/@types/IMiddlewareFunction.ts";

--- a/src/@types/UrsamuSDK.ts
+++ b/src/@types/UrsamuSDK.ts
@@ -61,6 +61,15 @@ export interface IUrsamuSDK {
     resolveFormat?(target: IDBObj, slot: string, defaultArg: string): Promise<string | null>;
     /** As `resolveFormat`, but returns `fallback` when the resolver yields null. */
     resolveFormatOr?(target: IDBObj, slot: string, defaultArg: string, fallback: string): Promise<string>;
+    /**
+     * Two-tier lookup for global-list format slots (WHO, @ps, +event/list,
+     * @mail, +bb, etc.). Consults `#0` (game-wide skin) first, falls back to
+     * the enactor (`u.me`) for per-player skin, then null. `#0` is only
+     * consulted if it exists in the DB.
+     */
+    resolveGlobalFormat?(slot: string, defaultArg: string): Promise<string | null>;
+    /** As `resolveGlobalFormat`, but returns `fallback` when the resolver yields null. */
+    resolveGlobalFormatOr?(slot: string, defaultArg: string, fallback: string): Promise<string>;
     [key: string]: unknown;
   };
   db: {

--- a/src/commands/ps.ts
+++ b/src/commands/ps.ts
@@ -3,29 +3,8 @@ import { isStaff } from "../utils/index.ts";
 import { queue } from "../services/Queue/index.ts";
 import { dbojs } from "../services/Database/index.ts";
 import { send } from "../services/broadcast/index.ts";
-import { resolveFormat } from "../utils/resolveFormat.ts";
-import { hydrate } from "../utils/evaluateLock.ts";
+import { resolveGlobalFormat } from "../utils/resolveGlobalFormat.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
-import type { FormatSlot } from "../utils/formatHandlers.ts";
-
-/**
- * Two-tier format lookup: check `#0` (root) for game-wide skin first, then
- * the enactor (`u.me`) for per-player skin. Returns null if neither yields
- * a non-null override.
- */
-async function resolveGlobalFormat(
-  u: IUrsamuSDK,
-  slot: FormatSlot,
-  defaultArg: string,
-): Promise<string | null> {
-  const root = await dbojs.queryOne({ id: "0" });
-  if (root) {
-    const rootObj = hydrate(root as unknown as Parameters<typeof hydrate>[0]);
-    const out = await resolveFormat(u, rootObj, slot, defaultArg);
-    if (out != null) return out;
-  }
-  return await resolveFormat(u, u.me, slot, defaultArg);
-}
 
 export async function execPs(u: IUrsamuSDK): Promise<void> {
       const sw  = (u.cmd.args[0] ?? "").toLowerCase().trim();
@@ -147,4 +126,3 @@ Examples:
     exec: execPs,
   });
 
-export { resolveGlobalFormat };

--- a/src/commands/social.ts
+++ b/src/commands/social.ts
@@ -1,33 +1,6 @@
 import { addCmd } from "../services/commands/cmdParser.ts";
 import type { IUrsamuSDK, IDBObj } from "../@types/UrsamuSDK.ts";
-import { resolveFormat, type FormatSlot } from "../utils/resolveFormat.ts";
-import { dbojs } from "../services/Database/database.ts";
-import { hydrate } from "../utils/evaluateLock.ts";
-
-/**
- * Two-tier lookup for global-list format slots (e.g. WHO):
- *   1. attr on #0 (game-wide skin) — wins if set.
- *   2. attr on the enactor (per-player skin).
- *   3. null → caller renders built-in default.
- *
- * Mirrors TinyMUX/PennMUSH precedent for WHO-style commands. Kept inline
- * here until a third caller appears; then promote to src/utils/.
- */
-async function resolveGlobalFormat(
-  u: IUrsamuSDK,
-  slot: FormatSlot,
-  defaultArg: string,
-): Promise<string | null> {
-  // Only consult #0 if it actually exists — otherwise plugin handlers would
-  // be invoked with a phantom target.id="0" (latent bug, M1 in TDD audit).
-  const root = await dbojs.queryOne({ id: "0" });
-  if (root) {
-    const rootObj = hydrate(root as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
-    const onRoot = await resolveFormat(u, rootObj, slot, defaultArg);
-    if (onRoot != null) return onRoot;
-  }
-  return await resolveFormat(u, u.me, slot, defaultArg);
-}
+import { resolveGlobalFormat } from "../utils/resolveGlobalFormat.ts";
 
 export async function execWho(u: IUrsamuSDK): Promise<void> {
   const players = (await u.db.search({ flags: /connected/i }))

--- a/src/services/SDK/index.ts
+++ b/src/services/SDK/index.ts
@@ -94,6 +94,14 @@ function buildSDKFromContext(ctx: GameContext): IUrsamuSDK {
         const { resolveFormatOr } = await import("../../utils/resolveFormat.ts");
         return await resolveFormatOr(u, target, slot as Parameters<typeof resolveFormatOr>[2], defaultArg, fallback);
       },
+      resolveGlobalFormat: async (slot: string, defaultArg: string): Promise<string | null> => {
+        const { resolveGlobalFormat } = await import("../../utils/resolveGlobalFormat.ts");
+        return await resolveGlobalFormat(u, slot as Parameters<typeof resolveGlobalFormat>[1], defaultArg);
+      },
+      resolveGlobalFormatOr: async (slot: string, defaultArg: string, fallback: string): Promise<string> => {
+        const { resolveGlobalFormatOr } = await import("../../utils/resolveGlobalFormat.ts");
+        return await resolveGlobalFormatOr(u, slot as Parameters<typeof resolveGlobalFormatOr>[1], defaultArg, fallback);
+      },
     },
 
     db: {

--- a/src/services/Sandbox/SandboxService.ts
+++ b/src/services/Sandbox/SandboxService.ts
@@ -102,6 +102,16 @@ class LocalSandbox {
           await handleUtilResolveFormatOrMessage(msg, worker);
           return;
         }
+        if (type === "util:resolveGlobalFormat") {
+          const { handleUtilResolveGlobalFormatMessage } = await import("./sandbox-handlers-format.ts");
+          await handleUtilResolveGlobalFormatMessage(msg, worker);
+          return;
+        }
+        if (type === "util:resolveGlobalFormatOr") {
+          const { handleUtilResolveGlobalFormatOrMessage } = await import("./sandbox-handlers-format.ts");
+          await handleUtilResolveGlobalFormatOrMessage(msg, worker);
+          return;
+        }
         if (type === "trigger:attr")     { await handleTriggerMessage(msg, worker, context); return; }
         if (type.startsWith("events:")) { await handleEventsMessage(msg, worker, context); return; }
 

--- a/src/services/Sandbox/sandbox-handlers-format.ts
+++ b/src/services/Sandbox/sandbox-handlers-format.ts
@@ -104,3 +104,33 @@ export async function handleUtilResolveFormatOrMessage(
   );
   respond(worker, msgId, out);
 }
+
+export async function handleUtilResolveGlobalFormatMessage(
+  msg:    Msg,
+  worker: Worker,
+): Promise<void> {
+  const { msgId } = msg;
+  const m = msg as FormatMsg;
+  if (!m.slot) { respond(worker, msgId, null); return; }
+
+  const { resolveGlobalFormat } = await import("../../utils/resolveGlobalFormat.ts");
+  const u = await buildBoundSDK(m.actorId, m.socketId);
+  const out = await resolveGlobalFormat(u, m.slot as FormatSlot, m.defaultArg ?? "");
+  respond(worker, msgId, out);
+}
+
+export async function handleUtilResolveGlobalFormatOrMessage(
+  msg:    Msg,
+  worker: Worker,
+): Promise<void> {
+  const { msgId } = msg;
+  const m = msg as FormatMsg;
+  if (!m.slot) { respond(worker, msgId, m.fallback ?? ""); return; }
+
+  const { resolveGlobalFormatOr } = await import("../../utils/resolveGlobalFormat.ts");
+  const u = await buildBoundSDK(m.actorId, m.socketId);
+  const out = await resolveGlobalFormatOr(
+    u, m.slot as FormatSlot, m.defaultArg ?? "", m.fallback ?? "",
+  );
+  respond(worker, msgId, out);
+}

--- a/src/services/Sandbox/worker.ts
+++ b/src/services/Sandbox/worker.ts
@@ -308,6 +308,21 @@ self.onmessage = async (e: MessageEvent) => {
           actorId:    sdkData.id,
           socketId:   sdkData.socketId,
         }),
+      resolveGlobalFormat: (slot: string, defaultArg: string) =>
+        request<string | null>("util:resolveGlobalFormat", {
+          slot,
+          defaultArg: defaultArg ?? "",
+          actorId:    sdkData.id,
+          socketId:   sdkData.socketId,
+        }),
+      resolveGlobalFormatOr: (slot: string, defaultArg: string, fallback: string) =>
+        request<string>("util:resolveGlobalFormatOr", {
+          slot,
+          defaultArg: defaultArg ?? "",
+          fallback:   fallback ?? "",
+          actorId:    sdkData.id,
+          socketId:   sdkData.socketId,
+        }),
       ...sdkData.util
     },
     db: {

--- a/src/utils/resolveGlobalFormat.ts
+++ b/src/utils/resolveGlobalFormat.ts
@@ -1,0 +1,43 @@
+/**
+ * Two-tier format-attribute lookup for "global-list" commands (WHO, @ps,
+ * @event/list, +mail, etc.) that don't bind to a specific target object.
+ *
+ *   1. attr on #0  — game-wide skin. Skipped if #0 doesn't exist (avoids
+ *                    phantom-target plugin-handler invocations; see M1 in
+ *                    the v2.3.0 TDD audit).
+ *   2. attr on the enactor (`u.me`) — per-player skin.
+ *   3. null → caller renders built-in default.
+ *
+ * Plugins consuming this helper from JSR see the same priority chain as
+ * the engine-bundled `who` / `@ps` commands. See ursamu/src/commands/social.ts
+ * and ursamu/src/commands/ps.ts for the original callers.
+ */
+import type { IDBObj, IUrsamuSDK } from "../@types/UrsamuSDK.ts";
+import { dbojs } from "../services/Database/database.ts";
+import { hydrate } from "./evaluateLock.ts";
+import { resolveFormat } from "./resolveFormat.ts";
+import type { FormatSlot } from "./formatHandlers.ts";
+
+export async function resolveGlobalFormat(
+  u:          IUrsamuSDK,
+  slot:       FormatSlot,
+  defaultArg: string,
+): Promise<string | null> {
+  const root = await dbojs.queryOne({ id: "0" });
+  if (root) {
+    const rootObj = hydrate(root as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
+    const onRoot  = await resolveFormat(u, rootObj, slot, defaultArg);
+    if (onRoot != null) return onRoot;
+  }
+  return await resolveFormat(u, u.me, slot, defaultArg);
+}
+
+/** As `resolveGlobalFormat`, but returns `fallback` when the resolver yields null. */
+export async function resolveGlobalFormatOr(
+  u:          IUrsamuSDK,
+  slot:       FormatSlot,
+  defaultArg: string,
+  fallback:   string,
+): Promise<string> {
+  return (await resolveGlobalFormat(u, slot, defaultArg)) ?? fallback;
+}

--- a/tests/resolveGlobalFormat.test.ts
+++ b/tests/resolveGlobalFormat.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for `resolveGlobalFormat` — promoted from inline copies in social.ts
+ * and ps.ts. Covers two-tier ordering (#0 → enactor → null), phantom-#0
+ * guard, and the sandbox bridge.
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import {
+  resolveGlobalFormat,
+  resolveGlobalFormatOr,
+} from "../src/utils/resolveGlobalFormat.ts";
+import {
+  registerFormatHandler,
+  unregisterFormatHandler,
+  _clearFormatHandlers,
+  type FormatHandler,
+} from "../src/utils/formatHandlers.ts";
+import { sandboxService } from "../src/services/Sandbox/SandboxService.ts";
+import type { SDKContext } from "../src/services/Sandbox/SDKService.ts";
+import type { IUrsamuSDK, IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 20000 };
+
+const ROOT  = "0";
+const ACTOR = "rgf_actor1";
+
+function mockU(): IUrsamuSDK {
+  return {
+    me: {
+      id: ACTOR, name: "Alice",
+      flags: new Set(["player", "connected"]),
+      state: { name: "Alice" }, location: ROOT, contents: [],
+    } as unknown as IDBObj,
+    socketId: "s-rgf",
+    cmd: { name: "test", args: [], switches: [] },
+    send: () => {},
+    canEdit: () => Promise.resolve(true),
+    attr: {
+      get: () => Promise.resolve(null),  // force plugin-handler path
+      set: () => Promise.resolve(),
+      clear: () => Promise.resolve(false),
+    },
+    util: { displayName: (o: IDBObj) => o.name ?? "?" },
+  } as unknown as IUrsamuSDK;
+}
+
+async function setup() {
+  _clearFormatHandlers();
+  await dbojs.delete({ id: ROOT }).catch(() => {});
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+}
+
+Deno.test("resolveGlobalFormat: #0 wins when both targets have handlers", OPTS, async () => {
+  await setup();
+  await dbojs.create({ id: ROOT,  flags: "room",   data: { name: "Root" } });
+  await dbojs.create({ id: ACTOR, flags: "player connected", data: { name: "Alice" } });
+  const seen: string[] = [];
+  const handler: FormatHandler = (_u, target) => { seen.push(target.id); return target.id === ROOT ? "ROOT" : "ACTOR"; };
+  registerFormatHandler("WHOFORMAT", handler);
+  try {
+    const out = await resolveGlobalFormat(mockU(), "WHOFORMAT", "default");
+    assertEquals(out, "ROOT");
+    assertEquals(seen, [ROOT]);  // enactor never consulted
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", handler);
+    await setup();
+  }
+});
+
+Deno.test("resolveGlobalFormat: enactor consulted when #0 returns null", OPTS, async () => {
+  await setup();
+  await dbojs.create({ id: ROOT,  flags: "room",   data: { name: "Root" } });
+  await dbojs.create({ id: ACTOR, flags: "player connected", data: { name: "Alice" } });
+  const seen: string[] = [];
+  const handler: FormatHandler = (_u, target) => { seen.push(target.id); return target.id === ACTOR ? "FROM_ACTOR" : null; };
+  registerFormatHandler("WHOFORMAT", handler);
+  try {
+    const out = await resolveGlobalFormat(mockU(), "WHOFORMAT", "default");
+    assertEquals(out, "FROM_ACTOR");
+    assertEquals(seen, [ROOT, ACTOR]);
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", handler);
+    await setup();
+  }
+});
+
+Deno.test("resolveGlobalFormat: skips #0 entirely when #0 doesn't exist (M1 guard)", OPTS, async () => {
+  await setup();  // #0 absent
+  await dbojs.create({ id: ACTOR, flags: "player connected", data: { name: "Alice" } });
+  const seen: string[] = [];
+  const handler: FormatHandler = (_u, target) => { seen.push(target.id); return null; };
+  registerFormatHandler("WHOFORMAT", handler);
+  try {
+    const out = await resolveGlobalFormat(mockU(), "WHOFORMAT", "default");
+    assertEquals(out, null);
+    assertEquals(seen, [ACTOR]);  // never invoked with phantom "0"
+  } finally {
+    unregisterFormatHandler("WHOFORMAT", handler);
+    await setup();
+  }
+});
+
+Deno.test("resolveGlobalFormatOr: returns fallback when resolver yields null", OPTS, async () => {
+  await setup();
+  await dbojs.create({ id: ACTOR, flags: "player connected", data: { name: "Alice" } });
+  const out = await resolveGlobalFormatOr(mockU(), "WHOFORMAT", "default", "FALLBACK");
+  assertEquals(out, "FALLBACK");
+  await setup();
+});
+
+Deno.test("sandbox: u.util.resolveGlobalFormat bridge works end-to-end", { ...OPTS, ...SLOW }, async () => {
+  await setup();
+  await dbojs.create({
+    id: ROOT,
+    flags: "room",
+    data: {
+      name: "Root",
+      attributes: [
+        { name: "WHOFORMAT", value: "<<%0>>", setter: ACTOR, type: "attribute" },
+      ],
+    },
+  });
+  await dbojs.create({ id: ACTOR, flags: "player connected", data: { name: "Alice" } });
+
+  const script = `
+    u.ui = { ...u.ui, layout: () => {}, panel: (o) => o };
+    return await u.util.resolveGlobalFormat("WHOFORMAT", "default-block");
+  `;
+  const ctx: SDKContext = {
+    id: ACTOR,
+    state: {},
+    me: { id: ACTOR, name: "Alice", flags: new Set(["player", "connected"]), state: { name: "Alice" }, location: ROOT },
+    here: { id: ROOT, name: "Root", flags: new Set(["room"]), state: {} },
+    cmd: { name: "test", args: [] },
+    socketId: "sock-rgf",
+  };
+  const result = await sandboxService.runScript(script, ctx, SLOW);
+  assertEquals(result, "<<default-block>>");
+  await setup();
+  await DBO.close();
+});


### PR DESCRIPTION
## Why
The two-tier \`#0 → enactor\` helper landed inline in two engine commands (\`social.ts\` for WHO, \`ps.ts\` for \`@ps\` — that one even re-exported it) and was copy-pasted into all five external plugins that needed a global-list format slot (mail, events, bbs, channel, wiki). The "kept inline until a third caller appears; then promote" comment is now stale — we're at 7+ callers.

## What

| Layer | Change |
|---|---|
| New | \`src/utils/resolveGlobalFormat.ts\` — single source of truth. Skips \`#0\` entirely when the DB has no \`#0\` (M1 guard from the v2.3.0 TDD audit). |
| \`mod.ts\` | Exports \`resolveGlobalFormat\` and \`resolveGlobalFormatOr\` for external plugins. Drops 5 plugin-local copies (follow-up PRs in mail/events/bbs/channel/wiki). |
| \`IUrsamuSDK.util\` | Adds \`resolveGlobalFormat(slot, defaultArg)\` and \`resolveGlobalFormatOr(slot, defaultArg, fallback)\` — sandbox parity via the worker bridge (same shape as v2.3.2's \`u.util.resolveFormat\`). |
| Sandbox bridge | Two new message types: \`util:resolveGlobalFormat\` / \`util:resolveGlobalFormatOr\`. Handlers in the existing \`sandbox-handlers-format.ts\`. |
| \`src/commands/social.ts\` | Drops the inline copy; imports from \`utils/\`. |
| \`src/commands/ps.ts\` | Drops the inline copy + its \`export { resolveGlobalFormat }\` (no callers). |

## Tests

\`tests/resolveGlobalFormat.test.ts\` (+5):
- \`#0\` wins when both targets have handlers (enactor never invoked)
- Enactor consulted when \`#0\` returns null
- Skips \`#0\` entirely when \`#0\` doesn't exist (M1 guard)
- \`resolveGlobalFormatOr\` returns fallback when null
- Sandbox \`u.util.resolveGlobalFormat\` bridge works end-to-end

## Gates
- [x] \`deno check --unstable-kv mod.ts\` — clean
- [x] \`deno lint\` — clean (354 files)
- [x] \`deno test tests/\` — **1124 passed / 0 failed** (+5)
- [x] \`deno test tests/security_*.test.ts\` — 141 passed / 0 failed

## Version
\`2.3.2\` → \`2.3.3\` (patch — internal refactor + sandbox bridge addition, no breaking changes).

## Follow-up
Each of mail/events/bbs/channel/wiki plugins can drop its local \`resolveGlobalFormat\` copy in a separate PR once consumers pin \`^2.3.3\`.