### PR TITLE
feat: v2.5.0 — math/spatial/noise/physics stdlib + TDD audit fixes

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/src/services/Softcode/stdlib/math.ts
+++ b/src/services/Softcode/stdlib/math.ts
@@ -296,27 +296,48 @@ register("randseed", async (a) => {
     const s = rngGetSeed();
     return s === null ? "" : String(s);
   }
+  // L3 audit fix — explicit "clear" arg reverts to Math.random() fallback.
+  if (a[0].trim().toLowerCase() === "clear") {
+    rngSetSeed(null);
+    return "";
+  }
   rngSetSeed(int(a[0]));
   return String(int(a[0]));
 });
 
 // ── Unreal-style vector aliases ───────────────────────────────────────────
+// All vector aliases require their args to be non-empty space-separated
+// numeric vectors. Missing or empty args return the MUSH "#-1 ARGUMENT
+// MISSING" string instead of throwing (M2 audit fix).
 
-register("vsize",    async (a) => { const v = a[0].split(" ").map(num); return fmt(Math.sqrt(v.reduce((s,x) => s+x*x, 0))); });
-register("vsizesq",  async (a) => { const v = a[0].split(" ").map(num); return fmt(v.reduce((s,x) => s+x*x, 0)); });
+const ARGMISS = "#-1 ARGUMENT MISSING";
+
+register("vsize", async (a) => {
+  if (!a[0]) return ARGMISS;
+  const v = a[0].split(" ").map(num);
+  return fmt(Math.sqrt(v.reduce((s,x) => s+x*x, 0)));
+});
+register("vsizesq", async (a) => {
+  if (!a[0]) return ARGMISS;
+  const v = a[0].split(" ").map(num);
+  return fmt(v.reduce((s,x) => s+x*x, 0));
+});
 register("vdistance", async (a) => {
+  if (!a[0] || !a[1]) return ARGMISS;
   const [x1,y1,z1] = a[0].split(" ").map(num);
   const [x2,y2,z2] = a[1].split(" ").map(num);
   const dx = x1-x2, dy = y1-y2, dz = (z1||0)-(z2||0);
   return fmt(Math.sqrt(dx*dx + dy*dy + dz*dz));
 });
 register("vdistsquared", async (a) => {
+  if (!a[0] || !a[1]) return ARGMISS;
   const [x1,y1,z1] = a[0].split(" ").map(num);
   const [x2,y2,z2] = a[1].split(" ").map(num);
   const dx = x1-x2, dy = y1-y2, dz = (z1||0)-(z2||0);
   return fmt(dx*dx + dy*dy + dz*dz);
 });
 register("vlerp", async (a) => {
+  if (!a[0] || !a[1] || a[2] === undefined) return ARGMISS;
   const va = a[0].split(" ").map(num);
   const vb = a[1].split(" ").map(num);
   const t  = num(a[2]);
@@ -326,6 +347,7 @@ register("vlerp", async (a) => {
   return out.join(" ");
 });
 register("vclamp", async (a) => {
+  if (!a[0] || a[1] === undefined || a[2] === undefined) return ARGMISS;
   const v  = a[0].split(" ").map(num);
   const b1 = num(a[1]), b2 = num(a[2]);
   const lo = Math.min(b1, b2), hi = Math.max(b1, b2);

--- a/src/services/Softcode/stdlib/noise.ts
+++ b/src/services/Softcode/stdlib/noise.ts
@@ -224,10 +224,14 @@ function ridged2(x: number, y: number, octaves: number, persistence: number): nu
 // ── registrations ─────────────────────────────────────────────────────────
 
 register("noiseseed", async (a) => {
-  const seed = num(a[0]);
-  const prev = _seedInitialized ? _noiseSeed : "";
-  setSeed(seed);
-  return prev === "" ? "" : fmt(prev as number);
+  // No-arg or empty: read-only. Returns current seed, or "" if unseeded.
+  // M1 audit fix — previously coerced to setSeed(NaN) → seed 0 silently.
+  if (a[0] === undefined || a[0].trim() === "") {
+    return _seedInitialized ? fmt(_noiseSeed) : "";
+  }
+  const prev = _seedInitialized ? _noiseSeed : null;
+  setSeed(num(a[0]));
+  return prev === null ? "" : fmt(prev);
 });
 
 register("perlin1", async (a) => {

--- a/src/services/Softcode/stdlib/physics.ts
+++ b/src/services/Softcode/stdlib/physics.ts
@@ -1,20 +1,38 @@
 // deno-lint-ignore-file require-await
 import { register } from "./registry.ts";
-import { num, fmt } from "./helpers.ts";
+import { fmt } from "./helpers.ts";
 
 const EPS = 1e-10;
+const ARGBAD = "#-1 ARGUMENT OUT OF RANGE";
 
-function parseVec3(s: string): [number, number, number] {
-  const parts = s.split(" ").map(num);
-  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+/**
+ * Parse a "x y z" 3-vector. Returns null if any component is non-numeric or
+ * the string is missing/empty (L1 audit fix — previously silently coerced
+ * garbage to zero).
+ */
+function parseVec3(s: string | undefined): [number, number, number] | null {
+  if (s === undefined || s.trim() === "") return null;
+  const parts = s.split(" ").map(p => parseFloat(p));
+  if (parts.length < 3 || parts.some(p => !Number.isFinite(p))) return null;
+  return [parts[0], parts[1], parts[2]];
+}
+
+/** Parse a numeric arg, returning null on non-numeric or missing input. */
+function parseN(s: string | undefined): number | null {
+  if (s === undefined || s.trim() === "") return null;
+  const v = parseFloat(s);
+  return Number.isFinite(v) ? v : null;
 }
 
 // ── vreflect ──────────────────────────────────────────────────────────────
 // Reflect v across plane with normal n: r = v - 2*(v·n)*n.
 // Assumes n is already a unit vector; callers should pass a normalized normal.
 register("vreflect", async (a) => {
-  const [vx, vy, vz] = parseVec3(a[0] ?? "");
-  const [nx, ny, nz] = parseVec3(a[1] ?? "");
+  const v = parseVec3(a[0]);
+  const n = parseVec3(a[1]);
+  if (v === null || n === null) return ARGBAD;
+  const [vx, vy, vz] = v;
+  const [nx, ny, nz] = n;
   const dot = vx * nx + vy * ny + vz * nz;
   return [
     fmt(vx - 2 * dot * nx),
@@ -26,9 +44,9 @@ register("vreflect", async (a) => {
 // ── pointinaabb ───────────────────────────────────────────────────────────
 // Inclusive bounds check. Empty box (min > max on any axis) → outside.
 register("pointinaabb", async (a) => {
-  const px = num(a[0]), py = num(a[1]), pz = num(a[2]);
-  const minx = num(a[3]), miny = num(a[4]), minz = num(a[5]);
-  const maxx = num(a[6]), maxy = num(a[7]), maxz = num(a[8]);
+  const args = [0,1,2,3,4,5,6,7,8].map(i => parseN(a[i]));
+  if (args.some(v => v === null)) return ARGBAD;
+  const [px, py, pz, minx, miny, minz, maxx, maxy, maxz] = args as number[];
   if (minx > maxx || miny > maxy || minz > maxz) return "0";
   const inside =
     px >= minx && px <= maxx &&
@@ -41,10 +59,11 @@ register("pointinaabb", async (a) => {
 // Slab-method ray/AABB intersection. Returns entry t (≥0) on hit, or -1.
 // Ray starting inside the box returns 0.
 register("rayaabb", async (a) => {
-  const ox = num(a[0]), oy = num(a[1]), oz = num(a[2]);
-  const dx = num(a[3]), dy = num(a[4]), dz = num(a[5]);
-  const minv = [num(a[6]), num(a[7]), num(a[8])];
-  const maxv = [num(a[9]), num(a[10]), num(a[11])];
+  const args = [0,1,2,3,4,5,6,7,8,9,10,11].map(i => parseN(a[i]));
+  if (args.some(v => v === null)) return ARGBAD;
+  const [ox, oy, oz, dx, dy, dz, minx, miny, minz, maxx, maxy, maxz] = args as number[];
+  const minv = [minx, miny, minz];
+  const maxv = [maxx, maxy, maxz];
   const o = [ox, oy, oz];
   const d = [dx, dy, dz];
 

--- a/tests/security_softcode_v2_5_audit.test.ts
+++ b/tests/security_softcode_v2_5_audit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * v2.5.0 stdlib TDD audit — covers M1, M2, L1, L3 findings.
+ *
+ * M1: noiseseed() with empty/missing arg must NOT silently reset seed to 0.
+ * M2: Unreal vector aliases (vsize/vsizesq/vdistance/vdistsquared/vlerp/vclamp)
+ *     must return MUSH-style "#-1 ARGUMENT MISSING" on missing args, not throw.
+ * L1: parseVec3 (vreflect inputs) must reject non-numeric input rather than
+ *     silently coercing to zero.
+ * L3: randseed must accept any numeric seed value (truncating documented in help)
+ *     and randseed("clear") must restore Math.random() fallback.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { softcodeService } from "../src/services/Softcode/index.ts";
+import { dbojs, DBO } from "../src/services/Database/database.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false, timeout: 15000 };
+
+const ACTOR = "audit_v2_5";
+
+async function evalCode(code: string): Promise<string> {
+  return await softcodeService.runSoftcode(code, {
+    actorId:    ACTOR,
+    executorId: ACTOR,
+    args:       [],
+  });
+}
+
+Deno.test("audit setup", OPTS, async () => {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected",
+    data: { name: "Auditor" },
+    location: ACTOR,
+  });
+});
+
+// ── M1 ──────────────────────────────────────────────────────────────────────
+// Softcode module state is per-eval (each runSoftcode spawns a fresh worker),
+// so we exercise read/write semantics within a single eval.
+
+Deno.test("M1: noiseseed() with no arg reads current seed without resetting", OPTS, async () => {
+  // After noiseseed(42), a no-arg noiseseed() must report 42 (not "" / 0).
+  const out = await evalCode("[noiseseed(42)][noiseseed()]");
+  assertStringIncludes(out, "42");
+});
+
+Deno.test("M1: noiseseed() with no arg on fresh worker returns empty (unseeded)", OPTS, async () => {
+  const out = await evalCode("[noiseseed()]");
+  assertEquals(out, "", "fresh worker has no seed; read should be empty");
+});
+
+Deno.test("M1: noiseseed() with explicit numeric arg returns prev seed and updates state", OPTS, async () => {
+  // After noiseseed(42), call noiseseed(99) → returns "42" (prev). Then a
+  // read returns "99". Final concat: "4299" — three chars from prev plus
+  // empty from the noop set return.
+  const out = await evalCode("[noiseseed(42)][noiseseed(99)][noiseseed()]");
+  // Expect: first set returns "" (no prev), second set returns "42", read returns "99"
+  assertEquals(out, "4299");
+});
+
+// ── M2 ──────────────────────────────────────────────────────────────────────
+Deno.test("M2: vsize() with no arg returns MUSH error, doesn't throw", OPTS, async () => {
+  const out = await evalCode("[vsize()]");
+  assertStringIncludes(out, "#-1");
+  assertStringIncludes(out, "ARGUMENT");
+});
+
+Deno.test("M2: vsizesq() with no arg returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vsizesq()]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("M2: vdistance() with missing second arg returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vdistance(0 0 0)]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("M2: vdistsquared() with missing second arg returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vdistsquared(0 0 0)]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("M2: vlerp() with missing args returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vlerp()]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("M2: vclamp() with missing args returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vclamp()]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("M2: well-formed calls still work after the guards", OPTS, async () => {
+  assertEquals(await evalCode("[vsize(3 0 4)]"), "5");
+  assertEquals(await evalCode("[vsizesq(3 0 4)]"), "25");
+  assertEquals(await evalCode("[vdistance(0 0 0,3 0 4)]"), "5");
+});
+
+// ── L1 ──────────────────────────────────────────────────────────────────────
+Deno.test("L1: vreflect() with non-numeric input returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[vreflect(foo bar baz,0 1 0)]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("L1: pointinaabb() with non-numeric input returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[pointinaabb(foo,0,0,0,0,0,1,1,1)]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("L1: rayaabb() with non-numeric input returns MUSH error", OPTS, async () => {
+  const out = await evalCode("[rayaabb(foo,0,0,1,0,0,0,0,0,1,1,1)]");
+  assertStringIncludes(out, "#-1");
+});
+
+Deno.test("L1: physics functions still work on valid input", OPTS, async () => {
+  assertEquals(await evalCode("[pointinaabb(0.5,0.5,0.5,0,0,0,1,1,1)]"), "1");
+  assertEquals(await evalCode("[pointinaabb(2,0.5,0.5,0,0,0,1,1,1)]"), "0");
+});
+
+// ── L3 ──────────────────────────────────────────────────────────────────────
+// Same per-worker scope caveat: do all reads/writes inside one eval.
+Deno.test("L3: randseed(clear) restores Math.random() fallback within one eval", OPTS, async () => {
+  // Set seed → read seed → clear → read seed. All in one softcode eval.
+  // Expected concat: "123" (set returns the new seed) + "123" (read) + "" (clear returns empty) + "" (read post-clear) = "123123"
+  const out = await evalCode("[randseed(123)][randseed()][randseed(clear)][randseed()]");
+  assertEquals(out, "123123", `concat was: ${JSON.stringify(out)}`);
+});
+
+Deno.test("audit cleanup", OPTS, async () => {
+  await dbojs.delete({ id: ACTOR }).catch(() => {});
+  await DBO.close();
+});


### PR DESCRIPTION
## Summary
Bumps to **v2.5.0** with full stdlib expansion (Phases A/B/C merged via #139/#140/#141) plus TDD-audit remediation of 4 findings on the new surface.

## v2.5.0 surface (from prior PRs)

| File | Phase | Adds |
|---|---|---|
| math.ts | A (#141) | 30 funcs: hypot/cbrt/log{2,10,1p}/expm1, hyperbolic + inverse, clamp, lerp/inverselerp/remap/smoothstep/smootherstep, dist{,sq}{2d,3d}, manhattan/chebyshev/angle2d/bearing, randseed, vsize/vsizesq/vdistance/vdistsquared/vlerp/vclamp |
| noise.ts | B (#139) | perlin1/2/3, simplex2, worley2, fbm2, ridged2, noiseseed, noisegrid |
| physics.ts | C (#140) | vreflect, pointinaabb, rayaabb |
| rng.ts | A (#141) | shared seedable mulberry32 backing rand/lrand/randseed |

## Audit fixes (this PR)

| ID | Sev | Issue | Fix |
|---|---|---|---|
| M1 | MED | \`noiseseed()\` with empty arg silently coerced to \`setSeed(NaN)\` → seed 0 | Empty/missing arg now reads the current seed; only sets on explicit numeric input |
| M2 | MED | Unreal vector aliases threw \`TypeError\` on missing arg | All 6 aliases now return \`#-1 ARGUMENT MISSING\` |
| L1 | LOW | physics \`parseVec3\` silently coerced garbage to zero | Returns \`#-1 ARGUMENT OUT OF RANGE\` on non-numeric input |
| L3 | LOW | \`randseed\` had no softcode path to revert to \`Math.random()\` | \`randseed(clear)\` exposes the inverse |

(L2 was an unsound TS type assertion in \`noiseseed\` — cleaned up by the M1 fix.)

## Tests
\`tests/security_softcode_v2_5_audit.test.ts\` — **17 new cases** covering all four findings. Notably exercises the per-worker softcode state scope (each \`runSoftcode\` is a fresh worker, so audit tests use multi-statement softcode to inspect within one eval).

## Gates
- [x] \`deno check --unstable-kv mod.ts\` — clean
- [x] \`deno lint\` — clean (362 files)
- [x] \`deno test tests/\` — **1204 passed / 0 failed**
- [x] \`deno test tests/security_*.test.ts\` — 158 passed / 0 failed

## Version
\`2.4.0\` → \`2.5.0\` (minor — substantial stdlib additions, no breaking changes).