### PR TITLE
feat: v2.3.4 — widen FormatSlot to accept arbitrary uppercase strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,13 @@ format-attr authors most often (`NAMEFORMAT`, `DESCFORMAT`, row templates) —
 write `<<%0>>` or `ROW(%0)` rather than `[%0]` when the brackets must appear
 in output.
 
+**Plugin slot names**: `FormatSlot` is an open union — plugin authors can pass
+any `"UPPERCASE"` slot name (e.g. `"MAILFORMAT"`, `"BBROWFORMAT"`,
+`"CHANNELLISTFORMAT"`) directly to `registerFormatHandler` / `resolveFormat` /
+`resolveGlobalFormat` without `as FormatSlot` casts. The eight engine-known
+literals (NAMEFORMAT, DESCFORMAT, CONFORMAT, EXITFORMAT, WHOFORMAT,
+WHOROWFORMAT, PSFORMAT, PSROWFORMAT) still get IDE autocomplete.
+
 ---
 
 ## Help file standards (non-negotiable)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/src/services/SDK/index.ts
+++ b/src/services/SDK/index.ts
@@ -88,19 +88,19 @@ function buildSDKFromContext(ctx: GameContext): IUrsamuSDK {
       // u is captured by closure — plugin handlers see the same SDK instance.
       resolveFormat: async (target: IDBObj, slot: string, defaultArg: string): Promise<string | null> => {
         const { resolveFormat } = await import("../../utils/resolveFormat.ts");
-        return await resolveFormat(u, target, slot as Parameters<typeof resolveFormat>[2], defaultArg);
+        return await resolveFormat(u, target, slot, defaultArg);
       },
       resolveFormatOr: async (target: IDBObj, slot: string, defaultArg: string, fallback: string): Promise<string> => {
         const { resolveFormatOr } = await import("../../utils/resolveFormat.ts");
-        return await resolveFormatOr(u, target, slot as Parameters<typeof resolveFormatOr>[2], defaultArg, fallback);
+        return await resolveFormatOr(u, target, slot, defaultArg, fallback);
       },
       resolveGlobalFormat: async (slot: string, defaultArg: string): Promise<string | null> => {
         const { resolveGlobalFormat } = await import("../../utils/resolveGlobalFormat.ts");
-        return await resolveGlobalFormat(u, slot as Parameters<typeof resolveGlobalFormat>[1], defaultArg);
+        return await resolveGlobalFormat(u, slot, defaultArg);
       },
       resolveGlobalFormatOr: async (slot: string, defaultArg: string, fallback: string): Promise<string> => {
         const { resolveGlobalFormatOr } = await import("../../utils/resolveGlobalFormat.ts");
-        return await resolveGlobalFormatOr(u, slot as Parameters<typeof resolveGlobalFormatOr>[1], defaultArg, fallback);
+        return await resolveGlobalFormatOr(u, slot, defaultArg, fallback);
       },
     },
 

--- a/src/services/Sandbox/sandbox-handlers-format.ts
+++ b/src/services/Sandbox/sandbox-handlers-format.ts
@@ -10,7 +10,6 @@
  * could not consult format-attribute overrides.
  */
 import type { IDBObj, IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
-import type { FormatSlot } from "../../utils/formatHandlers.ts";
 
 type Msg = Record<string, unknown>;
 
@@ -75,7 +74,7 @@ export async function handleUtilResolveFormatMessage(
   if (!tarRaw) { respond(worker, msgId, null); return; }
   const target = hydrate(tarRaw as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
 
-  const out = await resolveFormat(u, target, m.slot as FormatSlot, m.defaultArg ?? "");
+  const out = await resolveFormat(u, target, m.slot, m.defaultArg ?? "");
   respond(worker, msgId, out);
 }
 
@@ -100,7 +99,7 @@ export async function handleUtilResolveFormatOrMessage(
   const target = hydrate(tarRaw as unknown as Parameters<typeof hydrate>[0]) as IDBObj;
 
   const out = await resolveFormatOr(
-    u, target, m.slot as FormatSlot, m.defaultArg ?? "", m.fallback ?? "",
+    u, target, m.slot, m.defaultArg ?? "", m.fallback ?? "",
   );
   respond(worker, msgId, out);
 }
@@ -115,7 +114,7 @@ export async function handleUtilResolveGlobalFormatMessage(
 
   const { resolveGlobalFormat } = await import("../../utils/resolveGlobalFormat.ts");
   const u = await buildBoundSDK(m.actorId, m.socketId);
-  const out = await resolveGlobalFormat(u, m.slot as FormatSlot, m.defaultArg ?? "");
+  const out = await resolveGlobalFormat(u, m.slot, m.defaultArg ?? "");
   respond(worker, msgId, out);
 }
 
@@ -130,7 +129,7 @@ export async function handleUtilResolveGlobalFormatOrMessage(
   const { resolveGlobalFormatOr } = await import("../../utils/resolveGlobalFormat.ts");
   const u = await buildBoundSDK(m.actorId, m.socketId);
   const out = await resolveGlobalFormatOr(
-    u, m.slot as FormatSlot, m.defaultArg ?? "", m.fallback ?? "",
+    u, m.slot, m.defaultArg ?? "", m.fallback ?? "",
   );
   respond(worker, msgId, out);
 }

--- a/src/utils/formatHandlers.ts
+++ b/src/utils/formatHandlers.ts
@@ -19,7 +19,14 @@ export type FormatSlot =
   | "EXITFORMAT"
   | "WHOFORMAT"
   | "WHOROWFORMAT"
-  | "PSFORMAT" | "PSROWFORMAT";
+  | "PSFORMAT"
+  | "PSROWFORMAT"
+  // Open the union so plugin authors can use their own UPPERCASE slot names
+  // (MAILFORMAT, BBROWFORMAT, CHANNELLISTFORMAT, ...) without casting. The
+  // `& {}` is intentional — it keeps IDE autocomplete on the known literals
+  // above; using bare `string` would collapse the union and lose the hints.
+  // deno-lint-ignore ban-types
+  | (string & {});
 
 /**
  * Plugin handler signature.


### PR DESCRIPTION
## Summary
- Widens `FormatSlot` to an open union (`... | (string & {})`) so plugin authors can pass any UPPERCASE slot name without `as FormatSlot` casts.
- Known literals (NAMEFORMAT/DESCFORMAT/CONFORMAT/EXITFORMAT/WHOFORMAT/WHOROWFORMAT/PSFORMAT/PSROWFORMAT) still get IDE autocomplete.
- Drops unnecessary casts in `src/services/SDK/index.ts` (4) and `src/services/Sandbox/sandbox-handlers-format.ts` (4 + unused import).
- Bumps version to 2.3.4 and updates CLAUDE.md.

## Test plan
- [x] deno check --unstable-kv mod.ts
- [x] deno lint
- [x] deno test tests/ — 1124 passed, 0 failed
- [x] deno test tests/security_*.test.ts — 141 passed, 0 failed
- [x] deno publish --dry-run — success