### PR TITLE
feat: coherent noise stdlib — perlin, simplex, worley, fbm, ridged, noisegrid (v2.5.0 phase B)

### DIFF
--- a/src/services/Softcode/stdlib/index.ts
+++ b/src/services/Softcode/stdlib/index.ts
@@ -8,6 +8,7 @@ export type { StdlibFn } from "./registry.ts";
 
 // ── Load all modules (side-effect imports register their functions) ────────
 import "./math.ts";
+import "./noise.ts";
 import "./logic.ts";
 import "./string.ts";
 import "./list.ts";

--- a/src/services/Softcode/stdlib/noise.ts
+++ b/src/services/Softcode/stdlib/noise.ts
@@ -1,0 +1,308 @@
+// deno-lint-ignore-file require-await
+// Coherent noise stdlib — Perlin (Ken Perlin, "Improved Noise", 2002, patent
+// expired 2022) and simplex (Stefan Gustavson, public-domain reference impl,
+// see https://weber.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf).
+// Worley/cellular noise: Steven Worley, 1996.
+import { register } from "./registry.ts";
+import { num, int, fmt } from "./helpers.ts";
+
+const MAX_LEN = 10_000;
+const MAX_OCTAVES = 16;
+
+// ── module state ──────────────────────────────────────────────────────────
+let _noiseSeed = 0;
+let _seedInitialized = false;
+const PERM = new Uint8Array(512);
+
+function setSeed(seed: number): void {
+  // FNV-1a hash → seeded shuffle of 0..255 into PERM
+  let h = 2166136261 >>> 0;
+  const bytes = new Uint8Array(new Float64Array([seed]).buffer);
+  for (const b of bytes) {
+    h ^= b;
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  const p = new Uint8Array(256);
+  for (let i = 0; i < 256; i++) p[i] = i;
+  // Fisher–Yates with xorshift32 driven by h
+  let s = h || 1;
+  for (let i = 255; i > 0; i--) {
+    s ^= s << 13; s >>>= 0;
+    s ^= s >>> 17;
+    s ^= s << 5;  s >>>= 0;
+    const j = s % (i + 1);
+    const tmp = p[i]; p[i] = p[j]; p[j] = tmp;
+  }
+  for (let i = 0; i < 512; i++) PERM[i] = p[i & 255];
+  _noiseSeed = seed;
+  _seedInitialized = true;
+}
+
+function ensureSeed(): void {
+  if (!_seedInitialized) setSeed(0);
+}
+
+function withSeed<T>(args: string[], idx: number, fn: () => T): T {
+  if (args[idx] !== undefined && args[idx] !== "") {
+    const prev = _noiseSeed;
+    const prevInit = _seedInitialized;
+    setSeed(num(args[idx]));
+    try { return fn(); } finally {
+      if (prevInit) setSeed(prev); else { _seedInitialized = false; }
+    }
+  }
+  ensureSeed();
+  return fn();
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+function fade(t: number): number {
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+function lerp(t: number, a: number, b: number): number {
+  return a + t * (b - a);
+}
+function grad1(hash: number, x: number): number {
+  return (hash & 1) === 0 ? x : -x;
+}
+function grad2(hash: number, x: number, y: number): number {
+  const h = hash & 7;
+  const u = h < 4 ? x : y;
+  const v = h < 4 ? y : x;
+  return ((h & 1) ? -u : u) + ((h & 2) ? -2 * v : 2 * v);
+}
+function grad3(hash: number, x: number, y: number, z: number): number {
+  const h = hash & 15;
+  const u = h < 8 ? x : y;
+  const v = h < 4 ? y : (h === 12 || h === 14 ? x : z);
+  return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
+}
+
+// ── perlin ────────────────────────────────────────────────────────────────
+function perlin1(x: number): number {
+  const xi = Math.floor(x) & 255;
+  const xf = x - Math.floor(x);
+  const u  = fade(xf);
+  const a  = PERM[xi];
+  const b  = PERM[xi + 1];
+  return lerp(u, grad1(a, xf), grad1(b, xf - 1));
+}
+
+function perlin2(x: number, y: number): number {
+  const xi = Math.floor(x) & 255;
+  const yi = Math.floor(y) & 255;
+  const xf = x - Math.floor(x);
+  const yf = y - Math.floor(y);
+  const u  = fade(xf);
+  const v  = fade(yf);
+  const aa = PERM[PERM[xi] + yi];
+  const ab = PERM[PERM[xi] + yi + 1];
+  const ba = PERM[PERM[xi + 1] + yi];
+  const bb = PERM[PERM[xi + 1] + yi + 1];
+  const x1 = lerp(u, grad2(aa, xf, yf),     grad2(ba, xf - 1, yf));
+  const x2 = lerp(u, grad2(ab, xf, yf - 1), grad2(bb, xf - 1, yf - 1));
+  // grad2 magnitude is up to ~3, scale to roughly [-1,1]
+  return lerp(v, x1, x2) / 3;
+}
+
+function perlin3(x: number, y: number, z: number): number {
+  const xi = Math.floor(x) & 255;
+  const yi = Math.floor(y) & 255;
+  const zi = Math.floor(z) & 255;
+  const xf = x - Math.floor(x);
+  const yf = y - Math.floor(y);
+  const zf = z - Math.floor(z);
+  const u = fade(xf), v = fade(yf), w = fade(zf);
+  const A  = PERM[xi]   + yi;
+  const AA = PERM[A]    + zi;
+  const AB = PERM[A + 1] + zi;
+  const B  = PERM[xi + 1] + yi;
+  const BA = PERM[B]    + zi;
+  const BB = PERM[B + 1] + zi;
+  return lerp(w,
+    lerp(v,
+      lerp(u, grad3(PERM[AA],     xf,     yf,     zf),
+              grad3(PERM[BA],     xf - 1, yf,     zf)),
+      lerp(u, grad3(PERM[AB],     xf,     yf - 1, zf),
+              grad3(PERM[BB],     xf - 1, yf - 1, zf))),
+    lerp(v,
+      lerp(u, grad3(PERM[AA + 1], xf,     yf,     zf - 1),
+              grad3(PERM[BA + 1], xf - 1, yf,     zf - 1)),
+      lerp(u, grad3(PERM[AB + 1], xf,     yf - 1, zf - 1),
+              grad3(PERM[BB + 1], xf - 1, yf - 1, zf - 1))));
+}
+
+// ── simplex 2D (Gustavson reference impl, public domain) ──────────────────
+const F2 = 0.5 * (Math.sqrt(3) - 1);
+const G2 = (3 - Math.sqrt(3)) / 6;
+
+function simplex2(xin: number, yin: number): number {
+  const s = (xin + yin) * F2;
+  const i = Math.floor(xin + s);
+  const j = Math.floor(yin + s);
+  const t = (i + j) * G2;
+  const X0 = i - t;
+  const Y0 = j - t;
+  const x0 = xin - X0;
+  const y0 = yin - Y0;
+  const i1 = x0 > y0 ? 1 : 0;
+  const j1 = x0 > y0 ? 0 : 1;
+  const x1 = x0 - i1 + G2;
+  const y1 = y0 - j1 + G2;
+  const x2 = x0 - 1 + 2 * G2;
+  const y2 = y0 - 1 + 2 * G2;
+  const ii = i & 255;
+  const jj = j & 255;
+  const gi0 = PERM[ii + PERM[jj]] & 7;
+  const gi1 = PERM[ii + i1 + PERM[jj + j1]] & 7;
+  const gi2 = PERM[ii + 1 + PERM[jj + 1]] & 7;
+  let n0 = 0, n1 = 0, n2 = 0;
+  let t0 = 0.5 - x0 * x0 - y0 * y0;
+  if (t0 >= 0) { t0 *= t0; n0 = t0 * t0 * grad2(gi0, x0, y0); }
+  let t1 = 0.5 - x1 * x1 - y1 * y1;
+  if (t1 >= 0) { t1 *= t1; n1 = t1 * t1 * grad2(gi1, x1, y1); }
+  let t2 = 0.5 - x2 * x2 - y2 * y2;
+  if (t2 >= 0) { t2 *= t2; n2 = t2 * t2 * grad2(gi2, x2, y2); }
+  // Scaling factor ~70 in Gustavson; with our grad2 magnitude ~3 the
+  // empirical scale is ~40 to land in [-1, 1].
+  return 40 * (n0 + n1 + n2);
+}
+
+// ── worley 2D (cellular F1 distance) ──────────────────────────────────────
+function worley2(x: number, y: number): number {
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  let min = Infinity;
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dy = -1; dy <= 1; dy++) {
+      const cx = xi + dx;
+      const cy = yi + dy;
+      // Feature point inside this cell: jittered by hashed offsets in [0, 1).
+      const h1 = PERM[(cx & 255) + PERM[cy & 255]];
+      const h2 = PERM[(cx & 255) + PERM[(cy + 1) & 255]];
+      const px = cx + (h1 / 255);
+      const py = cy + (h2 / 255);
+      const ex = px - x;
+      const ey = py - y;
+      const d  = ex * ex + ey * ey;
+      if (d < min) min = d;
+    }
+  }
+  return Math.sqrt(min);
+}
+
+// ── fbm / ridged ──────────────────────────────────────────────────────────
+function fbm2(x: number, y: number, octaves: number, persistence: number): number {
+  let total = 0;
+  let freq = 1;
+  let amp = 1;
+  let maxAmp = 0;
+  for (let i = 0; i < octaves; i++) {
+    total += perlin2(x * freq, y * freq) * amp;
+    maxAmp += amp;
+    amp *= persistence;
+    freq *= 2;
+  }
+  return maxAmp === 0 ? 0 : total / maxAmp;
+}
+
+function ridged2(x: number, y: number, octaves: number, persistence: number): number {
+  let total = 0;
+  let freq = 1;
+  let amp = 1;
+  let maxAmp = 0;
+  for (let i = 0; i < octaves; i++) {
+    const n = 1 - Math.abs(perlin2(x * freq, y * freq));
+    total += (n * 2 - 1) * amp; // remap [0,1] to [-1,1]
+    maxAmp += amp;
+    amp *= persistence;
+    freq *= 2;
+  }
+  return maxAmp === 0 ? 0 : total / maxAmp;
+}
+
+// ── registrations ─────────────────────────────────────────────────────────
+
+register("noiseseed", async (a) => {
+  const seed = num(a[0]);
+  const prev = _seedInitialized ? _noiseSeed : "";
+  setSeed(seed);
+  return prev === "" ? "" : fmt(prev as number);
+});
+
+register("perlin1", async (a) => {
+  const x = num(a[0]);
+  return withSeed(a, 1, () => fmt(perlin1(x)));
+});
+
+register("perlin2", async (a) => {
+  const x = num(a[0]); const y = num(a[1]);
+  return withSeed(a, 2, () => fmt(perlin2(x, y)));
+});
+
+register("perlin3", async (a) => {
+  const x = num(a[0]); const y = num(a[1]); const z = num(a[2]);
+  return withSeed(a, 3, () => fmt(perlin3(x, y, z)));
+});
+
+register("simplex2", async (a) => {
+  const x = num(a[0]); const y = num(a[1]);
+  return withSeed(a, 2, () => fmt(simplex2(x, y)));
+});
+
+register("worley2", async (a) => {
+  const x = num(a[0]); const y = num(a[1]);
+  return withSeed(a, 2, () => fmt(worley2(x, y)));
+});
+
+register("fbm2", async (a) => {
+  const x = num(a[0]); const y = num(a[1]);
+  const oct = Math.min(Math.max(1, int(a[2]) || 1), MAX_OCTAVES);
+  const per = num(a[3]) || 0.5;
+  return withSeed(a, 4, () => fmt(fbm2(x, y, oct, per)));
+});
+
+register("ridged2", async (a) => {
+  const x = num(a[0]); const y = num(a[1]);
+  const oct = Math.min(Math.max(1, int(a[2]) || 1), MAX_OCTAVES);
+  const per = num(a[3]) || 0.5;
+  return withSeed(a, 4, () => fmt(ridged2(x, y, oct, per)));
+});
+
+register("noisegrid", async (a) => {
+  const seed = num(a[0]);
+  const w = Math.max(0, int(a[1]) | 0);
+  const h = Math.max(0, int(a[2]) | 0);
+  const scale = num(a[3]) || 1;
+  const fn = (a[4] ?? "perlin2").toLowerCase().trim();
+  const total = w * h;
+  if (total > MAX_LEN) {
+    // clamp to MAX_LEN cells (preserve aspect by truncating rows)
+    const rows = Math.max(1, Math.floor(MAX_LEN / Math.max(1, w)));
+    return generateGrid(seed, Math.min(w, MAX_LEN), rows, scale, fn);
+  }
+  return generateGrid(seed, w, h, scale, fn);
+});
+
+function generateGrid(
+  seed: number, w: number, h: number, scale: number, fn: string,
+): string {
+  const prevInit = _seedInitialized;
+  const prevSeed = _noiseSeed;
+  setSeed(seed);
+  try {
+    const out: string[] = [];
+    let pick: (x: number, y: number) => number;
+    if (fn === "simplex2") pick = simplex2;
+    else if (fn === "worley2") pick = worley2;
+    else pick = perlin2; // default + fail-soft
+    for (let j = 0; j < h; j++) {
+      for (let i = 0; i < w; i++) {
+        out.push(fmt(pick(i * scale, j * scale)));
+      }
+    }
+    return out.join(" ");
+  } finally {
+    if (prevInit) setSeed(prevSeed); else _seedInitialized = false;
+  }
+}

--- a/tests/softcode_noise.test.ts
+++ b/tests/softcode_noise.test.ts
@@ -1,0 +1,252 @@
+/**
+ * tests/softcode_noise.test.ts
+ *
+ * Tests for coherent noise stdlib: perlin1/2/3, simplex2, worley2,
+ * fbm2, ridged2, noisegrid, noiseseed. Exercised through the real
+ * UrsaMU softcode engine.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { runSoftcode, softcodeEngine } from "../src/services/Softcode/ursamu-engine.ts";
+import type { UrsaEvalContext } from "../src/services/Softcode/ursamu-context.ts";
+import type { DbAccessor, OutputAccessor } from "../src/services/Softcode/context.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+function makeActor(overrides: Partial<IDBObj> = {}): IDBObj {
+  return {
+    id: "1",
+    name: "Tester",
+    flags: new Set(["player", "connected"]),
+    location: "0",
+    state: {},
+    contents: [],
+    ...overrides,
+  };
+}
+
+function makeDb(overrides: Partial<DbAccessor> = {}): DbAccessor {
+  return {
+    queryById:        () => Promise.resolve(null),
+    queryByName:      () => Promise.resolve(null),
+    lcon:             () => Promise.resolve([]),
+    lwho:             () => Promise.resolve([]),
+    lattr:            () => Promise.resolve([]),
+    getAttribute:     () => Promise.resolve(null),
+    getTagById:       () => Promise.resolve(null),
+    getPlayerTagById: () => Promise.resolve(null),
+    lsearch:          () => Promise.resolve([]),
+    children:         () => Promise.resolve([]),
+    lchannels:        () => Promise.resolve(""),
+    channelsFor:      () => Promise.resolve(""),
+    mailCount:        () => Promise.resolve(0),
+    queueLength:      () => Promise.resolve(0),
+    getIdleSecs:      () => Promise.resolve(0),
+    getUserFn:        () => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+const noOutput: OutputAccessor = {
+  send:          () => {},
+  roomBroadcast: () => {},
+  broadcast:     () => {},
+};
+
+function makeCtx(): UrsaEvalContext {
+  const actor = makeActor();
+  return {
+    enactor:      actor.id,
+    executor:     actor,
+    caller:       null,
+    actor,
+    args:         [],
+    registers:    new Map(),
+    iterStack:    [],
+    depth:        0,
+    maxDepth:     50,
+    maxOutputLen: 1_000_000,
+    deadline:     Date.now() + 30_000,
+    db:           makeDb(),
+    output:       noOutput,
+    _engine:      softcodeEngine,
+  };
+}
+
+const run = (code: string) => runSoftcode(code, makeCtx());
+const runNum = async (code: string) => parseFloat(await run(code));
+
+// ── determinism ─────────────────────────────────────────────────────────
+
+Deno.test("perlin2 — determinism: same (x,y,seed) → same output", async () => {
+  const a = await run("[perlin2(1.5, 2.5, 42)]");
+  const b = await run("[perlin2(1.5, 2.5, 42)]");
+  const c = await run("[perlin2(1.5, 2.5, 42)]");
+  assertEquals(a, b);
+  assertEquals(b, c);
+});
+
+Deno.test("simplex2 — determinism", async () => {
+  const a = await run("[simplex2(3.14, 2.71, 7)]");
+  const b = await run("[simplex2(3.14, 2.71, 7)]");
+  assertEquals(a, b);
+});
+
+Deno.test("worley2 — determinism", async () => {
+  const a = await run("[worley2(0.3, 0.7, 99)]");
+  const b = await run("[worley2(0.3, 0.7, 99)]");
+  assertEquals(a, b);
+});
+
+// ── seed independence ──────────────────────────────────────────────────
+
+Deno.test("perlin2 — different seeds → mostly different outputs", async () => {
+  let differ = 0;
+  for (let i = 0; i < 100; i++) {
+    const x = i * 0.37 + 0.01;
+    const y = i * 0.61 + 0.02;
+    const a = await runNum(`[perlin2(${x}, ${y}, 1)]`);
+    const b = await runNum(`[perlin2(${x}, ${y}, 999)]`);
+    if (a !== b) differ++;
+  }
+  assert(differ >= 90, `expected >=90 differing samples, got ${differ}`);
+});
+
+// ── output range ───────────────────────────────────────────────────────
+
+Deno.test("perlin2 — 1000 samples in [-1, 1]", async () => {
+  for (let i = 0; i < 1000; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const v = await runNum(`[perlin2(${x}, ${y}, 7)]`);
+    assert(v >= -1 && v <= 1, `perlin2 out of range: ${v} at (${x},${y})`);
+  }
+});
+
+Deno.test("perlin1 — 200 samples in [-1, 1]", async () => {
+  for (let i = 0; i < 200; i++) {
+    const x = Math.random() * 100;
+    const v = await runNum(`[perlin1(${x}, 7)]`);
+    assert(v >= -1 && v <= 1, `perlin1 out of range: ${v}`);
+  }
+});
+
+Deno.test("perlin3 — 200 samples in [-1, 1]", async () => {
+  for (let i = 0; i < 200; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const z = Math.random() * 100;
+    const v = await runNum(`[perlin3(${x}, ${y}, ${z}, 7)]`);
+    assert(v >= -1 && v <= 1, `perlin3 out of range: ${v}`);
+  }
+});
+
+Deno.test("simplex2 — 1000 samples in [-1, 1]", async () => {
+  for (let i = 0; i < 1000; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const v = await runNum(`[simplex2(${x}, ${y}, 11)]`);
+    assert(v >= -1 && v <= 1, `simplex2 out of range: ${v}`);
+  }
+});
+
+Deno.test("fbm2 — 1000 samples in [-1, 1] (normalized)", async () => {
+  for (let i = 0; i < 1000; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const v = await runNum(`[fbm2(${x}, ${y}, 4, 0.5, 7)]`);
+    assert(v >= -1 && v <= 1, `fbm2 out of range: ${v}`);
+  }
+});
+
+Deno.test("ridged2 — 1000 samples in [-1, 1]", async () => {
+  for (let i = 0; i < 1000; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const v = await runNum(`[ridged2(${x}, ${y}, 4, 0.5, 7)]`);
+    assert(v >= -1 && v <= 1, `ridged2 out of range: ${v}`);
+  }
+});
+
+Deno.test("worley2 — outputs are non-negative distances", async () => {
+  for (let i = 0; i < 500; i++) {
+    const x = Math.random() * 100;
+    const y = Math.random() * 100;
+    const v = await runNum(`[worley2(${x}, ${y}, 5)]`);
+    assert(v >= 0, `worley2 negative: ${v}`);
+  }
+});
+
+// ── continuity ─────────────────────────────────────────────────────────
+
+Deno.test("perlin2 — smooth gradient (|f(x,y)-f(x+eps,y)| < 0.1)", async () => {
+  for (let i = 0; i < 50; i++) {
+    const x = Math.random() * 10;
+    const y = Math.random() * 10;
+    const a = await runNum(`[perlin2(${x}, ${y}, 3)]`);
+    const b = await runNum(`[perlin2(${x + 0.001}, ${y}, 3)]`);
+    assert(Math.abs(a - b) < 0.1, `discontinuity: ${a} vs ${b}`);
+  }
+});
+
+// ── noisegrid ──────────────────────────────────────────────────────────
+
+Deno.test("noisegrid — returns w*h space-separated values", async () => {
+  const r = await run("[noisegrid(42, 10, 8, 0.1)]");
+  const parts = r.split(" ");
+  assertEquals(parts.length, 80);
+  for (const p of parts) {
+    const n = parseFloat(p);
+    assert(!isNaN(n), `non-numeric value: ${p}`);
+  }
+});
+
+Deno.test("noisegrid — DoS clamp: 1000x1000 returns ≤10000 cells", async () => {
+  const r = await run("[noisegrid(0, 1000, 1000, 0.1)]");
+  const parts = r.split(" ");
+  assert(parts.length <= 10_000, `clamp failed: ${parts.length} cells`);
+  assert(parts.length > 0, "clamp returned empty");
+});
+
+Deno.test("noisegrid — simplex2 fn dispatch", async () => {
+  const r = await run("[noisegrid(1, 4, 4, 0.2, simplex2)]");
+  assertEquals(r.split(" ").length, 16);
+});
+
+Deno.test("noisegrid — worley2 fn dispatch", async () => {
+  const r = await run("[noisegrid(1, 4, 4, 0.2, worley2)]");
+  assertEquals(r.split(" ").length, 16);
+});
+
+Deno.test("noisegrid — unknown fn defaults to perlin2 (fail-soft)", async () => {
+  const a = await run("[noisegrid(1, 4, 4, 0.2, bogus)]");
+  const b = await run("[noisegrid(1, 4, 4, 0.2, perlin2)]");
+  assertEquals(a, b);
+});
+
+// ── noiseseed ──────────────────────────────────────────────────────────
+
+Deno.test("noiseseed — same seed → same subsequent output", async () => {
+  await run("[noiseseed(123)]");
+  const a = await run("[perlin2(0.5, 0.5)]");
+  await run("[noiseseed(456)]");
+  const b = await run("[perlin2(0.5, 0.5)]");
+  await run("[noiseseed(123)]");
+  const c = await run("[perlin2(0.5, 0.5)]");
+  assertEquals(a, c);
+  assert(a !== b, "different seeds should produce different output");
+});
+
+// ── performance smoke ──────────────────────────────────────────────────
+
+Deno.test("perlin2 — single call < 50ms (cold-start budget)", async () => {
+  const start = performance.now();
+  await run("[perlin2(0, 0, 1)]");
+  const elapsed = performance.now() - start;
+  assert(elapsed < 50, `perlin2 too slow: ${elapsed}ms`);
+});
+
+Deno.test("noisegrid — 50x50 < 500ms", async () => {
+  const start = performance.now();
+  await run("[noisegrid(0, 50, 50, 0.1)]");
+  const elapsed = performance.now() - start;
+  assert(elapsed < 500, `noisegrid 50x50 too slow: ${elapsed}ms`);
+});


### PR DESCRIPTION
## Summary

Phase B of the v2.5.0 math stdlib expansion. Adds coherent noise functions to the softcode stdlib, vendored from now-patent-free reference impls.

**New stdlib module**: `src/services/Softcode/stdlib/noise.ts` (~280 LOC)

**Registered functions**:
- `noiseseed(seed)` — seed + reshuffle a 512-entry permutation table.
- `perlin1(x [, seed])`, `perlin2(x, y [, seed])`, `perlin3(x, y, z [, seed])` — Ken Perlin's 2002 improved noise (US patent 6,867,776 expired Jan 2022). Outputs in `[-1, 1]`.
- `simplex2(x, y [, seed])` — Stefan Gustavson's public-domain 2D simplex reference impl.
- `worley2(x, y [, seed])` — 2D cellular F1-distance noise (3x3 neighborhood scan).
- `fbm2(x, y, octaves, persistence [, seed])` and `ridged2(...)` — octave-summed fractal noise built on `perlin2`, **normalized** to `[-1, 1]` by total amplitude. Octaves clamped to `<= 16`.
- `noisegrid(seed, w, h, scale [, fn])` — flattened grid as space-separated values; `fn` in `{perlin2, simplex2, worley2}` with fail-soft default to `perlin2`. `w*h` clamped to `MAX_LEN = 10_000` to prevent DoS.

Wired into `src/services/Softcode/stdlib/index.ts` via side-effect import.

## Pre-commit gate results

- `deno check --unstable-kv mod.ts` — clean
- `deno lint` — clean across 357 files
- `deno test tests/softcode_noise.test.ts ...` — **20 passed, 0 failed**
- `deno test tests/ ...` — **1146 passed, 0 failed**
- `deno test tests/security_*.test.ts ...` — **141 passed, 0 failed**

## Test plan

- [x] Determinism: same `(x, y, seed)` → same output across multiple calls (perlin2, simplex2, worley2)
- [x] Seed independence: different seeds → >= 90/100 differing samples
- [x] Output range: 1000-sample sweeps for perlin2/simplex2/fbm2/ridged2 stay in `[-1, 1]`; perlin1/perlin3 200-sample sweeps; worley2 outputs >= 0
- [x] Continuity: `|perlin2(x, y) - perlin2(x+0.001, y)| < 0.1`
- [x] `noisegrid` returns exactly `w*h` numeric tokens
- [x] DoS clamp: `noisegrid(0, 1000, 1000, 0.1)` returns <= 10 000 cells, not a million
- [x] `fn` dispatch for `simplex2`/`worley2`; unknown fn falls back to `perlin2`
- [x] `noiseseed(123) ... noiseseed(456) ... noiseseed(123)` returns same value first and third time
- [x] Perf smoke: single `perlin2` < 50ms, `noisegrid(0, 50, 50, 0.1)` < 500ms

## Notes

- Reference impls cited at the top of `noise.ts`: Perlin 2002 "Improved Noise"; Gustavson simplex reference (https://weber.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf); Worley 1996.
- No version bump in `deno.json` — coordinated with Phase A/C agents.
- Deferred per scope: `simplex3`, `worley3`.