### PR TITLE
feat: v2.4.0 — registerFormatTemplate, supervised game scaffold, telnet IAC byte-strip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config/*.json
 
 # Fresh build directory
 _fresh/
+games/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,6 +467,7 @@ function mockU(opts: {
 - No Claude/AI attribution in PR titles, commit messages, or code comments.
 - Use squash-merge for feature PRs.
 - Tag versions after squash-merge: `git tag v<version> && git push --tags`.
+- **Before every commit, update `README.md` and `docs/` to match the current code.** Touched a public API, command, config field, script, or scaffold output? Update the corresponding section before staging. A commit that lands behavior changes with stale docs is incomplete.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![ursamu header](https://raw.githubusercontent.com/ursamu/ursamu/main/ursamu_github_banner.png)
 
 [![JSR](https://jsr.io/badges/@ursamu/ursamu)](https://jsr.io/@ursamu/ursamu)
-[![Version](https://img.shields.io/badge/version-2.0.0-blue)](https://github.com/UrsaMU/ursamu/releases)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue)](https://github.com/UrsaMU/ursamu/releases)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Deno](https://img.shields.io/badge/deno-2.x-black)](https://deno.land)
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",
@@ -92,6 +92,6 @@
   "exclude": ["docs/_site", "config", ".claude"],
   "lint": {
     "rules": { "tags": ["recommended"] },
-    "exclude": ["src/services/Softcode/parser.cjs"]
+    "exclude": ["src/services/Softcode/parser.cjs", "legends"]
   }
 }

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -676,3 +676,77 @@ import { dbojs } from "jsr:@ursamu/ursamu";
 const players = await dbojs.queryAll((o) => o.flags.has("player"));
 const room    = await dbojs.queryOne((o) => o.id === "1");
 ```
+
+---
+
+## Format handlers
+
+Pluggable display formatters for engine and plugin output. Used by `look`,
+`who`, `+ps`, `+mail`, and anywhere that resolves a `*FORMAT` slot. Resolution
+priority is fixed: per-object softcode attribute → registered TS handler →
+registered MUSH-softcode template → built-in default.
+
+```typescript
+import {
+  registerFormatHandler,
+  registerFormatTemplate,
+  unregisterFormatHandler,
+} from "jsr:@ursamu/ursamu";
+import type { FormatHandler, FormatSlot } from "jsr:@ursamu/ursamu";
+```
+
+### `registerFormatHandler(slot, fn)`
+
+Install a TypeScript handler for a `FormatSlot`. Slot is an open `UPPERCASE`
+string union — the eight engine-known literals (`NAMEFORMAT`, `DESCFORMAT`,
+`CONFORMAT`, `EXITFORMAT`, `WHOFORMAT`, `WHOROWFORMAT`, `PSFORMAT`,
+`PSROWFORMAT`) get IDE autocomplete; plugin-defined slots like `"MAILFORMAT"`
+are accepted without casts. Return a string to render, or `null` to fall
+through to the next handler / built-in default. The first non-null handler
+wins.
+
+```typescript
+registerFormatHandler("NAMEFORMAT", (u, target, defaultName) => {
+  if (!target.flags.has("room")) return null;
+  return `%ch%cy[${defaultName}]%cn\n`;
+});
+```
+
+### `registerFormatTemplate(slot, mushSource)`
+
+Shortcut for plugins that want to install a MUSH-softcode template as a
+handler. The engine runs `mushSource` whenever the slot resolves; `%0` is
+bound to the default rendering and the resolver's target is the executor —
+so `name(%0)`, `get(%0/<attr>)`, and friends work directly. Returns the
+underlying handler so callers can pass it to `unregisterFormatHandler` from
+plugin `remove()`.
+
+```typescript
+const handler = registerFormatTemplate(
+  "NAMEFORMAT",
+  "[center(strcat(%cy[ ,%0, ]%cn),78,=)]",
+);
+// later, in plugin remove():
+unregisterFormatHandler("NAMEFORMAT", handler);
+```
+
+### `unregisterFormatHandler(slot, fn)`
+
+Remove a previously registered handler. Same reference identity that
+`registerFormatHandler` / `registerFormatTemplate` returned at registration.
+
+### Type: `FormatHandler`
+
+```typescript
+type FormatHandler = (
+  u:          IUrsamuSDK,
+  target:     IDBObj,
+  defaultArg: string,
+) => Promise<string | null> | string | null;
+```
+
+### Type: `FormatSlot`
+
+Open `UPPERCASE` string union — see `registerFormatHandler` above. Use one
+of the engine literals for autocomplete or any custom slot your plugin
+defines.

--- a/mod.ts
+++ b/mod.ts
@@ -79,6 +79,7 @@ export { evaluateLock, validateLock } from "./src/utils/evaluateLock.ts";
 // fallbacks (priority: softcode attr > plugin handler > built-in default)
 export {
   registerFormatHandler,
+  registerFormatTemplate,
   unregisterFormatHandler,
 } from "./src/utils/formatHandlers.ts";
 export type { FormatHandler, FormatSlot } from "./src/utils/formatHandlers.ts";

--- a/src/cli/create-project.ts
+++ b/src/cli/create-project.ts
@@ -10,6 +10,11 @@ import {
   gameMainTs,
   gameTelnetTs,
   gameRunSh,
+  gameDaemonSh,
+  gameStopSh,
+  gameRestartSh,
+  gameStatusSh,
+  gameEnvFile,
   gameConnectTxt,
   gameWikiHome,
   gameGitignore,
@@ -101,92 +106,95 @@ export async function scaffoldProject(
     console.log(`Created directory: ${dir}`);
   }
 
-  if (!isLocal) {
-    await Deno.writeTextFile(
-      join(targetDir, "src", "plugins", "plugins.manifest.json"),
-      JSON.stringify(DEFAULT_PLUGINS_MANIFEST, null, 2),
-    );
-    console.log("Created src/plugins/plugins.manifest.json");
-  }
+  await Deno.writeTextFile(
+    join(targetDir, "src", "plugins", "plugins.manifest.json"),
+    JSON.stringify(DEFAULT_PLUGINS_MANIFEST, null, 2),
+  );
+  console.log("Created src/plugins/plugins.manifest.json");
 
   await Deno.writeTextFile(join(targetDir, "wiki", "home.md"), gameWikiHome(name));
   console.log("Created wiki/home.md");
 
-  if (!isLocal) await copySystemScripts(targetDir);
+  await copySystemScripts(targetDir);
 
   await Deno.writeTextFile(join(targetDir, "src", "main.ts"),   gameMainTs(name));
   console.log("Created src/main.ts");
   await Deno.writeTextFile(join(targetDir, "src", "telnet.ts"), gameTelnetTs());
   console.log("Created src/telnet.ts");
-  await Deno.writeTextFile(join(targetDir, "scripts", "run.sh"), gameRunSh(name));
-  console.log("Created scripts/run.sh");
-  try {
-    await Deno.chmod(join(targetDir, "scripts", "run.sh"), 0o755);
-  } catch { /* non-fatal on some platforms */ }
+  const shellScripts: Array<[string, string]> = [
+    ["run.sh",     gameRunSh(name)],
+    ["daemon.sh",  gameDaemonSh()],
+    ["stop.sh",    gameStopSh()],
+    ["restart.sh", gameRestartSh()],
+    ["status.sh",  gameStatusSh()],
+  ];
+  for (const [file, content] of shellScripts) {
+    const path = join(targetDir, "scripts", file);
+    await Deno.writeTextFile(path, content);
+    try { await Deno.chmod(path, 0o755); } catch { /* non-fatal */ }
+    console.log(`Created scripts/${file}`);
+  }
+
+  // Stable JWT secret so telnet auto-reauth survives main-server restarts.
+  const jwtBytes = new Uint8Array(32);
+  crypto.getRandomValues(jwtBytes);
+  const jwtSecret = Array.from(jwtBytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  await Deno.writeTextFile(
+    join(targetDir, ".env"),
+    gameEnvFile().replace("__JWT_SECRET__", jwtSecret),
+  );
+  console.log("Created .env (with generated JWT_SECRET)");
 
   await writeConnectTxt(targetDir, name);
   console.log("Created text/default_connect.txt");
 
-  const denoJson = isLocal
-    ? JSON.stringify({
-        tasks: {
-          "start":  "bash ./scripts/run.sh",
-          "server": "deno run -A --watch --unstable-detect-cjs --unstable-kv --unstable-net ./src/main.ts",
-          "telnet": "deno run -A --unstable-detect-cjs --unstable-kv --unstable-net ./src/telnet.ts",
-          "test":   "deno test --allow-all --unstable-kv --no-check",
-        },
-        imports: {
-          // ── local engine paths ───────────────────────────────────────────
-          "ursamu":                    `${engineRelPath}/mod.ts`,
-          "ursamu/":                   `${engineRelPath}/`,
-          "@ursamu/ursamu":            `${engineRelPath}/mod.ts`,
-          // Subpath exports — must point into the local engine tree so Deno
-          // resolves them even though they are bare specifiers in engine source.
-          "@ursamu/ursamu/app":        `${engineRelPath}/src/app.ts`,
-          "@ursamu/ursamu/channels":   `${engineRelPath}/src/services/channel-events.ts`,
-          "@ursamu/ursamu/chargen":    `${engineRelPath}/src/services/Chargen/index.ts`,
-          "@ursamu/ursamu/jobs":       `${engineRelPath}/src/plugins/jobs/mod.ts`,
-          // ── std ──────────────────────────────────────────────────────────
-          "@std/assert":               "jsr:@std/assert@^0.224.0",
-          "@std/flags":                "jsr:@std/flags@^0.224.0",
-          "@std/fmt":                  "jsr:@std/fmt@^0.224.0",
-          "@std/fmt/":                 "jsr:@std/fmt@^0.224.0/",
-          "@std/fs":                   "jsr:@std/fs@^0.224.0",
-          "@std/path":                 "jsr:@std/path@^0.224.0",
-          "@std/semver":               "jsr:@std/semver@^1.0.0",
-          "@std/testing":              "jsr:@std/testing@^1.0.17",
-          "@std/testing/bdd":          "jsr:@std/testing@^1.0.17/bdd",
-          "@std/testing/mock":         "jsr:@std/testing@^1.0.17/mock",
-          // ── ursamu transitive deps ────────────────────────────────────────
-          "@ursamu/mushcode":          "jsr:@ursamu/mushcode@^0.6.0",
-          "@ursamu/mushcode/eval":     "jsr:@ursamu/mushcode@^0.6.0/eval",
-          "@ursamu/mushcode/parse":    "jsr:@ursamu/mushcode@^0.6.0/parse",
-          "@ursamu/parser":            "npm:@ursamu/parser@1.2.4",
-          "@digibear/tags":            "npm:@digibear/tags@1.0.0",
-          "bcrypt":                    "npm:bcryptjs@2.4.3",
-          "djwt":                      "jsr:@zaubrik/djwt@^3.0.2",
-          "dotenv":                    "jsr:@std/dotenv@^0.224.0",
-          "dotenv/":                   "jsr:@std/dotenv@^0.224.0/",
-          "dotenv/load":               "jsr:@std/dotenv@^0.224.0/load",
-          "lodash":                    "npm:lodash@^4.18.1",
-          "quickjs-emscripten":        "npm:quickjs-emscripten@0.29.0",
-        },
-      }, null, 2)
-    : `{
-  "nodeModulesDir": "auto",
-  "tasks": ${JSON.stringify(GAME_PROJECT_TASKS, null, 2).replace(/\n/g, "\n  ")},
-  "compilerOptions": {
-    "lib": ["deno.window"],
-    "types": ["./node_modules/@types/node/index.d.ts"]
-  },
-  "imports": {
-    "ursamu": "jsr:@ursamu/ursamu",
+  const localImports = {
+    "ursamu":                  `${engineRelPath}/mod.ts`,
+    "ursamu/":                 `${engineRelPath}/`,
+    "@ursamu/ursamu":          `${engineRelPath}/mod.ts`,
+    "@ursamu/ursamu/app":      `${engineRelPath}/src/app.ts`,
+    "@ursamu/ursamu/channels": `${engineRelPath}/src/services/channel-events.ts`,
+    "@ursamu/ursamu/chargen":  `${engineRelPath}/src/services/Chargen/index.ts`,
+    "@ursamu/ursamu/jobs":     `${engineRelPath}/src/plugins/jobs/mod.ts`,
+    "@std/assert":             "jsr:@std/assert@^0.224.0",
+    "@std/flags":              "jsr:@std/flags@^0.224.0",
+    "@std/fmt":                "jsr:@std/fmt@^0.224.0",
+    "@std/fmt/":               "jsr:@std/fmt@^0.224.0/",
+    "@std/fs":                 "jsr:@std/fs@^0.224.0",
+    "@std/path":               "jsr:@std/path@^0.224.0",
+    "@std/semver":             "jsr:@std/semver@^1.0.0",
+    "@std/testing":            "jsr:@std/testing@^1.0.17",
+    "@std/testing/bdd":        "jsr:@std/testing@^1.0.17/bdd",
+    "@std/testing/mock":       "jsr:@std/testing@^1.0.17/mock",
+    "@ursamu/mushcode":        "jsr:@ursamu/mushcode@^0.6.0",
+    "@ursamu/mushcode/eval":   "jsr:@ursamu/mushcode@^0.6.0/eval",
+    "@ursamu/mushcode/parse":  "jsr:@ursamu/mushcode@^0.6.0/parse",
+    "@ursamu/parser":          "npm:@ursamu/parser@1.2.4",
+    "@digibear/tags":          "npm:@digibear/tags@1.0.0",
+    "bcrypt":                  "npm:bcryptjs@2.4.3",
+    "djwt":                    "jsr:@zaubrik/djwt@^3.0.2",
+    "dotenv":                  "jsr:@std/dotenv@^0.224.0",
+    "dotenv/":                 "jsr:@std/dotenv@^0.224.0/",
+    "dotenv/load":             "jsr:@std/dotenv@^0.224.0/load",
+    "lodash":                  "npm:lodash@^4.18.1",
+    "quickjs-emscripten":      "npm:quickjs-emscripten@0.29.0",
+  };
+  const jsrImports = {
+    "ursamu":         "jsr:@ursamu/ursamu",
     "@ursamu/ursamu": "jsr:@ursamu/ursamu",
-    "@std/path": "jsr:@std/path@^0.224.0",
-    "@std/assert": "jsr:@std/assert@^0.224.0",
-    "@std/fs": "jsr:@std/fs@^0.224.0"
-  }
-}`;
+    "@std/path":      "jsr:@std/path@^0.224.0",
+    "@std/assert":    "jsr:@std/assert@^0.224.0",
+    "@std/fs":        "jsr:@std/fs@^0.224.0",
+  };
+  const denoJson = JSON.stringify({
+    nodeModulesDir: "auto",
+    tasks: GAME_PROJECT_TASKS,
+    compilerOptions: {
+      lib: ["deno.window"],
+      types: ["./node_modules/@types/node/index.d.ts"],
+    },
+    imports: isLocal ? localImports : jsrImports,
+  }, null, 2);
 
   await Deno.writeTextFile(join(targetDir, "deno.json"), denoJson);
   console.log("Created deno.json");

--- a/src/cli/create-templates.ts
+++ b/src/cli/create-templates.ts
@@ -344,6 +344,144 @@ cleanup
 `;
 }
 
+export function gameDaemonSh(): string {
+  return `#!/bin/bash
+# Start the UrsaMU supervisor (start.ts) in the background. The supervisor
+# spawns the telnet sidecar and the main server, and re-spawns main on
+# exit code 75 — so in-game @reboot just works. SIGUSR2 also triggers a
+# no-disconnect restart (scripts/restart.sh).
+set -e
+cd "\$(dirname "\$0")/.."
+
+mkdir -p run logs
+
+if [ -f run/supervisor.pid ] && kill -0 "\$(cat run/supervisor.pid)" 2>/dev/null; then
+  echo "supervisor already running (pid \$(cat run/supervisor.pid))"
+  exit 1
+fi
+
+for port in 4201 4202 4203; do
+  pids=\$(lsof -ti ":\$port" 2>/dev/null || true)
+  [ -n "\$pids" ] && echo "\$pids" | xargs kill -9 2>/dev/null || true
+done
+
+DENO_FLAGS="--allow-all --unstable-detect-cjs --unstable-kv --unstable-net"
+
+# Local-link projects (\`ursamu create --local\`) have the engine checkout
+# somewhere above this directory; walk upward looking for mod.ts + start.ts.
+# Falls back to JSR when no engine checkout is found.
+ENTRY="jsr:@ursamu/ursamu/start"
+probe="\$(pwd)"
+while [ "\$probe" != "/" ]; do
+  if [ -f "\$probe/mod.ts" ] && [ -f "\$probe/src/cli/start.ts" ]; then
+    ENTRY="\$probe/src/cli/start.ts"
+    break
+  fi
+  probe="\$(dirname "\$probe")"
+done
+
+echo "Starting UrsaMU supervisor (\$ENTRY)..."
+nohup deno run \$DENO_FLAGS "\$ENTRY" >>logs/main.log 2>&1 &
+echo \$! > run/supervisor.pid
+
+sleep 1
+echo "supervisor pid: \$(cat run/supervisor.pid)"
+echo "logs:           logs/main.log"
+echo "@reboot in-game (or scripts/restart.sh) respawns main without dropping telnet."
+`;
+}
+
+export function gameStopSh(): string {
+  return `#!/bin/bash
+# Stop the supervisor (and with it, main + telnet). Disconnects all telnet
+# clients. For a no-disconnect restart, use scripts/restart.sh or @reboot.
+cd "\$(dirname "\$0")/.."
+
+pidfile="run/supervisor.pid"
+if [ ! -f "\$pidfile" ]; then
+  echo "Nothing to stop."
+  exit 0
+fi
+
+pid=\$(cat "\$pidfile")
+if kill -0 "\$pid" 2>/dev/null; then
+  echo "Stopping supervisor (pid \$pid)..."
+  kill "\$pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "\$pid" 2>/dev/null || break
+    sleep 0.5
+  done
+  kill -0 "\$pid" 2>/dev/null && kill -9 "\$pid" 2>/dev/null || true
+fi
+rm -f "\$pidfile"
+
+for port in 4201 4202 4203; do
+  pids=\$(lsof -ti ":\$port" 2>/dev/null || true)
+  [ -n "\$pids" ] && echo "\$pids" | xargs kill -9 2>/dev/null || true
+done
+`;
+}
+
+export function gameRestartSh(): string {
+  return `#!/bin/bash
+# No-disconnect restart. Tells the supervisor to re-spawn main; telnet stays up
+# and connected players auto-reauth via their JWT session token. Equivalent to
+# typing @reboot in-game. For a full stop (disconnect everyone), use stop.sh
+# or @shutdown.
+cd "\$(dirname "\$0")/.."
+
+if [ ! -f run/supervisor.pid ]; then
+  echo "Supervisor not running — start with scripts/daemon.sh."
+  exit 1
+fi
+
+pid=\$(cat run/supervisor.pid)
+if ! kill -0 "\$pid" 2>/dev/null; then
+  echo "Stale supervisor pidfile (pid \$pid). Run scripts/daemon.sh."
+  exit 1
+fi
+
+echo "Signaling supervisor (pid \$pid) — main will respawn, telnet stays up."
+kill -USR2 "\$pid"
+`;
+}
+
+export function gameStatusSh(): string {
+  return `#!/bin/bash
+# Report supervisor status and port bindings.
+cd "\$(dirname "\$0")/.."
+
+pidfile="run/supervisor.pid"
+if [ ! -f "\$pidfile" ]; then
+  echo "supervisor  not running"
+else
+  pid=\$(cat "\$pidfile")
+  if kill -0 "\$pid" 2>/dev/null; then
+    echo "supervisor  running (pid \$pid)"
+  else
+    echo "supervisor  stale pidfile (pid \$pid, no process)"
+  fi
+fi
+
+for port in 4201:telnet 4202:ws 4203:http; do
+  p=\${port%:*}; label=\${port#*:}
+  bound=\$(lsof -ti ":\$p" 2>/dev/null || true)
+  if [ -n "\$bound" ]; then
+    printf "%-11s bound on :%s (pid %s)\\n" "\$label" "\$p" "\$bound"
+  else
+    printf "%-11s :%s free\\n" "\$label" "\$p"
+  fi
+done
+`;
+}
+
+export function gameEnvFile(): string {
+  return `# Stable JWT secret — required for telnet auto-reauth across server restarts.
+# Generated at scaffold time. Treat as a secret; do not commit.
+JWT_SECRET=__JWT_SECRET__
+`;
+}
+
 export function gameConnectTxt(name: string): string {
   return `%ch%cc==================================%cn
 %ch%cw Welcome to %cy${name}%cn
@@ -396,6 +534,8 @@ export function gameGitignore(): string {
 data/*.db
 config/config.json
 node_modules/
+run/
+logs/
 `;
 }
 

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -78,18 +78,26 @@ try {
 
 const REBOOT_CODE = 75;
 
-// Main server restart loop — exit code 75 means "please restart me" (@reboot).
-// Any other exit code means a permanent stop (@shutdown or crash).
+// SIGUSR2 is the "no-disconnect restart" signal: scripts/restart.sh sends it.
+// The supervisor kills the current main child, but treats the exit as a
+// reboot rather than a shutdown so telnet stays up and clients auto-reauth.
+let rebootRequested = false;
+let currentMain: Deno.ChildProcess | null = null;
+
 const runMain = async () => {
   while (true) {
-    const proc = spawnInherit("src/main.ts");
-    const { code } = await proc.status;
-    if (code !== REBOOT_CODE) break;
-    console.log("\n🔄 Restarting main server...");
+    currentMain = spawnInherit("src/main.ts");
+    const { code } = await currentMain.status;
+    currentMain = null;
+    if (code === REBOOT_CODE || rebootRequested) {
+      rebootRequested = false;
+      console.log("\n🔄 Restarting main server...");
+      continue;
+    }
+    break;
   }
 };
 
-// Hard shutdown cleanup — only reached when main exits permanently or on SIGINT.
 const cleanup = () => {
   console.log("\nShutting down servers...");
   try { telnetProc.kill(); } catch { /* ignore */ }
@@ -99,6 +107,20 @@ const cleanup = () => {
 Deno.addSignalListener("SIGINT", () => {
   cleanup();
   Deno.exit(0);
+});
+
+// SIGTERM = clean shutdown (matches stop.sh semantics — disconnects everyone).
+Deno.addSignalListener("SIGTERM", () => {
+  cleanup();
+  try { currentMain?.kill("SIGTERM"); } catch { /* ignore */ }
+  Deno.exit(0);
+});
+
+// SIGUSR2 = no-disconnect restart. Equivalent to in-game @reboot.
+Deno.addSignalListener("SIGUSR2", () => {
+  console.log("\n🛰  SIGUSR2 received — restarting main without dropping telnet.");
+  rebootRequested = true;
+  try { currentMain?.kill("SIGTERM"); } catch { /* ignore */ }
 });
 
 await runMain();

--- a/src/commands/@js.ts
+++ b/src/commands/@js.ts
@@ -2,8 +2,7 @@ import { getQuickJS } from "../../deps.ts";
 import { addCmd, send } from "../services/index.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "js",
     pattern: /^[+@]?js\s+(.*)/i,
     lock: "connected & admin+",

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -112,67 +112,65 @@ export async function execShutdown(u: IUrsamuSDK): Promise<void> {
   await u.sys.shutdown();
 }
 
-export default () => {
-  addCmd({
-    name: "@boot",
-    pattern: /^@boot\s+(.*)/i,
-    lock: "connected & admin+",
-    help: "Disconnect a player",
-    category: "admin",
-    exec: execBoot,
-  });
+addCmd({
+  name: "@boot",
+  pattern: /^@boot\s+(.*)/i,
+  lock: "connected & admin+",
+  help: "Disconnect a player",
+  category: "admin",
+  exec: execBoot,
+});
 
-  addCmd({
-    name: "@toad",
-    pattern: /^@toad\s+(.*)/i,
-    lock: "connected & admin+",
-    help: "Destroy a player",
-    category: "admin",
-    exec: execToad,
-  });
+addCmd({
+  name: "@toad",
+  pattern: /^@toad\s+(.*)/i,
+  lock: "connected & admin+",
+  help: "Destroy a player",
+  category: "admin",
+  exec: execToad,
+});
 
-  addCmd({
-    name: "@newpassword",
-    pattern: /^@newpass(?:word)?\s+(.*)\s*=\s*(.*)/i,
-    lock: "connected & admin+",
-    help: "Change a player's password",
-    category: "admin",
-    exec: execNewpassword,
-  });
+addCmd({
+  name: "@newpassword",
+  pattern: /^@newpass(?:word)?\s+(.*)\s*=\s*(.*)/i,
+  lock: "connected & admin+",
+  help: "Change a player's password",
+  category: "admin",
+  exec: execNewpassword,
+});
 
-  addCmd({
-    name: "@chown",
-    pattern: /^@chown\s+(.*)\s*=\s*(.*)/i,
-    lock: "connected & admin+",
-    help: "Change ownership of an object",
-    category: "admin",
-    exec: execChown,
-  });
+addCmd({
+  name: "@chown",
+  pattern: /^@chown\s+(.*)\s*=\s*(.*)/i,
+  lock: "connected & admin+",
+  help: "Change ownership of an object",
+  category: "admin",
+  exec: execChown,
+});
 
-  addCmd({
-    name: "@resettoken",
-    pattern: /^@resettoken\s+(.*)/i,
-    lock: "connected & admin+",
-    help: "Generate a one-time password-reset token for a player",
-    category: "admin",
-    exec: execResetToken,
-  });
+addCmd({
+  name: "@resettoken",
+  pattern: /^@resettoken\s+(.*)/i,
+  lock: "connected & admin+",
+  help: "Generate a one-time password-reset token for a player",
+  category: "admin",
+  exec: execResetToken,
+});
 
-  addCmd({
-    name: "@site",
-    pattern: /^@site\s+(.*)\s*=\s*(.*)/i,
-    lock: "connected & admin+",
-    help: "Set site configuration",
-    category: "admin",
-    exec: execSite,
-  });
+addCmd({
+  name: "@site",
+  pattern: /^@site\s+(.*)\s*=\s*(.*)/i,
+  lock: "connected & admin+",
+  help: "Set site configuration",
+  category: "admin",
+  exec: execSite,
+});
 
-  addCmd({
-    name: "@shutdown",
-    pattern: /^@shutdown$/i,
-    lock: "connected & admin+",
-    help: "Shut down the server",
-    category: "admin",
-    exec: execShutdown,
-  });
-};
+addCmd({
+  name: "@shutdown",
+  pattern: /^@shutdown$/i,
+  lock: "connected & admin+",
+  help: "Shut down the server",
+  category: "admin",
+  exec: execShutdown,
+});

--- a/src/commands/alias.ts
+++ b/src/commands/alias.ts
@@ -27,16 +27,14 @@ export async function execAlias(u: IUrsamuSDK): Promise<void> {
   }
 }
 
-export default () => {
-  addCmd({
-    name: "@alias",
-    pattern: /^[@/+]?alias\s+(.*)/i,
-    lock: "connected",
-    help: `@alias <target>=<alias>  — Set or clear an alias for an object.
+addCmd({
+  name: "@alias",
+  pattern: /^[@/+]?alias\s+(.*)/i,
+  lock: "connected",
+  help: `@alias <target>=<alias>  — Set or clear an alias for an object.
 
 Examples:
   @alias lamp=lantern
   @alias lamp=`,
-    exec: execAlias,
-  });
-};
+  exec: execAlias,
+});

--- a/src/commands/assert.ts
+++ b/src/commands/assert.ts
@@ -12,8 +12,7 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
  * silent.  In native context the literal condition string is inspected; when
  * called from softcode the argument will already be an evaluated string.
  */
-export default () =>
-  addCmd({
+addCmd({
     name: "@assert",
     pattern: /^@assert\s+(.*?)(?:\s*=\s*(.*))?$/i,
     lock: "connected",

--- a/src/commands/attrCommands.ts
+++ b/src/commands/attrCommands.ts
@@ -1,13 +1,12 @@
 import { addCmd } from "../services/commands/cmdParser.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  addCmd({
-    name: "&",
-    pattern: /^&(\S+)\s+(\S+)\s*=\s*(.*)?$/is,
-    lock: "connected",
-    category: "Building",
-    help: `&<attribute>[/softcode] <target>=<value>  — Set an attribute on an object.
+addCmd({
+  name: "&",
+  pattern: /^&(\S+)\s+(\S+)\s*=\s*(.*)?$/is,
+  lock: "connected",
+  category: "Building",
+  help: `&<attribute>[/softcode] <target>=<value>  — Set an attribute on an object.
 &<attribute> <target>=                     — Clear an attribute.
 
 The /softcode type hint marks the attribute as evaluable softcode.
@@ -17,38 +16,37 @@ Examples:
   &listen #5=*hello*
   &ahear/softcode #5=[say(hello)]
   &short-desc me=`,
-    exec: async (u: IUrsamuSDK) => {
-      const attrPart  = u.cmd.args[0] || "";
-      const targetRef = (u.cmd.args[1] || "").trim();
-      const value     = u.cmd.args[2] ?? "";
+  exec: async (u: IUrsamuSDK) => {
+    const attrPart  = u.cmd.args[0] || "";
+    const targetRef = (u.cmd.args[1] || "").trim();
+    const value     = u.cmd.args[2] ?? "";
 
-      // Parse optional /softcode type hint from attribute name
-      const slashIdx = attrPart.indexOf("/");
-      const attrName = (slashIdx === -1 ? attrPart : attrPart.slice(0, slashIdx)).toUpperCase();
-      const typeHint = slashIdx !== -1 && attrPart.slice(slashIdx + 1).toLowerCase() === "softcode"
-        ? "softcode"
-        : "attribute";
+    // Parse optional /softcode type hint from attribute name
+    const slashIdx = attrPart.indexOf("/");
+    const attrName = (slashIdx === -1 ? attrPart : attrPart.slice(0, slashIdx)).toUpperCase();
+    const typeHint = slashIdx !== -1 && attrPart.slice(slashIdx + 1).toLowerCase() === "softcode"
+      ? "softcode"
+      : "attribute";
 
-      if (!attrName) { u.send("Usage: &<attribute> <object>=<value>"); return; }
+    if (!attrName) { u.send("Usage: &<attribute> <object>=<value>"); return; }
 
-      const target = await u.util.target(u.me, targetRef, true);
-      if (!target) { u.send(`I can't find "${targetRef}".`); return; }
-      if (!await u.canEdit(u.me, target)) { u.send("You can't edit that."); return; }
+    const target = await u.util.target(u.me, targetRef, true);
+    if (!target) { u.send(`I can't find "${targetRef}".`); return; }
+    if (!await u.canEdit(u.me, target)) { u.send("You can't edit that."); return; }
 
-      const displayName = target.name || target.id;
+    const displayName = target.name || target.id;
 
-      if (!value) {
-        const removed = await u.attr.clear(target.id, attrName);
-        if (!removed) {
-          u.send(`${displayName} doesn't have attribute %ch${attrName}%cn.`);
-        } else {
-          u.send(`${displayName}'s attribute %ch${attrName}%cn removed.`);
-        }
-        return;
+    if (!value) {
+      const removed = await u.attr.clear(target.id, attrName);
+      if (!removed) {
+        u.send(`${displayName} doesn't have attribute %ch${attrName}%cn.`);
+      } else {
+        u.send(`${displayName}'s attribute %ch${attrName}%cn removed.`);
       }
+      return;
+    }
 
-      await u.attr.set(target.id, attrName, value, typeHint);
-      u.send(`${displayName}'s attribute %ch${attrName}%cn set.`);
-    },
-  });
-};
+    await u.attr.set(target.id, attrName, value, typeHint);
+    u.send(`${displayName}'s attribute %ch${attrName}%cn set.`);
+  },
+});

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -152,37 +152,36 @@ export async function execUpdate(u: IUrsamuSDK): Promise<void> {
   await u.sys.update(branch);
 }
 
-export default () => {
-  addCmd({
-    name: "connect",
-    pattern: /^connect\s+(.*)/i,
-    lock: "",
-    category: "Authentication",
-    help: `connect <name> <password>  — Log in to the game.
+addCmd({
+  name: "connect",
+  pattern: /^connect\s+(.*)/i,
+  lock: "",
+  category: "Authentication",
+  help: `connect <name> <password>  — Log in to the game.
 
 Examples:
   connect Alice mypassword`,
-    exec: execConnect,
-  });
+  exec: execConnect,
+});
 
-  addCmd({
-    name: "quit",
-    pattern: /^quit$/i,
-    lock: "connected",
-    category: "Authentication",
-    help: `quit  — Disconnect from the game.
+addCmd({
+  name: "quit",
+  pattern: /^quit$/i,
+  lock: "connected",
+  category: "Authentication",
+  help: `quit  — Disconnect from the game.
 
 Examples:
   quit`,
-    exec: execQuit,
-  });
+  exec: execQuit,
+});
 
-  addCmd({
-    name: "@motd",
-    pattern: /^@?motd(?:\/(set|clear))?\s*(.*)?/i,
-    lock: "connected",
-    category: "Authentication",
-    help: `@motd             — Display the message of the day.
+addCmd({
+  name: "@motd",
+  pattern: /^@?motd(?:\/(set|clear))?\s*(.*)?/i,
+  lock: "connected",
+  category: "Authentication",
+  help: `@motd             — Display the message of the day.
 @motd/set <text>  — Set the MOTD (admin/wizard only).
 @motd/clear       — Clear the MOTD (admin/wizard only).
 
@@ -190,35 +189,34 @@ Examples:
   @motd
   @motd/set Welcome to the game! Enjoy your stay.
   @motd/clear`,
-    exec: execMotd,
-  });
+  exec: execMotd,
+});
 
-  addCmd({
-    name: "@password",
-    pattern: /^@?password\s+(.*)/i,
-    lock: "connected",
-    category: "Authentication",
-    help: `@password <oldpass>=<newpass>   — Change your own password.
+addCmd({
+  name: "@password",
+  pattern: /^@?password\s+(.*)/i,
+  lock: "connected",
+  category: "Authentication",
+  help: `@password <oldpass>=<newpass>   — Change your own password.
 @password <player>=<newpass>   — Set a player's password (admin/wizard only).
 
 Examples:
   @password oldpass=newpass
   @password Alice=resetpass`,
-    exec: execPassword,
-  });
+  exec: execPassword,
+});
 
-  addCmd({
-    name: "@update",
-    pattern: /^@?(?:update|upgrade)(?:\s+(.*))?$/i,
-    lock: "connected admin+",
-    category: "System",
-    help: `@update [<branch>]  — Pull latest code and reboot (admin+).
+addCmd({
+  name: "@update",
+  pattern: /^@?(?:update|upgrade)(?:\s+(.*))?$/i,
+  lock: "connected admin+",
+  category: "System",
+  help: `@update [<branch>]  — Pull latest code and reboot (admin+).
 
 Aliases: @upgrade
 
 Examples:
   @update
   @update main`,
-    exec: execUpdate,
-  });
-};
+  exec: execUpdate,
+});

--- a/src/commands/avatar.ts
+++ b/src/commands/avatar.ts
@@ -61,8 +61,7 @@ async function removeExistingAvatar(id: string): Promise<void> {
   }
 }
 
-export default () =>
-  addCmd({
+addCmd({
     name: "avatar",
     pattern: /^[@+]?avatar(?:\s+(.*))?$/i,
     lock: "connected",

--- a/src/commands/channels.ts
+++ b/src/commands/channels.ts
@@ -242,13 +242,12 @@ export async function execAddcom(u: IUrsamuSDK): Promise<void> {
   }
 }
 
-export default () => {
-  addCmd({
-    name: "@channel",
-    pattern: /^@?channels?(?:\/(join|leave|list))?\s*(.*)?$/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@channel              — List available channels.
+addCmd({
+  name: "@channel",
+  pattern: /^@?channels?(?:\/(join|leave|list))?\s*(.*)?$/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@channel              — List available channels.
 @channel/join <chan>=<alias>  — Join a channel with an alias.
 @channel/leave <alias>        — Leave a channel.
 
@@ -258,44 +257,44 @@ Examples:
   @channel
   @channel/join Public=pub
   @channel/leave pub`,
-    exec: execChannel,
-  });
+  exec: execChannel,
+});
 
-  addCmd({
-    name: "@chanhistory",
-    pattern: /^(?:@chanhistory|\+channel\/history)\s+(.*)/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@chanhistory <name>[=<lines>]  — Show recent channel history.
+addCmd({
+  name: "@chanhistory",
+  pattern: /^(?:@chanhistory|\+channel\/history)\s+(.*)/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@chanhistory <name>[=<lines>]  — Show recent channel history.
 
 Aliases: +channel/history
 
 Examples:
   @chanhistory Public
   @chanhistory Public=50`,
-    exec: execChanhistory,
-  });
+  exec: execChanhistory,
+});
 
-  addCmd({
-    name: "@chantranscript",
-    pattern: /^(?:@chantranscript|\+channel\/transcript)\s+(.*)/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@chantranscript <name>=<lines>  — Export channel history as plain text.
+addCmd({
+  name: "@chantranscript",
+  pattern: /^(?:@chantranscript|\+channel\/transcript)\s+(.*)/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@chantranscript <name>=<lines>  — Export channel history as plain text.
 
 Aliases: +channel/transcript
 
 Examples:
   @chantranscript Public=100`,
-    exec: execChantranscript,
-  });
+  exec: execChantranscript,
+});
 
-  addCmd({
-    name: "@chancreate",
-    pattern: /^@?chancreate(?:\/(hidden|lock))?\s+(.*)/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@chancreate <name>[=<header>]          — Create a channel (admin+).
+addCmd({
+  name: "@chancreate",
+  pattern: /^@?chancreate(?:\/(hidden|lock))?\s+(.*)/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@chancreate <name>[=<header>]          — Create a channel (admin+).
 @chancreate/hidden <name>[=<header>]   — Create a hidden channel.
 @chancreate/lock <name>=<lock>         — Create a channel with a lock.
 
@@ -303,27 +302,27 @@ Examples:
   @chancreate Staff
   @chancreate/hidden Admin=[ADMIN]
   @chancreate/lock Guild=member+`,
-    exec: execChancreate,
-  });
+  exec: execChancreate,
+});
 
-  addCmd({
-    name: "@chandestroy",
-    pattern: /^@?chandestroy\s+(.*)/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@chandestroy <name>  — Destroy a channel (admin+).
+addCmd({
+  name: "@chandestroy",
+  pattern: /^@?chandestroy\s+(.*)/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@chandestroy <name>  — Destroy a channel (admin+).
 
 Examples:
   @chandestroy Staff`,
-    exec: execChandestroy,
-  });
+  exec: execChandestroy,
+});
 
-  addCmd({
-    name: "@chanset",
-    pattern: /^@?chanset\s+(.*)/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@chanset <name>/<property>=<value>  — Modify a channel property (admin+).
+addCmd({
+  name: "@chanset",
+  pattern: /^@?chanset\s+(.*)/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@chanset <name>/<property>=<value>  — Modify a channel property (admin+).
 
 Properties: header, lock, hidden (on/off), masking (on/off), log (on/off), historyLimit (<n>)
 
@@ -331,15 +330,15 @@ Examples:
   @chanset public/header=[PUB]
   @chanset public/lock=player+
   @chanset public/hidden=on`,
-    exec: execChanset,
-  });
+  exec: execChanset,
+});
 
-  addCmd({
-    name: "@addcom",
-    pattern: /^@?(?:addcom|delcom|allcom|clearcom|comtitle)(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Channel",
-    help: `@addcom <alias>=<channel>     — Add a channel alias (join if needed).
+addCmd({
+  name: "@addcom",
+  pattern: /^@?(?:addcom|delcom|allcom|clearcom|comtitle)(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Channel",
+  help: `@addcom <alias>=<channel>     — Add a channel alias (join if needed).
 @delcom <alias>               — Remove a channel alias.
 @allcom                       — List all your channel aliases.
 @clearcom                     — Remove all channel aliases.
@@ -349,6 +348,5 @@ Examples:
   @addcom pub=Public
   @delcom pub
   @comtitle pub=Lord`,
-    exec: execAddcom,
-  });
-};
+  exec: execAddcom,
+});

--- a/src/commands/comms.ts
+++ b/src/commands/comms.ts
@@ -303,9 +303,8 @@ export async function execFsay(u: IUrsamuSDK): Promise<void> {
   }
 }
 
-export default () => {
-  addCmd({
-    name: "say",
+addCmd({
+  name: "say",
     pattern: /^(?:say\s+|["'])(.*)/is,
     lock: "connected",
     category: "Communication",
@@ -480,4 +479,3 @@ Examples:
   fpose NPC=bows deeply.`,
     exec: execFsay,
   });
-};

--- a/src/commands/cpattr.ts
+++ b/src/commands/cpattr.ts
@@ -21,13 +21,12 @@ function parseDest(s: string): { objRef: string; newName?: string } {
   return { objRef: s.slice(0, i).trim(), newName: s.slice(i + 1).trim() || undefined };
 }
 
-export default () =>
-  addCmd({
-    name: "@cpattr",
-    pattern: /^@cpattr(?:\/(\S+))?\s+(.*)/i,
-    lock: "connected",
-    category: "Building",
-    help: `@cpattr[/<switches>] <obj>/<attr>=<dest>[/<newname>][,<dest2>[/<newname2>],...]
+addCmd({
+  name: "@cpattr",
+  pattern: /^@cpattr(?:\/(\S+))?\s+(.*)/i,
+  lock: "connected",
+  category: "Building",
+  help: `@cpattr[/<switches>] <obj>/<attr>=<dest>[/<newname>][,<dest2>[/<newname2>],...]
 
 Copy attributes from one object to one or more destinations.
 Both source and destination must be objects you control.
@@ -44,96 +43,96 @@ Examples:
   @cpattr me/DESC=box/ALTDESC       Copy me/DESC to box/ALTDESC.
   @cpattr/clear me/TEMP=archive     Move me/TEMP to archive/TEMP.
   @cpattr me/SKILL_*=puppet         Copy all SKILL_* attrs to puppet.`,
-    exec: async (u: IUrsamuSDK) => {
-      const swRaw = (u.cmd.args[0] ?? "").toLowerCase();
-      const rest  = (u.cmd.args[1] ?? "").trim();
+  exec: async (u: IUrsamuSDK) => {
+    const swRaw = (u.cmd.args[0] ?? "").toLowerCase();
+    const rest  = (u.cmd.args[1] ?? "").trim();
 
-      const doClear   = swRaw.includes("clear");
-      const doVerbose = swRaw.includes("verbose");
-      const doVerify  = swRaw.includes("verify");
+    const doClear   = swRaw.includes("clear");
+    const doVerbose = swRaw.includes("verbose");
+    const doVerify  = swRaw.includes("verify");
 
-      const eqIdx = rest.indexOf("=");
-      if (eqIdx === -1) return u.send("Usage: @cpattr[/switches] <obj>/<attr>=<dest>[/<newname>][,...]");
+    const eqIdx = rest.indexOf("=");
+    if (eqIdx === -1) return u.send("Usage: @cpattr[/switches] <obj>/<attr>=<dest>[/<newname>][,...]");
 
-      const srcStr  = rest.slice(0, eqIdx).trim();
-      const destStr = rest.slice(eqIdx + 1).trim();
-      if (!srcStr || !destStr) return u.send("Usage: @cpattr[/switches] <obj>/<attr>=<dest>[/<newname>][,...]");
+    const srcStr  = rest.slice(0, eqIdx).trim();
+    const destStr = rest.slice(eqIdx + 1).trim();
+    if (!srcStr || !destStr) return u.send("Usage: @cpattr[/switches] <obj>/<attr>=<dest>[/<newname>][,...]");
 
-      const { objRef: srcRef, attrGlob } = parseSrc(srcStr);
+    const { objRef: srcRef, attrGlob } = parseSrc(srcStr);
 
-      const en = await dbojs.queryOne({ id: u.me.id });
-      if (!en) return;
+    const en = await dbojs.queryOne({ id: u.me.id });
+    if (!en) return;
 
-      const srcResult = await target(en as unknown as IDBOBJ, srcRef);
-      if (!srcResult) return send([u.socketId ?? ""], `I can't find '${srcRef}'.`);
-      if (!await canEdit(en as unknown as IDBOBJ, srcResult)) return u.send("Permission denied on source.");
+    const srcResult = await target(en as unknown as IDBOBJ, srcRef);
+    if (!srcResult) return send([u.socketId ?? ""], `I can't find '${srcRef}'.`);
+    if (!await canEdit(en as unknown as IDBOBJ, srcResult)) return u.send("Permission denied on source.");
 
-      const srcObj = await Obj.get(srcResult.id);
-      if (!srcObj) return u.send("Source object not found.");
-      const srcAttrs: IAttribute[] = (srcObj.data?.attributes as IAttribute[] | undefined) ?? [];
+    const srcObj = await Obj.get(srcResult.id);
+    if (!srcObj) return u.send("Source object not found.");
+    const srcAttrs: IAttribute[] = (srcObj.data?.attributes as IAttribute[] | undefined) ?? [];
 
-      const _isStaff = isStaff(u.me.flags);
+    const _isStaff = isStaff(u.me.flags);
 
-      // Match source attributes by glob
-      const attrRe   = globToRegex(attrGlob);
-      const matched  = srcAttrs.filter(a => attrRe.test(a.name));
-      if (matched.length === 0) return u.send(`No attributes matching '${attrGlob}' on ${srcObj.name}.`);
+    // Match source attributes by glob
+    const attrRe   = globToRegex(attrGlob);
+    const matched  = srcAttrs.filter(a => attrRe.test(a.name));
+    if (matched.length === 0) return u.send(`No attributes matching '${attrGlob}' on ${srcObj.name}.`);
 
-      // Parse comma-separated destinations
-      const dests = destStr.split(",").map(s => parseDest(s.trim())).filter(d => d.objRef);
+    // Parse comma-separated destinations
+    const dests = destStr.split(",").map(s => parseDest(s.trim())).filter(d => d.objRef);
 
-      let totalCopied = 0;
-      const saves: Promise<void>[] = [];
+    let totalCopied = 0;
+    const saves: Promise<void>[] = [];
 
-      for (const { objRef: destRef, newName } of dests) {
-        const destResult = await target(en as unknown as IDBOBJ, destRef);
-        if (!destResult) { u.send(`I can't find destination '${destRef}'.`); continue; }
-        if (!await canEdit(en as unknown as IDBOBJ, destResult)) { u.send(`Permission denied on '${destRef}'.`); continue; }
+    for (const { objRef: destRef, newName } of dests) {
+      const destResult = await target(en as unknown as IDBOBJ, destRef);
+      if (!destResult) { u.send(`I can't find destination '${destRef}'.`); continue; }
+      if (!await canEdit(en as unknown as IDBOBJ, destResult)) { u.send(`Permission denied on '${destRef}'.`); continue; }
 
-        const destObj = await Obj.get(destResult.id);
-        if (!destObj) { u.send(`Destination object '${destRef}' not found.`); continue; }
+      const destObj = await Obj.get(destResult.id);
+      if (!destObj) { u.send(`Destination object '${destRef}' not found.`); continue; }
 
-        if (!destObj.dbobj.data) destObj.dbobj.data = { attributes: [] };
-        const destAttrs: IAttribute[] = (destObj.data?.attributes as IAttribute[] | undefined) ?? [];
+      if (!destObj.dbobj.data) destObj.dbobj.data = { attributes: [] };
+      const destAttrs: IAttribute[] = (destObj.data?.attributes as IAttribute[] | undefined) ?? [];
 
-        for (const srcAttr of matched) {
-          // Block copying attributes set by another player (unless staff or legacy attr).
-          if (srcAttr.setter && srcAttr.setter !== u.me.id && !_isStaff) {
-            if (doVerbose) u.send(`Skipped: ${srcObj.name}/${srcAttr.name} — set by another player.`);
-            continue;
-          }
-
-          const targetName = matched.length === 1 && newName ? newName : (newName ?? srcAttr.name);
-
-          // /verify: skip if destination attr name would be invalid
-          if (doVerify && !/^[A-Z0-9_]+$/i.test(targetName)) {
-            if (doVerbose) u.send(`Skipped: '${targetName}' is not a valid attribute name.`);
-            continue;
-          }
-
-          const existingIdx = destAttrs.findIndex(a => a.name.toLowerCase() === targetName.toLowerCase());
-          const newAttr: IAttribute = { name: targetName.toUpperCase(), value: srcAttr.value, setter: u.me.id, type: srcAttr.type };
-
-          if (existingIdx >= 0) destAttrs[existingIdx] = newAttr;
-          else destAttrs.push(newAttr);
-
-          if (doVerbose) u.send(`Copied: ${srcObj.name}/${srcAttr.name} → ${destObj.name}/${targetName.toUpperCase()}`);
-          totalCopied++;
+      for (const srcAttr of matched) {
+        // Block copying attributes set by another player (unless staff or legacy attr).
+        if (srcAttr.setter && srcAttr.setter !== u.me.id && !_isStaff) {
+          if (doVerbose) u.send(`Skipped: ${srcObj.name}/${srcAttr.name} — set by another player.`);
+          continue;
         }
 
-        destObj.dbobj.data.attributes = destAttrs;
-        saves.push(destObj.save());
+        const targetName = matched.length === 1 && newName ? newName : (newName ?? srcAttr.name);
+
+        // /verify: skip if destination attr name would be invalid
+        if (doVerify && !/^[A-Z0-9_]+$/i.test(targetName)) {
+          if (doVerbose) u.send(`Skipped: '${targetName}' is not a valid attribute name.`);
+          continue;
+        }
+
+        const existingIdx = destAttrs.findIndex(a => a.name.toLowerCase() === targetName.toLowerCase());
+        const newAttr: IAttribute = { name: targetName.toUpperCase(), value: srcAttr.value, setter: u.me.id, type: srcAttr.type };
+
+        if (existingIdx >= 0) destAttrs[existingIdx] = newAttr;
+        else destAttrs.push(newAttr);
+
+        if (doVerbose) u.send(`Copied: ${srcObj.name}/${srcAttr.name} → ${destObj.name}/${targetName.toUpperCase()}`);
+        totalCopied++;
       }
 
-      await Promise.all(saves);
+      destObj.dbobj.data.attributes = destAttrs;
+      saves.push(destObj.save());
+    }
 
-      if (doClear && totalCopied > 0) {
-        const remaining = srcAttrs.filter(a => !matched.some(m => m.name === a.name));
-        srcObj.dbobj.data!.attributes = remaining;
-        await srcObj.save();
-        u.send(`Copied ${totalCopied} attribute${totalCopied === 1 ? "" : "s"} and cleared from source.`);
-      } else {
-        u.send(`Copied ${totalCopied} attribute${totalCopied === 1 ? "" : "s"}.`);
-      }
-    },
-  });
+    await Promise.all(saves);
+
+    if (doClear && totalCopied > 0) {
+      const remaining = srcAttrs.filter(a => !matched.some(m => m.name === a.name));
+      srcObj.dbobj.data!.attributes = remaining;
+      await srcObj.save();
+      u.send(`Copied ${totalCopied} attribute${totalCopied === 1 ? "" : "s"} and cleared from source.`);
+    } else {
+      u.send(`Copied ${totalCopied} attribute${totalCopied === 1 ? "" : "s"}.`);
+    }
+  },
+});

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -4,11 +4,11 @@ import { getConfig } from "../services/Config/mod.ts";
 import { getNextId } from "../utils/getNextId.ts";
 import { moniker } from "../utils/moniker.ts";
 import { isNameTaken } from "../utils/isNameTaken.ts";
+import { sign } from "../services/jwt/jwt.ts";
 import type { IDBOBJ } from "../@types/IDBObj.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "create",
     pattern: /^(?:create|cr)\s+(.*)/i,
     exec: async (u: IUrsamuSDK) => {
@@ -65,10 +65,19 @@ export default () =>
       // Login the player (sets socket.cid and joins rooms)
       await u.auth.login(newPlayer.id);
 
+      // Issue a session token so telnet (or any client) can re-authenticate
+      // after a server restart without forcing the player to log in again.
+      let token: string | undefined;
+      try {
+        token = await sign({ id: newPlayer.id });
+      } catch (e) {
+        console.warn("[create] Failed to issue session token:", e);
+      }
+
       await u.send(
         `Welcome to ${getConfig<string>("game.name")}!`,
         u.socketId,
-        { cid: newPlayer.id }
+        token ? { cid: newPlayer.id, token } : { cid: newPlayer.id },
       );
 
       // Send connection message to everyone in the room

--- a/src/commands/decompile.ts
+++ b/src/commands/decompile.ts
@@ -14,8 +14,7 @@ const SKIP_KEYS = new Set([
   "quota", "money", "channels",
 ]);
 
-export default () =>
-  addCmd({
+addCmd({
     name: "@decompile",
     pattern: /^@decompile(?:\/(tf))?\s+(.*)/i,
     lock: "connected",

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -150,13 +150,12 @@ async function demoUI(u: IUrsamuSDK) {
   u.send(section("UI — panel types") + "\n  Sending structured layout — check your web client.\n");
 }
 
-export default () => {
-  addCmd({
-    name: "demo",
-    pattern: /^demo(?:\/(basics|format|db|sys|chan|ui))?\s*$/i,
-    lock: "connected",
-    category: "System",
-    help: `demo[/<switch>]  — Walk through the UrsaMU script engine SDK.
+addCmd({
+  name: "demo",
+  pattern: /^demo(?:\/(basics|format|db|sys|chan|ui))?\s*$/i,
+  lock: "connected",
+  category: "System",
+  help: `demo[/<switch>]  — Walk through the UrsaMU script engine SDK.
 
 Switches:
   /basics   Actor & room, state, flags
@@ -170,17 +169,16 @@ Examples:
   demo
   demo/basics
   demo/db`,
-    exec: async (u: IUrsamuSDK) => {
-      const sw = (u.cmd.args[0] || "").toLowerCase().trim();
-      switch (sw) {
-        case "basics": await demoBasics(u); break;
-        case "format": await demoFormat(u); break;
-        case "db":     await demoDB(u);     break;
-        case "sys":    await demoSys(u);    break;
-        case "chan":   await demoChan(u);   break;
-        case "ui":     await demoUI(u);     break;
-        default:       await demoOverview(u); break;
-      }
-    },
-  });
-};
+  exec: async (u: IUrsamuSDK) => {
+    const sw = (u.cmd.args[0] || "").toLowerCase().trim();
+    switch (sw) {
+      case "basics": await demoBasics(u); break;
+      case "format": await demoFormat(u); break;
+      case "db":     await demoDB(u);     break;
+      case "sys":    await demoSys(u);    break;
+      case "chan":   await demoChan(u);   break;
+      case "ui":     await demoUI(u);     break;
+      default:       await demoOverview(u); break;
+    }
+  },
+});

--- a/src/commands/drain.ts
+++ b/src/commands/drain.ts
@@ -10,13 +10,12 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
  * Without semaphore support: acts as @halt for a named object.
  * With semaphore support: also clears the semaphore queue and pre-notify counter.
  */
-export default () =>
-  addCmd({
-    name: "@drain",
-    pattern: /^@drain(?:\/(quiet))?\s*(.*)?/i,
-    lock: "connected",
-    category: "Softcode",
-    help: `@drain[/quiet] [<object>]
+addCmd({
+  name: "@drain",
+  pattern: /^@drain(?:\/(quiet))?\s*(.*)?/i,
+  lock: "connected",
+  category: "Softcode",
+  help: `@drain[/quiet] [<object>]
 
 Discard all commands waiting on the semaphore queue for <object> and reset
 its pre-notify counter to zero. Also cancels any time-delayed commands
@@ -32,32 +31,32 @@ Examples:
   @drain           Cancel all your own queued commands.
   @drain here      Drain the semaphore queue on the current room (admin+).
   @drain #5        Drain all queued commands for object #5 (admin+).`,
-    exec: async (u: IUrsamuSDK) => {
-      const quiet   = (u.cmd.args[0] ?? "").toLowerCase() === "quiet";
-      const ref     = (u.cmd.args[1] ?? "").trim();
-      const staff = isStaff(u.me.flags);
+  exec: async (u: IUrsamuSDK) => {
+    const quiet   = (u.cmd.args[0] ?? "").toLowerCase() === "quiet";
+    const ref     = (u.cmd.args[1] ?? "").trim();
+    const staff = isStaff(u.me.flags);
 
-      let targetId = u.me.id;
-      if (ref) {
-        if (!staff) return send([u.socketId ?? ""], "Permission denied.");
-        const found = (await dbojs.query({ id: ref }))[0]
-          ?? (await dbojs.query({ "data.name": ref }))[0];
-        if (!found) return send([u.socketId ?? ""], `I can't find '${ref}'.`);
-        targetId = found.id;
+    let targetId = u.me.id;
+    if (ref) {
+      if (!staff) return send([u.socketId ?? ""], "Permission denied.");
+      const found = (await dbojs.query({ id: ref }))[0]
+        ?? (await dbojs.query({ "data.name": ref }))[0];
+      if (!found) return send([u.socketId ?? ""], `I can't find '${ref}'.`);
+      targetId = found.id;
+    }
+
+    const [timeCancelled, semCancelled] = await Promise.all([
+      queue.cancelAll(targetId),
+      queue.drainSemaphore(targetId),
+    ]);
+
+    const total = timeCancelled + semCancelled;
+    if (!quiet) {
+      if (total === 0) {
+        u.send("No queued actions to drain.");
+      } else {
+        u.send(`Drained: ${timeCancelled} time-delayed, ${semCancelled} semaphore-blocked (total: ${total}).`);
       }
-
-      const [timeCancelled, semCancelled] = await Promise.all([
-        queue.cancelAll(targetId),
-        queue.drainSemaphore(targetId),
-      ]);
-
-      const total = timeCancelled + semCancelled;
-      if (!quiet) {
-        if (total === 0) {
-          u.send("No queued actions to drain.");
-        } else {
-          u.send(`Drained: ${timeCancelled} time-delayed, ${semCancelled} semaphore-blocked (total: ${total}).`);
-        }
-      }
-    },
-  });
+    }
+  },
+});

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -6,8 +6,7 @@ import { target } from "../utils/target.ts";
 import { canEdit } from "../utils/canEdit.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  addCmd({
+addCmd({
     name: "@edit",
     pattern: /^@edit\s+(.*)\/(.*)\s*=\s*(.*)\/(.*)/i,
     lock: "connected",
@@ -42,5 +41,4 @@ export default () => {
         send([u.socketId || ""], "Attribute not found.");
       }
     },
-  });
-};
+});

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -48,9 +48,7 @@ const addFormatCommand = (cmdName: string, attrName: string) => {
   });
 };
 
-export default () => {
-  addFormatCommand("@nameformat", "NAMEFORMAT");
-  addFormatCommand("@descformat", "DESCFORMAT");
-  addFormatCommand("@conformat", "CONFORMAT");
-  addFormatCommand("@exitformat", "EXITFORMAT");
-};
+addFormatCommand("@nameformat", "NAMEFORMAT");
+addFormatCommand("@descformat", "DESCFORMAT");
+addFormatCommand("@conformat", "CONFORMAT");
+addFormatCommand("@exitformat", "EXITFORMAT");

--- a/src/commands/function.ts
+++ b/src/commands/function.ts
@@ -7,13 +7,12 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
 // ── @function command ─────────────────────────────────────────────────────
 
-export default () =>
-  addCmd({
-    name: "@function",
-    pattern: /^@function(?:\/(list|remove))?\s*([^=\s]*)(?:\s*=\s*(.*))?/i,
-    lock: "connected wizard+",
-    category: "Scripting",
-    help: `@function[/list|/remove] <name>[=<code>]  — Define global softcode functions.
+addCmd({
+  name: "@function",
+  pattern: /^@function(?:\/(list|remove))?\s*([^=\s]*)(?:\s*=\s*(.*))?/i,
+  lock: "connected wizard+",
+  category: "Scripting",
+  help: `@function[/list|/remove] <name>[=<code>]  — Define global softcode functions.
 
 Switches:
   /list     List all defined functions.
@@ -26,63 +25,63 @@ Examples:
   @function double=%0 * 2
   @function/list
   @function/remove double`,
-    exec: async (u: IUrsamuSDK) => {
-      const sw   = (u.cmd.args[0] ?? "").toLowerCase();
-      const name = (u.cmd.args[1] ?? "").trim().toLowerCase();
-      const code = (u.cmd.args[2] ?? "").trim();
+  exec: async (u: IUrsamuSDK) => {
+    const sw   = (u.cmd.args[0] ?? "").toLowerCase();
+    const name = (u.cmd.args[1] ?? "").trim().toLowerCase();
+    const code = (u.cmd.args[2] ?? "").trim();
 
-      // Extra privilege check (lock may be evaluated as a string — this is authoritative).
-      // Global function registration requires wizard+ to prevent admin-level code injection.
-      if (!isWizard(u.me.flags)) { u.send("Permission denied. (wizard+ required)"); return; }
+    // Extra privilege check (lock may be evaluated as a string — this is authoritative).
+    // Global function registration requires wizard+ to prevent admin-level code injection.
+    if (!isWizard(u.me.flags)) { u.send("Permission denied. (wizard+ required)"); return; }
 
-      // ── /list ──────────────────────────────────────────────────────────
-      if (sw === "list") {
-        const all = await userFuncs.find({});
-        if (!all.length) {
-          send([u.socketId ?? ""], "No user-defined functions registered.");
-          return;
-        }
-        const lines = all.map(
-          f => `  %ch${f.name.toUpperCase()}%cn — owner #${f.ownerId}`,
-        );
-        send([u.socketId ?? ""], `%chUser Functions:%cn\r\n${lines.join("\r\n")}`);
+    // ── /list ──────────────────────────────────────────────────────────
+    if (sw === "list") {
+      const all = await userFuncs.find({});
+      if (!all.length) {
+        send([u.socketId ?? ""], "No user-defined functions registered.");
         return;
       }
+      const lines = all.map(
+        f => `  %ch${f.name.toUpperCase()}%cn — owner #${f.ownerId}`,
+      );
+      send([u.socketId ?? ""], `%chUser Functions:%cn\r\n${lines.join("\r\n")}`);
+      return;
+    }
 
-      // ── /remove ────────────────────────────────────────────────────────
-      if (sw === "remove") {
-        if (!name) { u.send("Usage: @function/remove <name>"); return; }
-        const existing = await userFuncs.findOne({ id: name });
-        if (!existing) {
-          send([u.socketId ?? ""], `Function '${name}' not found.`);
-          return;
-        }
-        await userFuncs.delete({ id: name });
-        send([u.socketId ?? ""], `Function '${name.toUpperCase()}' removed.`);
-        return;
-      }
-
-      // ── Register / update ──────────────────────────────────────────────
-      if (!name) { u.send("Usage: @function <name>=<code>"); return; }
-      if (!code) { u.send("Usage: @function <name>=<code>"); return; }
-
-      // Validate: function names must be alphanumeric + underscore, no spaces.
-      if (!/^[a-z_][a-z0-9_]*$/.test(name)) {
-        u.send("Function name must start with a letter and contain only letters, digits, and underscores.");
-        return;
-      }
-
+    // ── /remove ────────────────────────────────────────────────────────
+    if (sw === "remove") {
+      if (!name) { u.send("Usage: @function/remove <name>"); return; }
       const existing = await userFuncs.findOne({ id: name });
-      if (existing) {
-        await userFuncs.modify(
-          { id: name },
-          "$set",
-          { code, ownerId: u.me.id } as Partial<IUserFunc>,
-        );
-        send([u.socketId ?? ""], `Function '${name.toUpperCase()}' updated.`);
-      } else {
-        await userFuncs.create({ id: name, name, code, ownerId: u.me.id });
-        send([u.socketId ?? ""], `Function '${name.toUpperCase()}' registered.`);
+      if (!existing) {
+        send([u.socketId ?? ""], `Function '${name}' not found.`);
+        return;
       }
-    },
-  });
+      await userFuncs.delete({ id: name });
+      send([u.socketId ?? ""], `Function '${name.toUpperCase()}' removed.`);
+      return;
+    }
+
+    // ── Register / update ──────────────────────────────────────────────
+    if (!name) { u.send("Usage: @function <name>=<code>"); return; }
+    if (!code) { u.send("Usage: @function <name>=<code>"); return; }
+
+    // Validate: function names must be alphanumeric + underscore, no spaces.
+    if (!/^[a-z_][a-z0-9_]*$/.test(name)) {
+      u.send("Function name must start with a letter and contain only letters, digits, and underscores.");
+      return;
+    }
+
+    const existing = await userFuncs.findOne({ id: name });
+    if (existing) {
+      await userFuncs.modify(
+        { id: name },
+        "$set",
+        { code, ownerId: u.me.id } as Partial<IUserFunc>,
+      );
+      send([u.socketId ?? ""], `Function '${name.toUpperCase()}' updated.`);
+    } else {
+      await userFuncs.create({ id: name, name, code, ownerId: u.me.id });
+      send([u.socketId ?? ""], `Function '${name.toUpperCase()}' registered.`);
+    }
+  },
+});

--- a/src/commands/grep.ts
+++ b/src/commands/grep.ts
@@ -45,13 +45,12 @@ async function collectWithParents(
   return results;
 }
 
-export default () =>
-  addCmd({
-    name: "@grep",
-    pattern: /^@grep(?:\/(\S+))?\s+(.*)/i,
-    lock: "connected",
-    category: "Building",
-    help: `@grep[/<switches>] <object>=<attrglob>,<string>
+addCmd({
+  name: "@grep",
+  pattern: /^@grep(?:\/(\S+))?\s+(.*)/i,
+  lock: "connected",
+  category: "Building",
+  help: `@grep[/<switches>] <object>=<attrglob>,<string>
 
 Search the attributes of <object> whose names match <attrglob> for <string>.
 Wildcards (* and ?) are allowed in <attrglob>. Outputs matching attr names.
@@ -66,67 +65,67 @@ Examples:
   @grep box=DESC*,sword       Find DESC* attrs on box containing "sword".
   @grep/regexp me=*,^say      Find attrs on me whose value starts with "say".
   @grep/parent me=*,attack    Search me and all parents for "attack".`,
-    exec: async (u: IUrsamuSDK) => {
-      const swRaw = (u.cmd.args[0] ?? "").toLowerCase();
-      const rest  = (u.cmd.args[1] ?? "").trim();
+  exec: async (u: IUrsamuSDK) => {
+    const swRaw = (u.cmd.args[0] ?? "").toLowerCase();
+    const rest  = (u.cmd.args[1] ?? "").trim();
 
-      const doQuiet  = swRaw.includes("quiet");
-      const doRegexp = swRaw.includes("regexp");
-      const doParent = swRaw.includes("parent");
+    const doQuiet  = swRaw.includes("quiet");
+    const doRegexp = swRaw.includes("regexp");
+    const doParent = swRaw.includes("parent");
 
-      const eqIdx = rest.indexOf("=");
-      if (eqIdx === -1) return u.send("Usage: @grep[/switches] <object>=<attrglob>,<string>");
+    const eqIdx = rest.indexOf("=");
+    if (eqIdx === -1) return u.send("Usage: @grep[/switches] <object>=<attrglob>,<string>");
 
-      const objRef    = rest.slice(0, eqIdx).trim();
-      const afterEq   = rest.slice(eqIdx + 1);
-      const commaIdx  = afterEq.indexOf(",");
-      if (commaIdx === -1) return u.send("Usage: @grep[/switches] <object>=<attrglob>,<string>");
+    const objRef    = rest.slice(0, eqIdx).trim();
+    const afterEq   = rest.slice(eqIdx + 1);
+    const commaIdx  = afterEq.indexOf(",");
+    if (commaIdx === -1) return u.send("Usage: @grep[/switches] <object>=<attrglob>,<string>");
 
-      const attrGlob  = afterEq.slice(0, commaIdx).trim() || "*";
-      const searchStr = afterEq.slice(commaIdx + 1);
-      if (!searchStr) return u.send("Search string cannot be empty.");
+    const attrGlob  = afterEq.slice(0, commaIdx).trim() || "*";
+    const searchStr = afterEq.slice(commaIdx + 1);
+    if (!searchStr) return u.send("Search string cannot be empty.");
 
-      const en = await dbojs.queryOne({ id: u.me.id });
-      if (!en) return;
+    const en = await dbojs.queryOne({ id: u.me.id });
+    if (!en) return;
 
-      const result = await target(en as unknown as IDBOBJ, objRef);
-      if (!result) return send([u.socketId ?? ""], `I can't find '${objRef}'.`);
-      if (!await canEdit(en as unknown as IDBOBJ, result)) return u.send("Permission denied.");
+    const result = await target(en as unknown as IDBOBJ, objRef);
+    if (!result) return send([u.socketId ?? ""], `I can't find '${objRef}'.`);
+    if (!await canEdit(en as unknown as IDBOBJ, result)) return u.send("Permission denied.");
 
-      const obj = await Obj.get(result.id);
-      if (!obj) return u.send("Object not found.");
+    const obj = await Obj.get(result.id);
+    if (!obj) return u.send("Object not found.");
 
-      // Build matchers — compile once for efficiency
-      const attrRe   = globToRegex(attrGlob);
-      let valueRe: RegExp;
-      try {
-        if (doRegexp) {
-          if (isReDoSProne(searchStr)) {
-            return u.send(`Unsafe regular expression (nested quantifiers or excessive length): ${searchStr}`);
-          }
-          valueRe = new RegExp(searchStr, "i");
-        } else {
-          valueRe = new RegExp(searchStr.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+    // Build matchers — compile once for efficiency
+    const attrRe   = globToRegex(attrGlob);
+    let valueRe: RegExp;
+    try {
+      if (doRegexp) {
+        if (isReDoSProne(searchStr)) {
+          return u.send(`Unsafe regular expression (nested quantifiers or excessive length): ${searchStr}`);
         }
-      } catch {
-        return u.send(`Invalid regular expression: ${searchStr}`);
+        valueRe = new RegExp(searchStr, "i");
+      } else {
+        valueRe = new RegExp(searchStr.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
       }
+    } catch {
+      return u.send(`Invalid regular expression: ${searchStr}`);
+    }
 
-      const sources = doParent ? await collectWithParents(obj) : [{ objName: obj.name ?? obj.id, objId: obj.id, attrs: (obj.data?.attributes as IAttribute[] | undefined) ?? [] }];
+    const sources = doParent ? await collectWithParents(obj) : [{ objName: obj.name ?? obj.id, objId: obj.id, attrs: (obj.data?.attributes as IAttribute[] | undefined) ?? [] }];
 
-      let found = 0;
-      for (const { objName, objId, attrs } of sources) {
-        const header = doParent ? `${objName}(#${objId})` : null;
-        const hits = attrs.filter(a => attrRe.test(a.name) && valueRe.test(a.value));
-        if (hits.length === 0) continue;
-        if (header) u.send(`%ch${header}:%cn`);
-        for (const a of hits) {
-          u.send(`  ${a.name.toUpperCase()}`);
-          found++;
-        }
+    let found = 0;
+    for (const { objName, objId, attrs } of sources) {
+      const header = doParent ? `${objName}(#${objId})` : null;
+      const hits = attrs.filter(a => attrRe.test(a.name) && valueRe.test(a.value));
+      if (hits.length === 0) continue;
+      if (header) u.send(`%ch${header}:%cn`);
+      for (const a of hits) {
+        u.send(`  ${a.name.toUpperCase()}`);
+        found++;
       }
+    }
 
-      if (found === 0) u.send(`No matching attributes found.`);
-      if (!doQuiet) u.send("Grep: Done.");
-    },
-  });
+    if (found === 0) u.send(`No matching attributes found.`);
+    if (!doQuiet) u.send("Grep: Done.");
+  },
+});

--- a/src/commands/halt.ts
+++ b/src/commands/halt.ts
@@ -5,8 +5,7 @@ import { send } from "../services/broadcast/index.ts";
 import { dbojs } from "../services/Database/index.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  addCmd({
+addCmd({
     name: "@halt",
     pattern: /^@halt(?:\s+(.+))?$/i,
     lock: "connected",
@@ -30,5 +29,4 @@ export default () => {
         send([u.socketId || ""], `Halted ${count} queued action${count === 1 ? "" : "s"}.`);
       }
     },
-  });
-};
+});

--- a/src/commands/home.ts
+++ b/src/commands/home.ts
@@ -23,31 +23,29 @@ export function execInventory(u: IUrsamuSDK): void {
   u.send(telnet);
 }
 
-export default () => {
-  addCmd({
-    name: "home",
-    pattern: /^home$/i,
-    lock: "connected",
-    category: "Navigation",
-    help: `home  — Go to your home location.
+addCmd({
+  name: "home",
+  pattern: /^home$/i,
+  lock: "connected",
+  category: "Navigation",
+  help: `home  — Go to your home location.
 
 Examples:
   home`,
-    exec: execHome,
-  });
+  exec: execHome,
+});
 
-  addCmd({
-    name: "inventory",
-    pattern: /^(?:inventory|inv|i)$/i,
-    lock: "connected",
-    category: "Information",
-    help: `inventory  — List what you are carrying.
+addCmd({
+  name: "inventory",
+  pattern: /^(?:inventory|inv|i)$/i,
+  lock: "connected",
+  category: "Information",
+  help: `inventory  — List what you are carrying.
 
 Aliases: inv, i
 
 Examples:
   inventory
   inv`,
-    exec: execInventory,
-  });
-};
+  exec: execInventory,
+});

--- a/src/commands/include.ts
+++ b/src/commands/include.ts
@@ -14,8 +14,7 @@ const SYSTEM_ATTRS = new Set([
   "quota", "money", "channels",
 ]);
 
-export default () =>
-  addCmd({
+addCmd({
     name: "@include",
     pattern: /^@include\s+([^=]+)=([^/\r\n]+)(?:\/(.+))?/i,
     lock: "connected builder+",

--- a/src/commands/lock.ts
+++ b/src/commands/lock.ts
@@ -7,73 +7,71 @@ import { validateLock } from "../utils/evaluateLock.ts";
 import { target } from "../utils/target.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  addCmd({
-    name: "@lock",
-    pattern: /^[@\+]?lock(?:\/(\w+))?\s+([^=]+)\s*=\s*(.*)/i,
-    lock: "connected & builder+",
-    exec: async (u: IUrsamuSDK) => {
-      const [swtch, obj, key] = u.cmd.args;
-      const en = await Obj.get(u.me.id);
-      if (!en) return;
+addCmd({
+  name: "@lock",
+  pattern: /^[@\+]?lock(?:\/(\w+))?\s+([^=]+)\s*=\s*(.*)/i,
+  lock: "connected & builder+",
+  exec: async (u: IUrsamuSDK) => {
+    const [swtch, obj, key] = u.cmd.args;
+    const en = await Obj.get(u.me.id);
+    if (!en) return;
 
-      const targ = await target(en.dbobj, obj?.trim());
-      if (!targ) return send([u.socketId || ""], "You can't lock that.");
-      const tar = new Obj(targ);
+    const targ = await target(en.dbobj, obj?.trim());
+    if (!targ) return send([u.socketId || ""], "You can't lock that.");
+    const tar = new Obj(targ);
 
-      if (!await canEdit(en.dbobj, tar.dbobj)) {
-        return send([u.socketId || ""], "You can't lock that.");
+    if (!await canEdit(en.dbobj, tar.dbobj)) {
+      return send([u.socketId || ""], "You can't lock that.");
+    }
+    if (!await validateLock(key)) {
+      return send([u.socketId || ""], "Invalid lock string.");
+    }
+
+    tar.dbobj.data ||= {};
+    if (swtch) {
+      tar.dbobj.data.locks ||= {};
+      (tar.dbobj.data.locks as Record<string, string>)[swtch.toLowerCase()] = key;
+      send(
+        [u.socketId || ""],
+        `You lock ${displayName(en.dbobj, tar.dbobj, true)} (${swtch.toLowerCase()}).`
+      );
+    } else {
+      tar.dbobj.data.lock = key;
+      send([u.socketId || ""], `You lock ${displayName(en.dbobj, tar.dbobj, true)}.`);
+    }
+    await tar.save();
+  },
+});
+
+addCmd({
+  name: "@unlock",
+  pattern: /^[@\+]?unlock(?:\/(\w+))?\s+(.*)/i,
+  lock: "connected & builder+",
+  exec: async (u: IUrsamuSDK) => {
+    const [swtch, obj] = u.cmd.args;
+    const en = await Obj.get(u.me.id);
+    if (!en) return;
+    const targ = await target(en.dbobj, obj?.trim());
+    if (!targ) return send([u.socketId || ""], "You can't unlock that.");
+    const tar = new Obj(targ);
+
+    if (!await canEdit(en.dbobj, tar.dbobj)) {
+      return send([u.socketId || ""], "You can't unlock that.");
+    }
+
+    tar.dbobj.data ||= {};
+    if (swtch) {
+      if (tar.dbobj.data.locks) {
+        delete (tar.dbobj.data.locks as Record<string, string>)[swtch.toLowerCase()];
       }
-      if (!await validateLock(key)) {
-        return send([u.socketId || ""], "Invalid lock string.");
-      }
-
-      tar.dbobj.data ||= {};
-      if (swtch) {
-        tar.dbobj.data.locks ||= {};
-        (tar.dbobj.data.locks as Record<string, string>)[swtch.toLowerCase()] = key;
-        send(
-          [u.socketId || ""],
-          `You lock ${displayName(en.dbobj, tar.dbobj, true)} (${swtch.toLowerCase()}).`
-        );
-      } else {
-        tar.dbobj.data.lock = key;
-        send([u.socketId || ""], `You lock ${displayName(en.dbobj, tar.dbobj, true)}.`);
-      }
-      await tar.save();
-    },
-  });
-
-  addCmd({
-    name: "@unlock",
-    pattern: /^[@\+]?unlock(?:\/(\w+))?\s+(.*)/i,
-    lock: "connected & builder+",
-    exec: async (u: IUrsamuSDK) => {
-      const [swtch, obj] = u.cmd.args;
-      const en = await Obj.get(u.me.id);
-      if (!en) return;
-      const targ = await target(en.dbobj, obj?.trim());
-      if (!targ) return send([u.socketId || ""], "You can't unlock that.");
-      const tar = new Obj(targ);
-
-      if (!await canEdit(en.dbobj, tar.dbobj)) {
-        return send([u.socketId || ""], "You can't unlock that.");
-      }
-
-      tar.dbobj.data ||= {};
-      if (swtch) {
-        if (tar.dbobj.data.locks) {
-          delete (tar.dbobj.data.locks as Record<string, string>)[swtch.toLowerCase()];
-        }
-        send(
-          [u.socketId || ""],
-          `You unlock ${displayName(en.dbobj, tar.dbobj, true)} (${swtch.toLowerCase()}).`
-        );
-      } else {
-        tar.dbobj.data.lock = "";
-        send([u.socketId || ""], `You unlock ${displayName(en.dbobj, tar.dbobj, true)}.`);
-      }
-      await tar.save();
-    },
-  });
-};
+      send(
+        [u.socketId || ""],
+        `You unlock ${displayName(en.dbobj, tar.dbobj, true)} (${swtch.toLowerCase()}).`
+      );
+    } else {
+      tar.dbobj.data.lock = "";
+      send([u.socketId || ""], `You unlock ${displayName(en.dbobj, tar.dbobj, true)}.`);
+    }
+    await tar.save();
+  },
+});

--- a/src/commands/look.ts
+++ b/src/commands/look.ts
@@ -104,13 +104,12 @@ export async function execLook(u: IUrsamuSDK): Promise<void> {
   }
 }
 
-export default () => {
-  addCmd({
-    name: "look",
-    pattern: /^(?:look|l)(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Navigation",
-    help: `look [<object>]  — Look at your surroundings, or examine a specific object.
+addCmd({
+  name: "look",
+  pattern: /^(?:look|l)(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Navigation",
+  help: `look [<object>]  — Look at your surroundings, or examine a specific object.
 
 Without an argument, looks at the room you are in.
 Aliases: l
@@ -119,6 +118,5 @@ Examples:
   look
   look sword
   look Alice`,
-    exec: execLook,
-  });
-};
+  exec: execLook,
+});

--- a/src/commands/manipulation.ts
+++ b/src/commands/manipulation.ts
@@ -142,43 +142,41 @@ export async function execCreateObject(u: IUrsamuSDK): Promise<void> {
   u.send(`You create ${objName} (#${thing.id}).`);
 }
 
-export default () => {
-  addCmd({
-    name: "get",
-    pattern: /^get\s+(.*)/i,
-    lock: "connected",
-    category: "Object",
-    help: `get <object>  — Pick up an object from the room.
+addCmd({
+  name: "get",
+  pattern: /^get\s+(.*)/i,
+  lock: "connected",
+  category: "Object",
+  help: `get <object>  — Pick up an object from the room.
 
 Examples:
   get sword
   get #5`,
-    exec: execGet,
-  });
+  exec: execGet,
+});
 
-  addCmd({
-    name: "drop",
-    pattern: /^drop\s+(.*)/i,
-    lock: "connected",
-    category: "Object",
-    help: `drop <object>  — Drop an object from your inventory.
+addCmd({
+  name: "drop",
+  pattern: /^drop\s+(.*)/i,
+  lock: "connected",
+  category: "Object",
+  help: `drop <object>  — Drop an object from your inventory.
 
 Examples:
   drop sword`,
-    exec: execDrop,
-  });
+  exec: execDrop,
+});
 
-  addCmd({
-    name: "give",
-    pattern: /^give\s+(.+)\s*=\s*(.*)/i,
-    lock: "connected",
-    category: "Object",
-    help: `give <item>=<player>    — Give an item to a player.
+addCmd({
+  name: "give",
+  pattern: /^give\s+(.+)\s*=\s*(.*)/i,
+  lock: "connected",
+  category: "Object",
+  help: `give <item>=<player>    — Give an item to a player.
 give <amount>=<player>  — Give coins to a player.
 
 Examples:
   give sword=Alice
   give 50=Bob`,
-    exec: execGive,
-  });
-};
+  exec: execGive,
+});

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -6,57 +6,55 @@ import { target } from "../utils/target.ts";
 import { displayName } from "../utils/displayName.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  const messages = [
-    { name: "@succ", attr: "success", help: "Set the success message for an object" },
-    { name: "@osucc", attr: "osuccess", help: "Set the outer success message for an object" },
-    { name: "@fail", attr: "fail", help: "Set the failure message for an object" },
-    { name: "@ofail", attr: "ofail", help: "Set the outer failure message for an object" },
-    { name: "@drop", attr: "drop", help: "Set the drop message for an object" },
-    { name: "@odrop", attr: "odrop", help: "Set the outer drop message for an object" },
-  ];
+const messages = [
+  { name: "@succ", attr: "success", help: "Set the success message for an object" },
+  { name: "@osucc", attr: "osuccess", help: "Set the outer success message for an object" },
+  { name: "@fail", attr: "fail", help: "Set the failure message for an object" },
+  { name: "@ofail", attr: "ofail", help: "Set the outer failure message for an object" },
+  { name: "@drop", attr: "drop", help: "Set the drop message for an object" },
+  { name: "@odrop", attr: "odrop", help: "Set the outer drop message for an object" },
+];
 
-  messages.forEach((msg) => {
-    addCmd({
-      name: msg.name,
-      pattern: new RegExp(`^${msg.name}\\s+(.*)\\s*=\\s*(.*)?$`, "i"),
-      lock: "connected & builder+",
-      help: msg.help,
-      category: "building",
-      exec: async (u: IUrsamuSDK) => {
-        const [obj, message] = u.cmd.args;
-        const en = await Obj.get(u.me.id);
-        if (!en) return;
+messages.forEach((msg) => {
+  addCmd({
+    name: msg.name,
+    pattern: new RegExp(`^${msg.name}\\s+(.*)\\s*=\\s*(.*)?$`, "i"),
+    lock: "connected & builder+",
+    help: msg.help,
+    category: "building",
+    exec: async (u: IUrsamuSDK) => {
+      const [obj, message] = u.cmd.args;
+      const en = await Obj.get(u.me.id);
+      if (!en) return;
 
-        const tar = await target(en.dbobj, obj?.trim(), true);
-        if (!tar) return send([u.socketId || ""], "I don't see that here.");
+      const tar = await target(en.dbobj, obj?.trim(), true);
+      if (!tar) return send([u.socketId || ""], "I don't see that here.");
 
-        const tarObj = await Obj.get(tar.id);
-        if (!tarObj?.dbobj) return send([u.socketId || ""], "I don't see that here.");
+      const tarObj = await Obj.get(tar.id);
+      if (!tarObj?.dbobj) return send([u.socketId || ""], "I don't see that here.");
 
-        if (await canEdit(en.dbobj, tarObj.dbobj)) {
-          tarObj.dbobj.data ||= {};
+      if (await canEdit(en.dbobj, tarObj.dbobj)) {
+        tarObj.dbobj.data ||= {};
 
-          if (!message) {
-            if (!tarObj.dbobj.data) { await tarObj.save(); return; }
-            delete tarObj.dbobj.data[msg.attr];
-            await tarObj.save();
-            return send(
-              [u.socketId || ""],
-              `${msg.name} cleared on ${displayName(en.dbobj, tarObj.dbobj, true)}.`
-            );
-          }
-
-          tarObj.dbobj.data[msg.attr] = message;
+        if (!message) {
+          if (!tarObj.dbobj.data) { await tarObj.save(); return; }
+          delete tarObj.dbobj.data[msg.attr];
           await tarObj.save();
-          send(
+          return send(
             [u.socketId || ""],
-            `${msg.name} set on ${displayName(en.dbobj, tarObj.dbobj, true)}.`
+            `${msg.name} cleared on ${displayName(en.dbobj, tarObj.dbobj, true)}.`
           );
-        } else {
-          send([u.socketId || ""], "Permission denied.");
         }
-      },
-    });
+
+        tarObj.dbobj.data[msg.attr] = message;
+        await tarObj.save();
+        send(
+          [u.socketId || ""],
+          `${msg.name} set on ${displayName(en.dbobj, tarObj.dbobj, true)}.`
+        );
+      } else {
+        send([u.socketId || ""], "Permission denied.");
+      }
+    },
   });
-};
+});

--- a/src/commands/moniker.ts
+++ b/src/commands/moniker.ts
@@ -24,8 +24,7 @@ export async function execMoniker(u: IUrsamuSDK): Promise<void> {
   u.send(`Set moniker for ${tar.name} to ${moniker.trim()}.`);
 }
 
-export default () =>
-  addCmd({
+addCmd({
     name: "@moniker",
     pattern: /^[@+]?moniker\s+(.*)/i,
     lock: "connected & admin+",

--- a/src/commands/mvattr.ts
+++ b/src/commands/mvattr.ts
@@ -7,8 +7,7 @@ import type { IAttribute } from "../@types/IAttribute.ts";
 import type { IDBOBJ } from "../@types/IDBObj.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "@mvattr",
     pattern: /^@mvattr\s+(.+?)=(.+)/i,
     lock: "connected",

--- a/src/commands/name.ts
+++ b/src/commands/name.ts
@@ -5,31 +5,29 @@ import { target } from "../utils/target.ts";
 import { isNameTaken } from "../utils/isNameTaken.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () => {
-  addCmd({
-    name: "name",
-    pattern: /^[@/+]?name\s+(.*)\s*=\s*(.*)/i,
-    lock: "connected",
-    exec: async (u: IUrsamuSDK) => {
-      const en = await dbojs.queryOne({ id: u.me.id });
-      if (!en) return;
+addCmd({
+  name: "name",
+  pattern: /^[@/+]?name\s+(.*)\s*=\s*(.*)/i,
+  lock: "connected",
+  exec: async (u: IUrsamuSDK) => {
+    const en = await dbojs.queryOne({ id: u.me.id });
+    if (!en) return;
 
-      const [name, newName] = u.cmd.args;
-      const potential = await isNameTaken(newName?.trim());
-      const tar = await target(en, name?.trim(), true);
-      if (!tar) return u.send("I can't find that.");
-      if (!await canEdit(en, tar)) return u.send("I can't find that.");
-      if (
-        potential &&
-        newName.toLowerCase() !== String(tar.data?.name || "").toLowerCase()
-      )
-        return u.send("That name or alias is already taken.");
+    const [name, newName] = u.cmd.args;
+    const potential = await isNameTaken(newName?.trim());
+    const tar = await target(en, name?.trim(), true);
+    if (!tar) return u.send("I can't find that.");
+    if (!await canEdit(en, tar)) return u.send("I can't find that.");
+    if (
+      potential &&
+      newName.toLowerCase() !== String(tar.data?.name || "").toLowerCase()
+    )
+      return u.send("That name or alias is already taken.");
 
-      tar.data ||= {};
-      tar.data.name = newName;
-      delete tar.data.moniker;
-      await dbojs.modify({ id: tar.id }, "$set", tar);
-      u.send("Name set.");
-    },
-  });
-};
+    tar.data ||= {};
+    tar.data.name = newName;
+    delete tar.data.moniker;
+    await dbojs.modify({ id: tar.id }, "$set", tar);
+    u.send("Name set.");
+  },
+});

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -9,8 +9,7 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
  * @notify — release semaphore-blocked commands for an object.
  * If no blocked commands exist, stores a pre-notify (future @wait fires immediately).
  */
-export default () =>
-  addCmd({
+addCmd({
     name: "@notify",
     pattern: /^@notify(?:\/([\w]+))?\s*(.*?)(?:=(\d+))?$/i,
     lock: "connected",

--- a/src/commands/nuke.ts
+++ b/src/commands/nuke.ts
@@ -6,8 +6,7 @@ import { send } from "../services/broadcast/index.ts";
 import { broadcast } from "../services/broadcast/index.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "nuke",
     pattern: /^@nuke(?:\s+(.*))?$/i,
     lock: "superuser",

--- a/src/commands/ps.ts
+++ b/src/commands/ps.ts
@@ -98,8 +98,7 @@ export async function execPs(u: IUrsamuSDK): Promise<void> {
  * @ps — list queued processes on the time-delay and semaphore queues.
  * Switches: /brief (default), /long, /summary, /all
  */
-export default () =>
-  addCmd({
+addCmd({
     name: "@ps",
     pattern: /^@ps(?:\/([\w]+))?\s*(.*)?/i,
     lock: "connected",

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -13,8 +13,7 @@ export function setLoadedPlugins(plugins: import("../@types/IPlugin.ts").IPlugin
   _loadedPlugins = plugins;
 }
 
-export default () =>
-  addCmd({
+addCmd({
     name: "reload",
     pattern: /^@reload(?:\/(\S+))?(?:\s+(.*))?$/i,
     lock: "connected & admin+",

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -8,8 +8,7 @@ export async function execReboot(u: IUrsamuSDK): Promise<void> {
   await u.sys.reboot();
 }
 
-export default () =>
-  addCmd({
+addCmd({
     name: "reboot",
     pattern: /^@reboot|^@restart/i,
     lock: "connected & admin+",

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -5,74 +5,72 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
 const escRx = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-export default () => {
-  addCmd({
-    name: "@search",
-    pattern: /^@search\s+(.*)/i,
-    lock: "connected & builder+",
-    help: "Search for objects",
-    category: "admin",
-    exec: async (u: IUrsamuSDK) => {
-      const query = u.cmd.args[0];
-      const parts = query.split("=");
-      let search = {};
+addCmd({
+  name: "@search",
+  pattern: /^@search\s+(.*)/i,
+  lock: "connected & builder+",
+  help: "Search for objects",
+  category: "admin",
+  exec: async (u: IUrsamuSDK) => {
+    const query = u.cmd.args[0];
+    const parts = query.split("=");
+    let search = {};
 
-      if (parts.length > 1) {
-        const [key, val] = parts;
-        if (key.trim() === "name") {
-          search = { "data.name": new RegExp(escRx(val.trim()), "i") };
-        } else if (key.trim() === "flag" || key.trim() === "flags") {
-          search = { flags: new RegExp(escRx(val.trim()), "i") };
-        } else if (key.trim() === "owner") {
-          const ownerObj = await dbojs.queryOne({
-            "data.name": new RegExp(`^${escRx(val.trim())}$`, "i"),
-            flags: /player/i,
-          });
-          if (ownerObj) {
-            search = { "data.owner": ownerObj.id };
-          } else {
-            return u.send("Owner not found.");
-          }
+    if (parts.length > 1) {
+      const [key, val] = parts;
+      if (key.trim() === "name") {
+        search = { "data.name": new RegExp(escRx(val.trim()), "i") };
+      } else if (key.trim() === "flag" || key.trim() === "flags") {
+        search = { flags: new RegExp(escRx(val.trim()), "i") };
+      } else if (key.trim() === "owner") {
+        const ownerObj = await dbojs.queryOne({
+          "data.name": new RegExp(`^${escRx(val.trim())}$`, "i"),
+          flags: /player/i,
+        });
+        if (ownerObj) {
+          search = { "data.owner": ownerObj.id };
         } else {
-          return u.send("Invalid search parameter. Use name=..., flags=..., or owner=...");
+          return u.send("Owner not found.");
         }
       } else {
-        search = { "data.name": new RegExp(escRx(query.trim()), "i") };
+        return u.send("Invalid search parameter. Use name=..., flags=..., or owner=...");
       }
+    } else {
+      search = { "data.name": new RegExp(escRx(query.trim()), "i") };
+    }
 
-      const results = await dbojs.query(search);
-      if (!results.length) return u.send("No matches found.");
+    const results = await dbojs.query(search);
+    if (!results.length) return u.send("No matches found.");
 
-      const list = results.map((r) => `${r.data?.name}(#${r.id})`);
-      u.send(center(" Search Results ", 78, "="));
-      u.send(columns(list, 80, 4));
-      u.send(center("", 78, "="));
-    },
-  });
+    const list = results.map((r) => `${r.data?.name}(#${r.id})`);
+    u.send(center(" Search Results ", 78, "="));
+    u.send(columns(list, 80, 4));
+    u.send(center("", 78, "="));
+  },
+});
 
-  addCmd({
-    name: "@stats",
-    pattern: /^@stats$/i,
-    lock: "connected",
-    help: "Show server statistics",
-    category: "info",
-    exec: async (u: IUrsamuSDK) => {
-      const [allObjs, players, rooms, exits] = await Promise.all([
-        dbojs.all(),
-        dbojs.query({ flags: /player/i }),
-        dbojs.query({ flags: /room/i }),
-        dbojs.query({ flags: /exit/i }),
-      ]);
-      const total = allObjs.length;
-      const calcThings = total - players.length - rooms.length - exits.length;
+addCmd({
+  name: "@stats",
+  pattern: /^@stats$/i,
+  lock: "connected",
+  help: "Show server statistics",
+  category: "info",
+  exec: async (u: IUrsamuSDK) => {
+    const [allObjs, players, rooms, exits] = await Promise.all([
+      dbojs.all(),
+      dbojs.query({ flags: /player/i }),
+      dbojs.query({ flags: /room/i }),
+      dbojs.query({ flags: /exit/i }),
+    ]);
+    const total = allObjs.length;
+    const calcThings = total - players.length - rooms.length - exits.length;
 
-      u.send(center(" Server Statistics ", 78, "="));
-      u.send(`Total Objects: ${total}`);
-      u.send(`Rooms: ${rooms.length}`);
-      u.send(`Exits: ${exits.length}`);
-      u.send(`Things: ${calcThings}`);
-      u.send(`Players: ${players.length}`);
-      u.send(center("", 78, "="));
-    },
-  });
-};
+    u.send(center(" Server Statistics ", 78, "="));
+    u.send(`Total Objects: ${total}`);
+    u.send(`Rooms: ${rooms.length}`);
+    u.send(`Exits: ${exits.length}`);
+    u.send(`Things: ${calcThings}`);
+    u.send(`Players: ${players.length}`);
+    u.send(center("", 78, "="));
+  },
+});

--- a/src/commands/social.ts
+++ b/src/commands/social.ts
@@ -116,13 +116,12 @@ export async function execLast(u: IUrsamuSDK): Promise<void> {
   u.send(`Status:       ${target.flags.has("connected") ? "%chOnline%cn" : "Offline"}`);
 }
 
-export default () => {
-  addCmd({
-    name: "who",
-    pattern: /^who$/i,
-    lock: "",
-    category: "Information",
-    help: `who  — List all connected players.
+addCmd({
+  name: "who",
+  pattern: /^who$/i,
+  lock: "",
+  category: "Information",
+  help: `who  — List all connected players.
 
 Override hooks (attr on #0 first, else enactor):
   @whoformat     Replaces the entire WHO block; %0 = default block.
@@ -130,57 +129,57 @@ Override hooks (attr on #0 first, else enactor):
 
 Examples:
   who`,
-    exec: execWho,
-  });
+  exec: execWho,
+});
 
-  addCmd({
-    name: "score",
-    pattern: /^score$/i,
-    lock: "connected",
-    category: "Information",
-    help: `score  — Display your character scorecard.
+addCmd({
+  name: "score",
+  pattern: /^score$/i,
+  lock: "connected",
+  category: "Information",
+  help: `score  — Display your character scorecard.
 
 Examples:
   score`,
-    exec: execScore,
-  });
+  exec: execScore,
+});
 
-  addCmd({
-    name: "@doing",
-    pattern: /^@doing(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Information",
-    help: `@doing [<message>]  — Set or clear your WHO-list description.
+addCmd({
+  name: "@doing",
+  pattern: /^@doing(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Information",
+  help: `@doing [<message>]  — Set or clear your WHO-list description.
 
 Without a message, clears your doing.
 
 Examples:
   @doing Adventuring in the Shadowlands
   @doing`,
-    exec: execDoing,
-  });
+  exec: execDoing,
+});
 
-  addCmd({
-    name: "@poll",
-    pattern: /^@poll(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Information",
-    help: `@poll [<message>]  — Set or clear your WHO-list doing blurb.
+addCmd({
+  name: "@poll",
+  pattern: /^@poll(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Information",
+  help: `@poll [<message>]  — Set or clear your WHO-list doing blurb.
 
 @poll is like @doing but without the room announcement.
 
 Examples:
   @poll Exploring the northern ruins
   @poll`,
-    exec: execPoll,
-  });
+  exec: execPoll,
+});
 
-  addCmd({
-    name: "@away",
-    pattern: /^@away(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Communication",
-    help: `@away [<message>]  — Set or clear your away message.
+addCmd({
+  name: "@away",
+  pattern: /^@away(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Communication",
+  help: `@away [<message>]  — Set or clear your away message.
 
 When someone pages you while an away message is set, they see the message
 in addition to receiving the page.
@@ -188,15 +187,15 @@ in addition to receiving the page.
 Examples:
   @away At dinner, back in 30 min.
   @away`,
-    exec: execAway,
-  });
+  exec: execAway,
+});
 
-  addCmd({
-    name: "@last",
-    pattern: /^@last(?:\s+(.*))?$/i,
-    lock: "connected",
-    category: "Information",
-    help: `@last [<player>]  — Show last login/logout times.
+addCmd({
+  name: "@last",
+  pattern: /^@last(?:\s+(.*))?$/i,
+  lock: "connected",
+  category: "Information",
+  help: `@last [<player>]  — Show last login/logout times.
 
 Without an argument, shows your own times.
 Admin/wizard can look up any player.
@@ -204,6 +203,5 @@ Admin/wizard can look up any player.
 Examples:
   @last
   @last Alice`,
-    exec: execLast,
-  });
-};
+  exec: execLast,
+});

--- a/src/commands/tags.ts
+++ b/src/commands/tags.ts
@@ -4,9 +4,8 @@ import { playerTags, serverTags } from "../services/Database/index.ts";
 
 const MAX_TAGS = 50;
 
-export default () => {
-  // @ltag — personal object tags
-  addCmd({
+// @ltag — personal object tags
+addCmd({
     name: "@ltag",
     pattern: /^@?ltag(?:\/(remove|list))?\s*(.*)?$/i,
     lock: "connected",
@@ -91,8 +90,8 @@ Examples:
     },
   });
 
-  // @tag — global server tags (wizard+)
-  addCmd({
+// @tag — global server tags (wizard+)
+addCmd({
     name: "@tag",
     pattern: /^@?tag(?:\/(remove))?\s*(.*)?$/i,
     lock: "connected admin+",
@@ -160,4 +159,3 @@ Examples:
       }
     },
   });
-};

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -9,8 +9,7 @@ import { evaluateLock, hydrate } from "../utils/evaluateLock.ts";
 import { Obj } from "../services/DBObjs/DBObjs.ts";
 import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "test",
     pattern: /^@test(?:\s+(.*))?$/i,
     lock: "superuser",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,8 +1,7 @@
 import { addCmd } from "../services/commands/index.ts";
 import { send } from "../services/broadcast/index.ts";
 
-export default () =>
-  addCmd({
+addCmd({
     name: "@version",
     pattern: /^@version$/i,
     lock: "connected",

--- a/src/commands/zone.ts
+++ b/src/commands/zone.ts
@@ -15,8 +15,7 @@ import type { IUrsamuSDK } from "../@types/UrsamuSDK.ts";
  *   - zoneMemberships DBO: { id: "${zmId}:${memberId}", zmId, memberId }
  *   - Indexed by both zmId and memberId for O(1) lookups in both directions.
  */
-export default () =>
-  addCmd({
+addCmd({
     name: "@zone",
     pattern: /^@zone(?:\/([\w]+))?\s+(.+?)(?:=(.+))?$/i,
     lock: "connected",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
  * @module ursamu-core
  * @description The core engine initialization and management module.
  */
+import "dotenv/load";
 import { handleRequest } from "./app.ts";
 import "./reboot.ts";
 import { plugins } from "./utils/loadDIr.ts";
@@ -88,7 +89,7 @@ export const initializeEngine = async (
 ): Promise<any> => {
   // Set default options
   const {
-    loadDefaultCommands = false,
+    loadDefaultCommands = true,
     loadDefaultTextFiles = true,
     autoCreateDefaultRooms = true,
     autoCreateDefaultChannels = true,

--- a/src/services/Database/database.ts
+++ b/src/services/Database/database.ts
@@ -208,7 +208,7 @@ export class DBO<T extends WithId> implements IDatabase<T> {
 
   /** Detect { location: X }, { flags: /connected/i }, or $and combinations. */
   private tryIndexLookup(query?: Query<T>): Set<string> | null {
-    if (!query || !this.shadowIndex?.isBuilt) return null;
+    if (!query || typeof query !== "object" || !this.shadowIndex?.isBuilt) return null;
     let location: string | undefined;
     let needsConnected = false;
 
@@ -412,6 +412,7 @@ export class DBO<T extends WithId> implements IDatabase<T> {
 
   private matchesQuery(value: T, query?: Query<T>): boolean {
     if (!query) return true;
+    if (typeof query !== "object") return value === query;
 
     if ('$or' in query && Array.isArray(query.$or)) {
       return (query.$or as QueryCondition[]).some((cond: QueryCondition) => this.matchesQuery(value, cond));

--- a/src/services/SDK/index.ts
+++ b/src/services/SDK/index.ts
@@ -106,7 +106,20 @@ function buildSDKFromContext(ctx: GameContext): IUrsamuSDK {
 
     db: {
       search: async (query: string | Record<string, unknown>) => {
-        const results = await dbojs.query(query as Record<string, unknown>);
+        let q: Record<string, unknown>;
+        if (typeof query === "string") {
+          const trimmed = query.trim();
+          if (!trimmed) return [];
+          if (/^#?\d+$/.test(trimmed)) {
+            q = { id: trimmed.replace(/^#/, "") };
+          } else {
+            const rx = new RegExp(`^${escapeRegex(trimmed)}$`, "i");
+            q = { $or: [{ "data.name": rx }, { "data.alias": rx }] };
+          }
+        } else {
+          q = query;
+        }
+        const results = await dbojs.query(q);
         return results.map(hydrate);
       },
       create: async (template: Partial<IDBObj>) => {
@@ -204,6 +217,8 @@ function buildSDKFromContext(ctx: GameContext): IUrsamuSDK {
         socket.cid = id;
         socket.join(`#${id}`);
         if (player.location) socket.join(`#${player.location}`);
+        const { setFlags } = await import("../../utils/setFlags.ts");
+        await setFlags(player, "connected");
       },
       hash: async (password: string) => {
         try { return await hash(password, 10); }

--- a/src/services/WebSocket/index.ts
+++ b/src/services/WebSocket/index.ts
@@ -155,8 +155,15 @@ export class WebSocketService {
                         if (decoded && typeof decoded.id === "string") {
                             sockData.cid = decoded.id;
                             const player = await playerForSocket(sockData);
-                            if (player && !player.flags.includes("connected")) {
-                                await setFlags(player, "connected");
+                            if (player) {
+                                if (!player.flags.includes("connected")) {
+                                    await setFlags(player, "connected");
+                                }
+                                // Re-subscribe to broadcast channels — same as u.auth.login.
+                                // Without these, u.here.broadcast / room messages never
+                                // reach the reconnected socket.
+                                sockData.join(`#${sockData.cid}`);
+                                if (player.location) sockData.join(`#${player.location}`);
                             }
                             console.log(`[WS] Authenticated socket via auth message (cid: ${sockData.cid})`);
                         }

--- a/src/services/jwt/jwt.ts
+++ b/src/services/jwt/jwt.ts
@@ -1,23 +1,37 @@
 import { djwt } from "../../../deps.ts";
 
 // Generate a per-process fallback so there is no known static secret.
-// Tokens will be invalidated on restart. Set JWT_SECRET in production.
+// Tokens signed with it will be invalidated on restart — set JWT_SECRET in
+// production (or in .env for development) for cross-restart auto-reauth.
 const _FALLBACK_SECRET = crypto.randomUUID() + crypto.randomUUID();
-const _JWT_SECRET_ENV = Deno.env.get("JWT_SECRET");
-if (!_JWT_SECRET_ENV) {
-  if (Deno.env.get("DENO_ENV") === "production") {
-    console.error("[jwt] FATAL: JWT_SECRET must be set in production. Exiting.");
-    Deno.exit(1);
+
+let _resolvedSecret: string | null = null;
+let _warned = false;
+
+const resolveSecret = (): string => {
+  if (_resolvedSecret) return _resolvedSecret;
+  const env = Deno.env.get("JWT_SECRET");
+  if (env) {
+    _resolvedSecret = env;
+    return env;
   }
-  console.warn(
-    "[jwt] WARNING: JWT_SECRET not set. Using a random per-process secret — tokens will be invalidated on restart.",
-  );
-}
+  if (!_warned) {
+    _warned = true;
+    if (Deno.env.get("DENO_ENV") === "production") {
+      console.error("[jwt] FATAL: JWT_SECRET must be set in production. Exiting.");
+      Deno.exit(1);
+    }
+    console.warn(
+      "[jwt] WARNING: JWT_SECRET not set. Using a random per-process secret — tokens will be invalidated on restart.",
+    );
+  }
+  _resolvedSecret = _FALLBACK_SECRET;
+  return _FALLBACK_SECRET;
+};
 
 const getSecretKey = async () => {
-  const secret = _JWT_SECRET_ENV || _FALLBACK_SECRET;
   const encoder = new TextEncoder();
-  const keyData = encoder.encode(secret);
+  const keyData = encoder.encode(resolveSecret());
   return await crypto.subtle.importKey(
     "raw",
     keyData,

--- a/src/services/telnet/telnet.ts
+++ b/src/services/telnet/telnet.ts
@@ -191,6 +191,34 @@ export function accumulateNaws(
   return { naws: null, carry: new Uint8Array(0) };
 }
 
+/**
+ * Strip all Telnet IAC (Interpret As Command) sequences from a byte chunk.
+ * Handles: IAC IAC (escaped 0xFF → 0xFF), IAC WILL/WONT/DO/DONT <opt> (3-byte),
+ * IAC SB ... IAC SE (subnegotiation), and single-byte commands like IAC NOP/GA.
+ * Anything else after a lone IAC is dropped along with the following byte.
+ */
+export function stripIacBytes(chunk: Uint8Array): Uint8Array {
+  const out = new Uint8Array(chunk.length);
+  let w = 0;
+  for (let i = 0; i < chunk.length; i++) {
+    const b = chunk[i];
+    if (b !== IAC) { out[w++] = b; continue; }
+    const next = chunk[i + 1];
+    if (next === undefined) break; // trailing lone IAC — drop
+    if (next === IAC) { out[w++] = IAC; i += 1; continue; } // escaped 0xFF
+    if (next === SB) {
+      // Skip until IAC SE (handles double-IAC inside payload safely enough).
+      let j = i + 2;
+      while (j < chunk.length - 1 && !(chunk[j] === IAC && chunk[j + 1] === SE)) j++;
+      i = j + 1; // skip past SE (or jump to end if not found in this chunk)
+      continue;
+    }
+    if (next >= 0xFB && next <= 0xFE) { i += 2; continue; } // WILL/WONT/DO/DONT <opt>
+    i += 1; // any other 2-byte IAC sequence
+  }
+  return out.subarray(0, w);
+}
+
 async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, welcome: string) {
   let sock: WebSocket | null = null;
   let cid: string | undefined;
@@ -349,17 +377,16 @@ async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, welcome: 
         }
       }
 
-      const raw = new TextDecoder().decode(chunk);
+      // Strip Telnet IAC sequences at the byte level. We can't do this after
+      // UTF-8 decoding because lone 0xFF bytes become U+FFFD replacement chars
+      // and the byte-level patterns no longer match.
+      const cleaned = stripIacBytes(chunk);
+      const raw = new TextDecoder().decode(cleaned);
 
-         // Filter Telnet IAC sequences and non-printable chars
-        // IAC sequences start with 0xFF (\xff)
-        const msg = raw
-          .replace(/\xff[\xfb-\xfe]./g, "") // IAC DO/DONT/WILL/WONT <opt>
-          .replace(/\xff[\xf0-\xfa].*/g, "") // IAC SB/SE/etc (strip remainder of subneg)
-          .replace(/\xff\xff/g, "\xff")    // Escaped IAC
-          // deno-lint-ignore no-control-regex
-          .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "") // Non-printable ASCII
-          .trim();
+      const msg = raw
+        // deno-lint-ignore no-control-regex
+        .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "") // non-printable ASCII
+        .trim();
 
       if (sock && (sock as WebSocket).readyState === WebSocket.OPEN) {
         if (msg) {

--- a/src/utils/formatHandlers.ts
+++ b/src/utils/formatHandlers.ts
@@ -53,6 +53,41 @@ export function unregisterFormatHandler(slot: FormatSlot, fn: FormatHandler): vo
   if (idx >= 0) list.splice(idx, 1);
 }
 
+/**
+ * Register a MUSH-softcode template as a format handler for a slot. The engine
+ * evaluates `mushSource` whenever the slot is resolved, with `%0` bound to the
+ * default rendering and the resolver's target as the executor — so the
+ * template can call attribute and object functions on the target directly.
+ *
+ * Returns the underlying handler so callers can pass it to
+ * `unregisterFormatHandler` from their plugin `remove()`.
+ *
+ * @example
+ * ```ts
+ * registerFormatTemplate(
+ *   "NAMEFORMAT",
+ *   "[center(strcat(%cy[ ,name(%0), ]%cn),78,=)]",
+ * );
+ * ```
+ */
+export function registerFormatTemplate(
+  slot: FormatSlot,
+  mushSource: string,
+): FormatHandler {
+  const handler: FormatHandler = async (u, target, defaultArg) => {
+    const { softcodeService } = await import("../services/Softcode/index.ts");
+    const out = await softcodeService.runSoftcode(mushSource, {
+      actorId:    u.me.id,
+      executorId: target.id,
+      args:       [defaultArg],
+      socketId:   u.socketId,
+    });
+    return out ?? null;
+  };
+  registerFormatHandler(slot, handler);
+  return handler;
+}
+
 /** First registered handler that returns a non-null string wins. */
 export async function runPluginFormatHandlers(
   slot: FormatSlot,

--- a/tests/registerFormatTemplate.test.ts
+++ b/tests/registerFormatTemplate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for registerFormatTemplate — the MUSH-softcode shortcut for the
+ * format-handler registry.
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+import { createNativeSDK } from "../src/services/SDK/index.ts";
+import { resolveFormat } from "../src/utils/resolveFormat.ts";
+import {
+  _clearFormatHandlers,
+  registerFormatTemplate,
+  unregisterFormatHandler,
+} from "../src/utils/formatHandlers.ts";
+import { hydrate } from "../src/utils/evaluateLock.ts";
+import type { IDBObj, IUrsamuSDK } from "../src/@types/UrsamuSDK.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const SLOW = { timeout: 15000 };
+
+const ROOM = "920001";
+const ACTOR = "920002";
+const TARGET = "920003";
+
+async function cleanup() {
+  for (const id of [ROOM, ACTOR, TARGET]) {
+    await dbojs.delete({ id }).catch(() => {});
+  }
+}
+
+async function seed() {
+  await cleanup();
+  _clearFormatHandlers();
+  await dbojs.create({ id: ROOM, flags: "room", data: { name: "Tpl Room" } });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected wizard",
+    data: { name: "Alice" },
+    location: ROOM,
+  });
+  await dbojs.create({
+    id: TARGET,
+    flags: "thing",
+    data: { name: "Widget" },
+    location: ROOM,
+  });
+}
+
+async function ctx(): Promise<{ u: IUrsamuSDK; target: IDBObj }> {
+  const u = await createNativeSDK("tpl-sock", ACTOR, {
+    name: "test", original: "test", args: [], switches: [],
+  });
+  const raw = await dbojs.queryOne({ id: TARGET }) as unknown as IDBObj;
+  return { u, target: hydrate(raw) };
+}
+
+Deno.test("registerFormatTemplate: runs MUSH softcode with %0 = default", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  registerFormatTemplate("NAMEFORMAT", "<<%0>>");
+  const { u, target } = await ctx();
+  const out = await resolveFormat(u, target, "NAMEFORMAT", "Widget");
+  assertEquals(out, "<<Widget>>");
+  _clearFormatHandlers();
+  await cleanup();
+});
+
+Deno.test("registerFormatTemplate: returned handler unregisters cleanly", { ...OPTS, ...SLOW }, async () => {
+  await seed();
+  const h = registerFormatTemplate("DESCFORMAT", "[strcat(BOX:,%0,:BOX)]");
+  const { u, target } = await ctx();
+  let out = await resolveFormat(u, target, "DESCFORMAT", "hi");
+  assertEquals(out, "BOX:hi:BOX");
+  unregisterFormatHandler("DESCFORMAT", h);
+  out = await resolveFormat(u, target, "DESCFORMAT", "hi");
+  assertEquals(out, null);
+  await cleanup();
+  await DBO.close();
+});


### PR DESCRIPTION
## Summary

- **New API** — `registerFormatTemplate(slot, mushSource)` lets plugins ship MUSH-softcode format defaults as a one-liner; engine evaluates the template with `%0 = default` and the resolver target as executor. Priority is unchanged: per-object attr → TS handler → softcode template → built-in.
- **Supervised scaffold** — `ursamu create` now ships `daemon.sh` / `stop.sh` / `restart.sh` / `status.sh` driven by `src/cli/start.ts`. `restart.sh` and in-game `@reboot` both signal `SIGUSR2` and respawn main without dropping telnet (clients auto-reauth via JWT). `stop.sh` / `@shutdown` remain the disconnect path. Scaffold writes a fresh `JWT_SECRET` into `.env` so reauth survives restarts.
- **Engine bugfixes** — `matchesQuery`/`tryIndexLookup` guard against non-object queries; `u.db.search` interprets strings as name/alias/`#id` lookups; `u.auth.login` re-applies `connected` flag; WS auth rejoins broadcast channels on reauth; telnet sidecar strips IAC sequences at byte level (NAWS no longer leaks as "Huh?" commands); JWT secret resolves lazily after `dotenv/load`; `loadDefaultCommands` defaults to `true`; 39 `export default () => addCmd(...)` stubs unwrapped so the JSR import path actually registers core commands; `create` issues a JWT alongside `connect`.
- **Docs** — `docs/api/core.md` documents the full format-handler API. README version bumped to 2.4.0. New `CLAUDE.md` rule: update docs alongside every commit. `legends/` excluded from `deno lint`.

## Test plan

- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean (355 files)
- [x] `deno test tests/ --allow-all --unstable-kv --no-check` — 1126 passed
- [x] `deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check` — 141 passed
- [x] Manual: scaffolded `legends` game starts under supervisor, `@reboot` and `scripts/restart.sh` keep telnet clients connected, `say`/`look`/etc. work post-reboot, window resize doesn't generate "Huh?".
- [x] New `tests/registerFormatTemplate.test.ts` — 2 cases, green.