### PR TITLE
feat: physics primitives — vreflect, pointinaabb, rayaabb (v2.5.0 phase C)

### DIFF
--- a/src/services/Softcode/stdlib/index.ts
+++ b/src/services/Softcode/stdlib/index.ts
@@ -8,6 +8,7 @@ export type { StdlibFn } from "./registry.ts";
 
 // ── Load all modules (side-effect imports register their functions) ────────
 import "./math.ts";
+import "./physics.ts";
 import "./logic.ts";
 import "./string.ts";
 import "./list.ts";

--- a/src/services/Softcode/stdlib/physics.ts
+++ b/src/services/Softcode/stdlib/physics.ts
@@ -1,0 +1,69 @@
+// deno-lint-ignore-file require-await
+import { register } from "./registry.ts";
+import { num, fmt } from "./helpers.ts";
+
+const EPS = 1e-10;
+
+function parseVec3(s: string): [number, number, number] {
+  const parts = s.split(" ").map(num);
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}
+
+// ── vreflect ──────────────────────────────────────────────────────────────
+// Reflect v across plane with normal n: r = v - 2*(v·n)*n.
+// Assumes n is already a unit vector; callers should pass a normalized normal.
+register("vreflect", async (a) => {
+  const [vx, vy, vz] = parseVec3(a[0] ?? "");
+  const [nx, ny, nz] = parseVec3(a[1] ?? "");
+  const dot = vx * nx + vy * ny + vz * nz;
+  return [
+    fmt(vx - 2 * dot * nx),
+    fmt(vy - 2 * dot * ny),
+    fmt(vz - 2 * dot * nz),
+  ].join(" ");
+});
+
+// ── pointinaabb ───────────────────────────────────────────────────────────
+// Inclusive bounds check. Empty box (min > max on any axis) → outside.
+register("pointinaabb", async (a) => {
+  const px = num(a[0]), py = num(a[1]), pz = num(a[2]);
+  const minx = num(a[3]), miny = num(a[4]), minz = num(a[5]);
+  const maxx = num(a[6]), maxy = num(a[7]), maxz = num(a[8]);
+  if (minx > maxx || miny > maxy || minz > maxz) return "0";
+  const inside =
+    px >= minx && px <= maxx &&
+    py >= miny && py <= maxy &&
+    pz >= minz && pz <= maxz;
+  return inside ? "1" : "0";
+});
+
+// ── rayaabb ───────────────────────────────────────────────────────────────
+// Slab-method ray/AABB intersection. Returns entry t (≥0) on hit, or -1.
+// Ray starting inside the box returns 0.
+register("rayaabb", async (a) => {
+  const ox = num(a[0]), oy = num(a[1]), oz = num(a[2]);
+  const dx = num(a[3]), dy = num(a[4]), dz = num(a[5]);
+  const minv = [num(a[6]), num(a[7]), num(a[8])];
+  const maxv = [num(a[9]), num(a[10]), num(a[11])];
+  const o = [ox, oy, oz];
+  const d = [dx, dy, dz];
+
+  let tmin = -Infinity;
+  let tmax = Infinity;
+
+  for (let i = 0; i < 3; i++) {
+    if (Math.abs(d[i]) < EPS) {
+      if (o[i] < minv[i] || o[i] > maxv[i]) return "-1";
+      continue;
+    }
+    let t1 = (minv[i] - o[i]) / d[i];
+    let t2 = (maxv[i] - o[i]) / d[i];
+    if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
+    if (t1 > tmin) tmin = t1;
+    if (t2 < tmax) tmax = t2;
+    if (tmin > tmax) return "-1";
+  }
+
+  if (tmax < 0) return "-1";
+  return fmt(Math.max(tmin, 0));
+});

--- a/tests/softcode_physics.test.ts
+++ b/tests/softcode_physics.test.ts
@@ -1,0 +1,126 @@
+/**
+ * tests/softcode_physics.test.ts
+ *
+ * Unit tests for the physics-primitives stdlib functions
+ * (vreflect, pointinaabb, rayaabb) introduced in v2.5.0 phase C.
+ */
+// deno-lint-ignore-file require-await
+import { assertEquals } from "@std/assert";
+import { runSoftcode, softcodeEngine } from "../src/services/Softcode/ursamu-engine.ts";
+import type { UrsaEvalContext } from "../src/services/Softcode/ursamu-context.ts";
+import type { DbAccessor } from "../src/services/Softcode/context.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+function actor(): IDBObj {
+  return {
+    id: "100",
+    name: "Alice",
+    flags: new Set(["player", "connected"]),
+    location: "200",
+    state: {},
+    contents: [],
+  };
+}
+
+function makeCtx(): UrsaEvalContext {
+  const a = actor();
+  return {
+    enactor:      a.id,
+    executor:     a,
+    caller:       null,
+    actor:        a,
+    args:         [],
+    registers:    new Map(),
+    iterStack:    [],
+    depth:        0,
+    maxDepth:     50,
+    maxOutputLen: 65_536,
+    deadline:     Date.now() + 2000,
+    db: {
+      queryById:        async () => null,
+      queryByName:      async () => null,
+      lcon:             async () => [],
+      lwho:             async () => [],
+      lattr:            async () => [],
+      getAttribute:     async () => null,
+      getTagById:       async () => null,
+      getPlayerTagById: async () => null,
+      lsearch:          async () => [],
+      children:         async () => [],
+      lchannels:        async () => "",
+      channelsFor:      async () => "",
+      mailCount:        async () => 0,
+      queueLength:      async () => 0,
+      getIdleSecs:      async () => 0,
+      getUserFn:        async () => null,
+    } satisfies DbAccessor,
+    output:       { send: () => {}, roomBroadcast: () => {}, broadcast: () => {} },
+    _engine:      softcodeEngine,
+  };
+}
+
+function run(code: string): Promise<string> {
+  return runSoftcode(code, makeCtx());
+}
+
+// ── vreflect ──────────────────────────────────────────────────────────────
+
+Deno.test("physics/vreflect — bounce off floor (1 -1 0) off (0 1 0)", async () => {
+  assertEquals(await run("[vreflect(1 -1 0,0 1 0)]"), "1 1 0");
+});
+
+Deno.test("physics/vreflect — incident along normal (0 -1 0) off (0 1 0)", async () => {
+  assertEquals(await run("[vreflect(0 -1 0,0 1 0)]"), "0 1 0");
+});
+
+Deno.test("physics/vreflect — perpendicular (1 0 0) off (0 1 0) unchanged", async () => {
+  assertEquals(await run("[vreflect(1 0 0,0 1 0)]"), "1 0 0");
+});
+
+// ── pointinaabb ───────────────────────────────────────────────────────────
+
+Deno.test("physics/pointinaabb — center of unit cube inside", async () => {
+  assertEquals(await run("[pointinaabb(0.5,0.5,0.5,0,0,0,1,1,1)]"), "1");
+});
+
+Deno.test("physics/pointinaabb — corner on min inside (boundary inclusive)", async () => {
+  assertEquals(await run("[pointinaabb(0,0,0,0,0,0,1,1,1)]"), "1");
+});
+
+Deno.test("physics/pointinaabb — corner on max inside (boundary inclusive)", async () => {
+  assertEquals(await run("[pointinaabb(1,1,1,0,0,0,1,1,1)]"), "1");
+});
+
+Deno.test("physics/pointinaabb — just outside a face", async () => {
+  assertEquals(await run("[pointinaabb(1.0001,0.5,0.5,0,0,0,1,1,1)]"), "0");
+});
+
+Deno.test("physics/pointinaabb — empty box (min > max) → outside", async () => {
+  assertEquals(await run("[pointinaabb(0.5,0.5,0.5,1,1,1,0,0,0)]"), "0");
+});
+
+// ── rayaabb ───────────────────────────────────────────────────────────────
+
+Deno.test("physics/rayaabb — ray hits center of unit cube from -X axis", async () => {
+  assertEquals(await run("[rayaabb(-5,0.5,0.5,1,0,0,0,0,0,1,1,1)]"), "5");
+});
+
+Deno.test("physics/rayaabb — parallel ray offset from box misses", async () => {
+  assertEquals(await run("[rayaabb(0,2,0.5,1,0,0,0,0,0,1,1,1)]"), "-1");
+});
+
+Deno.test("physics/rayaabb — origin inside box returns 0", async () => {
+  assertEquals(await run("[rayaabb(0.5,0.5,0.5,1,0,0,0,0,0,1,1,1)]"), "0");
+});
+
+Deno.test("physics/rayaabb — ray pointing away from box returns -1", async () => {
+  assertEquals(await run("[rayaabb(-5,0.5,0.5,-1,0,0,0,0,0,1,1,1)]"), "-1");
+});
+
+Deno.test("physics/rayaabb — axis-parallel ray grazing a face", async () => {
+  assertEquals(await run("[rayaabb(-0.5,0,0.5,1,0,0,0,0,0,1,1,1)]"), "0.5");
+});
+
+Deno.test("physics/rayaabb — diagonal ray entering through corner", async () => {
+  assertEquals(await run("[rayaabb(-1,-1,-1,1,1,1,0,0,0,1,1,1)]"), "1");
+});


### PR DESCRIPTION
## Scope

Adds three new softcode stdlib functions under a new `src/services/Softcode/stdlib/physics.ts` (phase C of the v2.5.0 starter batch). Space-separated 3-vectors, matching the existing `vadd`/`vsub`/`vdot`/`vcross`/`vunit` family.

- `vreflect(v, n)` — reflect `v` across plane with normal `n`: `r = v - 2*(v·n)*n`. Assumes `n` is a unit vector (callers normalize).
- `pointinaabb(px,py,pz, minx,miny,minz, maxx,maxy,maxz)` — inclusive bounds test; returns `"1"`/`"0"`. Empty box (any axis `min > max`) → outside.
- `rayaabb(ox,oy,oz, dx,dy,dz, minx,miny,minz, maxx,maxy,maxz)` — slab-method ray/AABB intersection. Returns entry `t` (≥0) on hit, `-1` on miss. Origin inside box returns `0`.

Wired into `stdlib/index.ts` after `math.ts`. No changes to `math.ts` (phase A) or `noise.ts` (phase B). No `deno.json` version bump.

## Files

- `src/services/Softcode/stdlib/physics.ts` (69 LOC)
- `src/services/Softcode/stdlib/index.ts` (+1 line: `import "./physics.ts"`)
- `tests/softcode_physics.test.ts` (14 tests)

## Gate results

- `deno check --unstable-kv mod.ts` — clean
- `deno lint` — clean (357 files)
- `deno test tests/softcode_physics.test.ts` — 14 passed, 0 failed
- `deno test tests/` — 1140 passed, 0 failed
- `deno test tests/security_*.test.ts` — 141 passed, 0 failed

## Coverage

- **vreflect**: floor bounce, incident-along-normal (full reversal), perpendicular-to-normal (unchanged).
- **pointinaabb**: center, both corners (boundary inclusive), just-outside-a-face, empty box.
- **rayaabb**: direct hit, parallel miss, origin inside (0), pointing away, axis-parallel grazing face, diagonal corner entry.

## Not in scope

- No `deno.json` bump (per task constraints).
- No merge — review only.