### PR TITLE
feat: math/spatial/interpolation stdlib expansion + randseed + Unreal aliases (v2.5.0 phase A)

### DIFF
--- a/src/services/Softcode/stdlib/list.ts
+++ b/src/services/Softcode/stdlib/list.ts
@@ -4,6 +4,7 @@ import type { EvalContext } from "../context.ts";
 import type { UrsaEvalContext } from "../ursamu-context.ts";
 import { makeSubCtx, toLibCtx } from "../ursamu-context.ts";
 import { int, splitList as split, joinList as join } from "./helpers.ts";
+import { random as rngRandom } from "./rng.ts";
 
 // ── basic list access ─────────────────────────────────────────────────────
 
@@ -153,7 +154,7 @@ register("lrand", async (a) => {
   const lo = int(a[0]); const hi = int(a[1]); const n = int(a[2] ?? "1");
   if (hi < lo) return "";
   const out: string[] = [];
-  for (let i = 0; i < n; i++) out.push(String(lo + Math.floor(Math.random() * (hi - lo + 1))));
+  for (let i = 0; i < n; i++) out.push(String(lo + Math.floor(rngRandom() * (hi - lo + 1))));
   return join(out, a[3]);
 });
 

--- a/src/services/Softcode/stdlib/math.ts
+++ b/src/services/Softcode/stdlib/math.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file require-await
 import { register } from "./registry.ts";
 import { num, int, fmt } from "./helpers.ts";
+import { random as rngRandom, setSeed as rngSetSeed, getSeed as rngGetSeed } from "./rng.ts";
 
 // ── arithmetic ────────────────────────────────────────────────────────────
 
@@ -81,10 +82,13 @@ register("atan2",async (a) => fmt(Math.atan2(num(a[0]), num(a[1]))));
 
 // ── random ────────────────────────────────────────────────────────────────
 
+// rand() draws from the shared stdlib RNG (see ./rng.ts). When randseed()
+// has been called, results are deterministic; otherwise it falls through to
+// Math.random() for backwards compatibility.
 register("rand",  async (a) => {
   const n = int(a[0]);
   if (n <= 0) return "#-1 ARGUMENT MUST BE POSITIVE INTEGER";
-  return fmt(Math.floor(Math.random() * n));
+  return fmt(Math.floor(rngRandom() * n));
 });
 
 // ── comparison ────────────────────────────────────────────────────────────
@@ -194,6 +198,138 @@ register("distribute", async (a) => {
   const base  = Math.floor(total / slots);
   const extra = total % slots;
   return Array.from({ length: slots }, (_, i) => base + (i < extra ? 1 : 0)).join(delim);
+});
+
+// ── extended math (v2.5.0) ────────────────────────────────────────────────
+
+register("hypot",  async (a) => fmt(Math.hypot(...a.map(x => parseFloat(x) || 0))));
+register("cbrt",   async (a) => fmt(Math.cbrt(num(a[0]))));
+register("log2",   async (a) => { const v = num(a[0]); return v <= 0 ? "#-1 ARGUMENT OUT OF RANGE" : fmt(Math.log2(v)); });
+register("log10",  async (a) => { const v = num(a[0]); return v <= 0 ? "#-1 ARGUMENT OUT OF RANGE" : fmt(Math.log10(v)); });
+register("log1p",  async (a) => { const v = num(a[0]); return v <= -1 ? "#-1 ARGUMENT OUT OF RANGE" : fmt(Math.log1p(v)); });
+register("expm1",  async (a) => fmt(Math.expm1(num(a[0]))));
+register("sinh",   async (a) => fmt(Math.sinh(num(a[0]))));
+register("cosh",   async (a) => fmt(Math.cosh(num(a[0]))));
+register("tanh",   async (a) => fmt(Math.tanh(num(a[0]))));
+register("asinh",  async (a) => fmt(Math.asinh(num(a[0]))));
+register("acosh",  async (a) => { const v = num(a[0]); return v < 1 ? "#-1 ARGUMENT OUT OF RANGE" : fmt(Math.acosh(v)); });
+register("atanh",  async (a) => { const v = num(a[0]); return v <= -1 || v >= 1 ? "#-1 ARGUMENT OUT OF RANGE" : fmt(Math.atanh(v)); });
+
+register("clamp", async (a) => {
+  const x  = num(a[0]);
+  const b1 = num(a[1]);
+  const b2 = num(a[2]);
+  const lo = Math.min(b1, b2);
+  const hi = Math.max(b1, b2);
+  return fmt(Math.min(hi, Math.max(lo, x)));
+});
+
+// ── interpolation ─────────────────────────────────────────────────────────
+
+register("lerp", async (a) => {
+  const x = num(a[0]), y = num(a[1]), t = num(a[2]);
+  return fmt(x + (y - x) * t);
+});
+register("inverselerp", async (a) => {
+  const x = num(a[0]), y = num(a[1]), v = num(a[2]);
+  if (x === y) return "#-1 DIVISION BY ZERO";
+  return fmt((v - x) / (y - x));
+});
+register("remap", async (a) => {
+  const x = num(a[0]), iMin = num(a[1]), iMax = num(a[2]);
+  const oMin = num(a[3]), oMax = num(a[4]);
+  if (iMin === iMax) return "#-1 DIVISION BY ZERO";
+  return fmt(oMin + ((x - iMin) * (oMax - oMin)) / (iMax - iMin));
+});
+register("smoothstep", async (a) => {
+  const e0 = num(a[0]), e1 = num(a[1]), x = num(a[2]);
+  if (e0 === e1) return "#-1 DIVISION BY ZERO";
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return fmt(t * t * (3 - 2 * t));
+});
+register("smootherstep", async (a) => {
+  const e0 = num(a[0]), e1 = num(a[1]), x = num(a[2]);
+  if (e0 === e1) return "#-1 DIVISION BY ZERO";
+  const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return fmt(t * t * t * (t * (t * 6 - 15) + 10));
+});
+
+// ── spatial scalars ───────────────────────────────────────────────────────
+
+register("distsq2d", async (a) => {
+  const dx = num(a[0]) - num(a[2]);
+  const dy = num(a[1]) - num(a[3]);
+  return fmt(dx*dx + dy*dy);
+});
+register("distsq3d", async (a) => {
+  const dx = num(a[0]) - num(a[3]);
+  const dy = num(a[1]) - num(a[4]);
+  const dz = num(a[2]) - num(a[5]);
+  return fmt(dx*dx + dy*dy + dz*dz);
+});
+register("manhattan", async (a) => {
+  return fmt(Math.abs(num(a[0]) - num(a[2])) + Math.abs(num(a[1]) - num(a[3])));
+});
+register("chebyshev", async (a) => {
+  return fmt(Math.max(Math.abs(num(a[0]) - num(a[2])), Math.abs(num(a[1]) - num(a[3]))));
+});
+register("angle2d", async (a) => {
+  const dx = num(a[2]) - num(a[0]);
+  const dy = num(a[3]) - num(a[1]);
+  return fmt(Math.atan2(dy, dx));
+});
+// bearing — MUSH convention: 0 = N (+Y), clockwise, degrees in [0, 360).
+register("bearing", async (a) => {
+  const dx = num(a[2]) - num(a[0]);
+  const dy = num(a[3]) - num(a[1]);
+  const deg = Math.atan2(dy, dx) * 180 / Math.PI;
+  return fmt(((90 - deg) % 360 + 360) % 360);
+});
+
+// ── seedable RNG ──────────────────────────────────────────────────────────
+//
+// randseed() — get/set the shared RNG seed. Once set, rand() and lrand()
+// produce deterministic sequences. Call with no args to read the seed,
+// or pass an integer to (re)seed. There is no way to unseed via softcode.
+register("randseed", async (a) => {
+  if (a[0] === undefined || a[0].trim() === "") {
+    const s = rngGetSeed();
+    return s === null ? "" : String(s);
+  }
+  rngSetSeed(int(a[0]));
+  return String(int(a[0]));
+});
+
+// ── Unreal-style vector aliases ───────────────────────────────────────────
+
+register("vsize",    async (a) => { const v = a[0].split(" ").map(num); return fmt(Math.sqrt(v.reduce((s,x) => s+x*x, 0))); });
+register("vsizesq",  async (a) => { const v = a[0].split(" ").map(num); return fmt(v.reduce((s,x) => s+x*x, 0)); });
+register("vdistance", async (a) => {
+  const [x1,y1,z1] = a[0].split(" ").map(num);
+  const [x2,y2,z2] = a[1].split(" ").map(num);
+  const dx = x1-x2, dy = y1-y2, dz = (z1||0)-(z2||0);
+  return fmt(Math.sqrt(dx*dx + dy*dy + dz*dz));
+});
+register("vdistsquared", async (a) => {
+  const [x1,y1,z1] = a[0].split(" ").map(num);
+  const [x2,y2,z2] = a[1].split(" ").map(num);
+  const dx = x1-x2, dy = y1-y2, dz = (z1||0)-(z2||0);
+  return fmt(dx*dx + dy*dy + dz*dz);
+});
+register("vlerp", async (a) => {
+  const va = a[0].split(" ").map(num);
+  const vb = a[1].split(" ").map(num);
+  const t  = num(a[2]);
+  const n  = Math.max(va.length, vb.length);
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) out.push(fmt((va[i] ?? 0) + ((vb[i] ?? 0) - (va[i] ?? 0)) * t));
+  return out.join(" ");
+});
+register("vclamp", async (a) => {
+  const v  = a[0].split(" ").map(num);
+  const b1 = num(a[1]), b2 = num(a[2]);
+  const lo = Math.min(b1, b2), hi = Math.max(b1, b2);
+  return v.map(x => fmt(Math.min(hi, Math.max(lo, x)))).join(" ");
 });
 
 register("bittype",    async () => "0");

--- a/src/services/Softcode/stdlib/rng.ts
+++ b/src/services/Softcode/stdlib/rng.ts
@@ -1,0 +1,29 @@
+// Shared seedable RNG for the softcode stdlib.
+//
+// When unseeded (_state === null), `random()` defers to Math.random() to
+// preserve historical behavior. Once `setSeed(n)` is called (including
+// setSeed(0)), all stdlib random consumers (rand, lrand, randseed) draw
+// from a mulberry32 PRNG so sequences become deterministic across calls.
+//
+// Call `setSeed(null)` to clear the seed and return to Math.random().
+
+let _state: number | null = null;
+let _seed:  number | null = null;
+
+/** Returns the current seed, or null if unseeded. */
+export function getSeed(): number | null { return _seed; }
+
+/** Seed the RNG. Pass null to clear and fall back to Math.random(). */
+export function setSeed(seed: number | null): void {
+  _seed  = seed;
+  _state = seed === null ? null : (seed >>> 0);
+}
+
+/** mulberry32 — returns a float in [0, 1). */
+export function random(): number {
+  if (_state === null) return Math.random();
+  let t = (_state = (_state + 0x6D2B79F5) >>> 0);
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}

--- a/tests/softcode_math_extensions.test.ts
+++ b/tests/softcode_math_extensions.test.ts
@@ -1,0 +1,247 @@
+/**
+ * tests/softcode_math_extensions.test.ts
+ *
+ * Tests for v2.5.0 math/spatial/interpolation stdlib extensions —
+ * extended trig/log, clamp, lerp family, distance helpers, bearing,
+ * randseed determinism, and Unreal-style vector aliases.
+ */
+import { assertEquals, assertAlmostEquals } from "@std/assert";
+import { runSoftcode, softcodeEngine } from "../src/services/Softcode/ursamu-engine.ts";
+import type { UrsaEvalContext } from "../src/services/Softcode/ursamu-context.ts";
+import type { DbAccessor, OutputAccessor } from "../src/services/Softcode/context.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+function makeActor(overrides: Partial<IDBObj> = {}): IDBObj {
+  return {
+    id: "1",
+    name: "Tester",
+    flags: new Set(["player", "connected"]),
+    location: "0",
+    state: {},
+    contents: [],
+    ...overrides,
+  };
+}
+
+function makeDb(overrides: Partial<DbAccessor> = {}): DbAccessor {
+  return {
+    queryById:        () => Promise.resolve(null),
+    queryByName:      () => Promise.resolve(null),
+    lcon:             () => Promise.resolve([]),
+    lwho:             () => Promise.resolve([]),
+    lattr:            () => Promise.resolve([]),
+    getAttribute:     () => Promise.resolve(null),
+    getTagById:       () => Promise.resolve(null),
+    getPlayerTagById: () => Promise.resolve(null),
+    lsearch:          () => Promise.resolve([]),
+    children:         () => Promise.resolve([]),
+    lchannels:        () => Promise.resolve(""),
+    channelsFor:      () => Promise.resolve(""),
+    mailCount:        () => Promise.resolve(0),
+    queueLength:      () => Promise.resolve(0),
+    getIdleSecs:      () => Promise.resolve(0),
+    getUserFn:        () => Promise.resolve(null),
+    ...overrides,
+  };
+}
+
+const noOutput: OutputAccessor = {
+  send:          () => {},
+  roomBroadcast: () => {},
+  broadcast:     () => {},
+};
+
+function makeCtx(overrides: Partial<UrsaEvalContext> = {}): UrsaEvalContext {
+  const actor = makeActor();
+  return {
+    enactor:      actor.id,
+    executor:     actor,
+    caller:       null,
+    actor,
+    args:         [],
+    registers:    new Map(),
+    iterStack:    [],
+    depth:        0,
+    maxDepth:     50,
+    maxOutputLen: 65_536,
+    deadline:     Date.now() + 5000,
+    db:           makeDb(),
+    output:       noOutput,
+    _engine:      softcodeEngine,
+    ...overrides,
+  };
+}
+
+const run  = (code: string) => runSoftcode(code, makeCtx());
+const runF = async (code: string) => parseFloat(await run(code));
+
+// ── extended trig / log ────────────────────────────────────────────────────
+
+Deno.test("hypot — pythagorean triple", async () => {
+  assertEquals(await run("[hypot(3,4)]"), "5");
+});
+
+Deno.test("hypot — variadic 3 args", async () => {
+  assertAlmostEquals(await runF("[hypot(2,3,6)]"), 7, 1e-9);
+});
+
+Deno.test("cbrt — perfect cube", async () => {
+  assertEquals(await run("[cbrt(27)]"), "3");
+});
+
+Deno.test("log2/log10/log1p/expm1 parity", async () => {
+  assertEquals(await run("[log2(8)]"), "3");
+  assertEquals(await run("[log10(1000)]"), "3");
+  assertAlmostEquals(await runF("[log1p(0)]"), 0, 1e-12);
+  assertAlmostEquals(await runF("[expm1(0)]"), 0, 1e-12);
+});
+
+Deno.test("hyperbolic trig parity", async () => {
+  assertAlmostEquals(await runF("[sinh(0)]"), 0, 1e-12);
+  assertAlmostEquals(await runF("[cosh(0)]"), 1, 1e-12);
+  assertAlmostEquals(await runF("[tanh(0)]"), 0, 1e-12);
+  assertAlmostEquals(await runF("[asinh(0)]"), 0, 1e-12);
+  assertAlmostEquals(await runF("[acosh(1)]"), 0, 1e-12);
+  assertAlmostEquals(await runF("[atanh(0)]"), 0, 1e-12);
+});
+
+// ── sign / clamp ───────────────────────────────────────────────────────────
+
+Deno.test("sign — negative/zero/positive", async () => {
+  assertEquals(await run("[sign(-7.5)]"), "-1");
+  assertEquals(await run("[sign(0)]"), "0");
+  assertEquals(await run("[sign(3.2)]"), "1");
+});
+
+Deno.test("clamp — below/inside/above", async () => {
+  assertEquals(await run("[clamp(-5,0,10)]"), "0");
+  assertEquals(await run("[clamp(5,0,10)]"), "5");
+  assertEquals(await run("[clamp(99,0,10)]"), "10");
+});
+
+Deno.test("clamp — swapped bounds normalized", async () => {
+  assertEquals(await run("[clamp(5,10,0)]"), "5");
+  assertEquals(await run("[clamp(-1,10,0)]"), "0");
+  assertEquals(await run("[clamp(99,10,0)]"), "10");
+});
+
+// ── interpolation ──────────────────────────────────────────────────────────
+
+Deno.test("lerp — endpoints + midpoint + out-of-range", async () => {
+  assertEquals(await run("[lerp(0,10,0)]"), "0");
+  assertEquals(await run("[lerp(0,10,1)]"), "10");
+  assertEquals(await run("[lerp(0,10,0.5)]"), "5");
+  assertEquals(await run("[lerp(0,10,2)]"), "20"); // no clamping
+});
+
+Deno.test("inverselerp — basic and degenerate", async () => {
+  assertEquals(await run("[inverselerp(0,10,5)]"), "0.5");
+  const err = await run("[inverselerp(5,5,5)]");
+  assertEquals(err.startsWith("#-1"), true);
+});
+
+Deno.test("remap — linear remap", async () => {
+  assertEquals(await run("[remap(5,0,10,0,100)]"), "50");
+  assertEquals(await run("[remap(0,0,1,-1,1)]"), "-1");
+});
+
+Deno.test("smoothstep — boundaries and midpoint", async () => {
+  assertEquals(await run("[smoothstep(0,1,-1)]"), "0");
+  assertEquals(await run("[smoothstep(0,1,2)]"), "1");
+  assertEquals(await run("[smoothstep(0,1,0.5)]"), "0.5");
+});
+
+Deno.test("smootherstep — boundaries and midpoint", async () => {
+  assertEquals(await run("[smootherstep(0,1,-1)]"), "0");
+  assertEquals(await run("[smootherstep(0,1,2)]"), "1");
+  assertEquals(await run("[smootherstep(0,1,0.5)]"), "0.5");
+});
+
+// ── spatial scalars ────────────────────────────────────────────────────────
+
+Deno.test("dist2d / distsq2d parity", async () => {
+  assertEquals(await run("[dist2d(0,0,3,4)]"), "5");
+  assertEquals(await run("[distsq2d(0,0,3,4)]"), "25");
+  assertEquals(await run("[dist2d(0,0,0,0)]"), "0");
+  assertEquals(await run("[dist2d(-1,-1,2,3)]"), "5");
+});
+
+Deno.test("dist3d / distsq3d parity", async () => {
+  assertEquals(await run("[dist3d(0,0,0,1,2,2)]"), "3");
+  assertEquals(await run("[distsq3d(0,0,0,1,2,2)]"), "9");
+});
+
+Deno.test("manhattan / chebyshev", async () => {
+  assertEquals(await run("[manhattan(0,0,3,4)]"), "7");
+  assertEquals(await run("[chebyshev(0,0,3,4)]"), "4");
+});
+
+Deno.test("angle2d — returns radians", async () => {
+  // (0,0) → (1,1) is 45° = pi/4
+  assertAlmostEquals(await runF("[angle2d(0,0,1,1)]"), Math.PI / 4, 1e-9);
+  // (0,0) → (1,0) is 0
+  assertAlmostEquals(await runF("[angle2d(0,0,1,0)]"), 0, 1e-12);
+});
+
+Deno.test("bearing — MUSH compass (N=0, clockwise)", async () => {
+  // due-N target (+Y) → 0°
+  assertAlmostEquals(await runF("[bearing(0,0,0,1)]"), 0, 1e-9);
+  // due-E target (+X) → 90°
+  assertAlmostEquals(await runF("[bearing(0,0,1,0)]"), 90, 1e-9);
+  // due-S → 180°
+  assertAlmostEquals(await runF("[bearing(0,0,0,-1)]"), 180, 1e-9);
+  // due-W → 270°
+  assertAlmostEquals(await runF("[bearing(0,0,-1,0)]"), 270, 1e-9);
+});
+
+Deno.test("bearing — in [0, 360)", async () => {
+  const v = await runF("[bearing(0,0,-1,-1)]");
+  if (v < 0 || v >= 360) throw new Error(`bearing out of range: ${v}`);
+});
+
+// ── randseed determinism ───────────────────────────────────────────────────
+
+Deno.test("randseed — same seed → same sequence", async () => {
+  const a = await run("[randseed(42)][rand(1000000)] [rand(1000000)] [rand(1000000)]");
+  const b = await run("[randseed(42)][rand(1000000)] [rand(1000000)] [rand(1000000)]");
+  // Strip the leading "42" that randseed echoes back, then compare.
+  assertEquals(a, b);
+});
+
+Deno.test("randseed — different seed differs", async () => {
+  const a = await run("[randseed(42)][rand(1000000)] [rand(1000000)] [rand(1000000)]");
+  const b = await run("[randseed(43)][rand(1000000)] [rand(1000000)] [rand(1000000)]");
+  if (a === b) throw new Error("expected different sequences for different seeds");
+});
+
+Deno.test("randseed — seed 0 is valid", async () => {
+  const a = await run("[randseed(0)][rand(100)]");
+  const b = await run("[randseed(0)][rand(100)]");
+  assertEquals(a, b);
+});
+
+Deno.test("randseed — get current seed", async () => {
+  // Set then read back
+  await run("[randseed(7)]");
+  assertEquals(await run("[randseed()]"), "7");
+});
+
+// ── Unreal-style aliases ───────────────────────────────────────────────────
+
+Deno.test("vsize / vsizesq", async () => {
+  assertEquals(await run("[vsize(3 0 4)]"), "5");
+  assertEquals(await run("[vsizesq(3 0 4)]"), "25");
+});
+
+Deno.test("vdistance / vdistsquared", async () => {
+  assertEquals(await run("[vdistance(0 0 0,3 0 4)]"), "5");
+  assertEquals(await run("[vdistsquared(0 0 0,3 0 4)]"), "25");
+});
+
+Deno.test("vlerp — component-wise", async () => {
+  assertEquals(await run("[vlerp(0 0 0,10 20 30,0.5)]"), "5 10 15");
+});
+
+Deno.test("vclamp — component-wise", async () => {
+  assertEquals(await run("[vclamp(-5 5 20,0,10)]"), "0 5 10");
+});


### PR DESCRIPTION
## Summary

Phase A of the v2.5.0 softcode stdlib expansion. Adds extended math,
interpolation helpers, spatial scalars, a seedable RNG, and Unreal-style
vector aliases. Version bump in `deno.json` is intentionally deferred —
the release-train orchestrator will bump once all three Phase agents land.

### New functions

**Math (11):** `hypot` (variadic), `cbrt`, `log2`, `log10`, `log1p`,
`expm1`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `clamp`.
`atan2`, `sign`, `trunc` were already present in `math.ts`.

**Interpolation (5):** `lerp`, `inverselerp`, `remap`, `smoothstep`,
`smootherstep`.

**Spatial scalars (6):** `distsq2d`, `distsq3d`, `manhattan`, `chebyshev`,
`angle2d` (radians), `bearing` (MUSH compass — 0 = N, clockwise, degrees
in `[0, 360)`). `dist2d` / `dist3d` were already present.

**Seedable RNG (1):** `randseed(n)` sets the seed; `randseed()` reads it.
A new shared `stdlib/rng.ts` module (mulberry32) backs both `rand()` and
`lrand()`. When unseeded, both functions fall through to `Math.random()`
for backwards compatibility. `randseed(0)` is a valid seed.

**Unreal aliases (6):** `vsize`, `vsizesq`, `vdistance`, `vdistsquared`,
`vlerp` (component-wise), `vclamp` (component-wise).

### Notes

- `clamp(x, a, b)` normalizes swapped bounds — it clamps to
  `[min(a, b), max(a, b)]` regardless of arg order.
- `bearing` uses the MUSH convention (`((90 - degrees(atan2(dy, dx))) +
  360) mod 360`) — North = +Y, 0°; clockwise.
- `lerp` does **not** clamp `t` to `[0, 1]`; out-of-range extrapolates.
- `randseed` does not expose an unseed path from softcode — once set, the
  process-local RNG stays deterministic until restart.

### Gate results

- `deno check --unstable-kv mod.ts` — clean.
- `deno lint` — clean (357 files).
- `deno test tests/` — **1173 passed, 0 failed** (was 1141; +27 new + a
  few that landed on main since the last snapshot).
- `deno test tests/security_*.test.ts` — **147 passed, 0 failed**.

## Test plan

- [ ] CI runs the full suite + security suite green.
- [ ] Sanity-check `bearing`/`angle2d` from in-game softcode if desired.
- [ ] Confirm no regression in existing `rand()` / `lrand()` callers
      (both still defer to `Math.random()` until `randseed` is called).