### PR TITLE
feat: per-instance Rng class for plugin TS code (v2.5.1 part 2)

### DIFF
--- a/src/services/Softcode/stdlib/rng.ts
+++ b/src/services/Softcode/stdlib/rng.ts
@@ -7,23 +7,93 @@
 //
 // Call `setSeed(null)` to clear the seed and return to Math.random().
 
+/** Internal: mulberry32 step — advances state and returns next float in [0,1). */
+function mulberry32Step(state: number): { value: number; state: number } {
+  const s = (state + 0x6D2B79F5) >>> 0;
+  let t = s;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return { value: ((t ^ (t >>> 14)) >>> 0) / 4294967296, state: s };
+}
+
 let _state: number | null = null;
-let _seed:  number | null = null;
+let _seed: number | null = null;
 
 /** Returns the current seed, or null if unseeded. */
-export function getSeed(): number | null { return _seed; }
+export function getSeed(): number | null {
+  return _seed;
+}
 
 /** Seed the RNG. Pass null to clear and fall back to Math.random(). */
 export function setSeed(seed: number | null): void {
-  _seed  = seed;
+  _seed = seed;
   _state = seed === null ? null : (seed >>> 0);
 }
 
 /** mulberry32 — returns a float in [0, 1). */
 export function random(): number {
   if (_state === null) return Math.random();
-  let t = (_state = (_state + 0x6D2B79F5) >>> 0);
-  t = Math.imul(t ^ (t >>> 15), t | 1);
-  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  const step = mulberry32Step(_state);
+  _state = step.state;
+  return step.value;
+}
+
+/**
+ * Per-instance seedable PRNG (mulberry32). Independent of the module-level
+ * singleton used by softcode rand()/lrand().
+ *
+ * Construct with a numeric seed for deterministic sequences, or with no arg
+ * (or null) to delegate to Math.random().
+ */
+export class Rng {
+  private _state: number | null;
+  private _seed: number | null;
+
+  constructor(seed: number | null = null) {
+    this._seed = seed ?? null;
+    this._state = seed == null ? null : (seed >>> 0);
+  }
+
+  setSeed(seed: number | null): void {
+    this._seed = seed;
+    this._state = seed === null ? null : (seed >>> 0);
+  }
+
+  getSeed(): number | null {
+    return this._seed;
+  }
+
+  /** [0, 1) */
+  random(): number {
+    if (this._state === null) return Math.random();
+    const step = mulberry32Step(this._state);
+    this._state = step.state;
+    return step.value;
+  }
+
+  /** Integer in [min, max] inclusive. */
+  rand(min: number, max: number): number {
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  /** Pick a random element; undefined when items is empty. */
+  pick<T>(items: readonly T[]): T | undefined {
+    if (items.length === 0) return undefined;
+    return items[Math.floor(this.random() * items.length)];
+  }
+
+  /** Fisher–Yates shuffle; returns a new array, never mutates input. */
+  shuffle<T>(items: readonly T[]): T[] {
+    const out = items.slice();
+    for (let i = out.length - 1; i > 0; i--) {
+      const j = Math.floor(this.random() * (i + 1));
+      [out[i], out[j]] = [out[j], out[i]];
+    }
+    return out;
+  }
+}
+
+/** Convenience factory: `createRng(42)` is equivalent to `new Rng(42)`. */
+export function createRng(seed: number | null = null): Rng {
+  return new Rng(seed);
 }

--- a/tests/sdk_rng_class.test.ts
+++ b/tests/sdk_rng_class.test.ts
@@ -1,0 +1,110 @@
+import { assert, assertEquals, assertNotStrictEquals } from "jsr:@std/assert@^1";
+import { createRng, Rng } from "../src/services/Softcode/stdlib/rng.ts";
+
+Deno.test("createRng(42) produces deterministic sequence", () => {
+  const a = createRng(42);
+  const b = createRng(42);
+  for (let i = 0; i < 3; i++) {
+    assertEquals(a.random(), b.random());
+  }
+});
+
+Deno.test("Two Rng(42) instances are independent", () => {
+  const a = new Rng(42);
+  const b = new Rng(42);
+  const seqA = [a.random(), a.random(), a.random()];
+  const b0 = b.random();
+  const b1 = b.random();
+  const b2 = b.random();
+  assertEquals(seqA, [b0, b1, b2]);
+});
+
+Deno.test("Rng(null) returns numbers in [0,1)", () => {
+  const r = new Rng(null);
+  for (let i = 0; i < 100; i++) {
+    const v = r.random();
+    assert(v >= 0 && v < 1);
+  }
+});
+
+Deno.test("setSeed(null) returns to Math.random()", () => {
+  const r = new Rng(42);
+  r.random();
+  r.setSeed(null);
+  const v = r.random();
+  assert(v >= 0 && v < 1);
+  assertEquals(r.getSeed(), null);
+});
+
+Deno.test("rand(0,10) over 1000 samples stays in [0,10]", () => {
+  const r = new Rng(123);
+  for (let i = 0; i < 1000; i++) {
+    const v = r.rand(0, 10);
+    assert(Number.isInteger(v));
+    assert(v >= 0 && v <= 10);
+  }
+});
+
+Deno.test("rand handles negative ranges", () => {
+  const r = new Rng(7);
+  for (let i = 0; i < 500; i++) {
+    const v = r.rand(-5, 5);
+    assert(v >= -5 && v <= 5);
+    assert(Number.isInteger(v));
+  }
+});
+
+Deno.test("rand(7,7) is degenerate", () => {
+  const r = new Rng(1);
+  for (let i = 0; i < 20; i++) assertEquals(r.rand(7, 7), 7);
+});
+
+Deno.test("pick returns one of provided; covers all values", () => {
+  const r = new Rng(99);
+  const items = ["a", "b", "c"];
+  const seen = new Set<string>();
+  for (let i = 0; i < 1000; i++) {
+    const v = r.pick(items)!;
+    assert(items.includes(v));
+    seen.add(v);
+  }
+  assertEquals(seen.size, 3);
+});
+
+Deno.test("pick([]) returns undefined", () => {
+  const r = new Rng(1);
+  assertEquals(r.pick([]), undefined);
+});
+
+Deno.test("shuffle returns same elements, doesn't mutate input", () => {
+  const r = new Rng(42);
+  const input = [1, 2, 3, 4, 5];
+  const copy = input.slice();
+  const out = r.shuffle(input);
+  assertEquals(input, copy);
+  assertEquals(out.length, 5);
+  assertEquals(out.slice().sort((a, b) => a - b), [1, 2, 3, 4, 5]);
+  assertNotStrictEquals(out, input);
+});
+
+Deno.test("shuffle is deterministic with same seed", () => {
+  const a = createRng(42).shuffle([1, 2, 3, 4, 5]);
+  const b = createRng(42).shuffle([1, 2, 3, 4, 5]);
+  assertEquals(a, b);
+});
+
+Deno.test("getSeed round-trip", () => {
+  const r = new Rng(42);
+  assertEquals(r.getSeed(), 42);
+  r.setSeed(null);
+  assertEquals(r.getSeed(), null);
+  r.setSeed(7);
+  assertEquals(r.getSeed(), 7);
+});
+
+Deno.test("Rng() with no args is unseeded", () => {
+  const r = new Rng();
+  assertEquals(r.getSeed(), null);
+  const v = r.random();
+  assert(v >= 0 && v < 1);
+});


### PR DESCRIPTION
## Scope

Add a public `Rng` class and `createRng` factory in
`src/services/Softcode/stdlib/rng.ts` so external plugins consuming
`jsr:@ursamu/ursamu` can use a seedable PRNG instead of pulling
`npm:alea`.

- Mulberry32 step factored into a private helper shared by the existing
  module-level singleton (`getSeed`/`setSeed`/`random`) and the new class.
- Singleton behavior is unchanged — softcode `rand`/`lrand`/`randseed`
  tests remain green.
- New class API:
  - `random()` → `[0, 1)`
  - `rand(min, max)` → integer in `[min, max]` inclusive
  - `pick(items)` → element of `items`, or `undefined` when empty
  - `shuffle(items)` → new array (Fisher–Yates), never mutates input
  - `setSeed(seed | null)` / `getSeed()`
- `mod.ts` is intentionally untouched in this PR.
- `deno.json` version is intentionally untouched.

## Gates

- `deno check --unstable-kv mod.ts` — clean
- `deno lint` — clean (365 files)
- `deno test tests/ --allow-all --unstable-kv --no-check` — 1239 passed, 0 failed
- `deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check` — 158 passed, 0 failed

## Tests

13 new cases in `tests/sdk_rng_class.test.ts` covering determinism,
instance independence, unseeded fallback, `setSeed(null)` reseeding,
`rand` range/negatives/degenerate, `pick` coverage and empty-array,
`shuffle` element-preservation/non-mutation/determinism, and
`getSeed` round-trip.