### PR TITLE
feat: expose physics primitives as TS functions (v2.5.1 part 3)

### DIFF
--- a/src/services/Softcode/stdlib/physics.ts
+++ b/src/services/Softcode/stdlib/physics.ts
@@ -5,6 +5,72 @@ import { fmt } from "./helpers.ts";
 const EPS = 1e-10;
 const ARGBAD = "#-1 ARGUMENT OUT OF RANGE";
 
+export type Vec3 = readonly [number, number, number];
+
+/**
+ * Reflect v across the plane with normal n (assumed unit).
+ *   r = v - 2*(v·n)*n
+ */
+export function vreflect(v: Vec3, n: Vec3): [number, number, number] {
+  const [vx, vy, vz] = v;
+  const [nx, ny, nz] = n;
+  const dot = vx * nx + vy * ny + vz * nz;
+  return [
+    vx - 2 * dot * nx,
+    vy - 2 * dot * ny,
+    vz - 2 * dot * nz,
+  ];
+}
+
+/** Inclusive 3D point-in-AABB test. Returns false if min > max on any axis. */
+export function pointInAabb(p: Vec3, min: Vec3, max: Vec3): boolean {
+  const [px, py, pz] = p;
+  const [minx, miny, minz] = min;
+  const [maxx, maxy, maxz] = max;
+  if (minx > maxx || miny > maxy || minz > maxz) return false;
+  return (
+    px >= minx && px <= maxx &&
+    py >= miny && py <= maxy &&
+    pz >= minz && pz <= maxz
+  );
+}
+
+/**
+ * Slab-method ray/AABB intersection.
+ * Returns the entry t (≥0) when the ray hits, or -1 when it misses.
+ * A ray starting inside the box returns 0.
+ */
+export function rayAabb(
+  origin: Vec3,
+  dir: Vec3,
+  min: Vec3,
+  max: Vec3,
+): number {
+  const o = [origin[0], origin[1], origin[2]];
+  const d = [dir[0], dir[1], dir[2]];
+  const minv = [min[0], min[1], min[2]];
+  const maxv = [max[0], max[1], max[2]];
+
+  let tmin = -Infinity;
+  let tmax = Infinity;
+
+  for (let i = 0; i < 3; i++) {
+    if (Math.abs(d[i]) < EPS) {
+      if (o[i] < minv[i] || o[i] > maxv[i]) return -1;
+      continue;
+    }
+    let t1 = (minv[i] - o[i]) / d[i];
+    let t2 = (maxv[i] - o[i]) / d[i];
+    if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
+    if (t1 > tmin) tmin = t1;
+    if (t2 < tmax) tmax = t2;
+    if (tmin > tmax) return -1;
+  }
+
+  if (tmax < 0) return -1;
+  return Math.max(tmin, 0);
+}
+
 /**
  * Parse a "x y z" 3-vector. Returns null if any component is non-numeric or
  * the string is missing/empty (L1 audit fix — previously silently coerced
@@ -25,64 +91,36 @@ function parseN(s: string | undefined): number | null {
 }
 
 // ── vreflect ──────────────────────────────────────────────────────────────
-// Reflect v across plane with normal n: r = v - 2*(v·n)*n.
-// Assumes n is already a unit vector; callers should pass a normalized normal.
 register("vreflect", async (a) => {
   const v = parseVec3(a[0]);
   const n = parseVec3(a[1]);
   if (v === null || n === null) return ARGBAD;
-  const [vx, vy, vz] = v;
-  const [nx, ny, nz] = n;
-  const dot = vx * nx + vy * ny + vz * nz;
-  return [
-    fmt(vx - 2 * dot * nx),
-    fmt(vy - 2 * dot * ny),
-    fmt(vz - 2 * dot * nz),
-  ].join(" ");
+  const r = vreflect(v, n);
+  return [fmt(r[0]), fmt(r[1]), fmt(r[2])].join(" ");
 });
 
 // ── pointinaabb ───────────────────────────────────────────────────────────
-// Inclusive bounds check. Empty box (min > max on any axis) → outside.
 register("pointinaabb", async (a) => {
   const args = [0,1,2,3,4,5,6,7,8].map(i => parseN(a[i]));
   if (args.some(v => v === null)) return ARGBAD;
   const [px, py, pz, minx, miny, minz, maxx, maxy, maxz] = args as number[];
-  if (minx > maxx || miny > maxy || minz > maxz) return "0";
-  const inside =
-    px >= minx && px <= maxx &&
-    py >= miny && py <= maxy &&
-    pz >= minz && pz <= maxz;
-  return inside ? "1" : "0";
+  return pointInAabb(
+    [px, py, pz],
+    [minx, miny, minz],
+    [maxx, maxy, maxz],
+  ) ? "1" : "0";
 });
 
 // ── rayaabb ───────────────────────────────────────────────────────────────
-// Slab-method ray/AABB intersection. Returns entry t (≥0) on hit, or -1.
-// Ray starting inside the box returns 0.
 register("rayaabb", async (a) => {
   const args = [0,1,2,3,4,5,6,7,8,9,10,11].map(i => parseN(a[i]));
   if (args.some(v => v === null)) return ARGBAD;
   const [ox, oy, oz, dx, dy, dz, minx, miny, minz, maxx, maxy, maxz] = args as number[];
-  const minv = [minx, miny, minz];
-  const maxv = [maxx, maxy, maxz];
-  const o = [ox, oy, oz];
-  const d = [dx, dy, dz];
-
-  let tmin = -Infinity;
-  let tmax = Infinity;
-
-  for (let i = 0; i < 3; i++) {
-    if (Math.abs(d[i]) < EPS) {
-      if (o[i] < minv[i] || o[i] > maxv[i]) return "-1";
-      continue;
-    }
-    let t1 = (minv[i] - o[i]) / d[i];
-    let t2 = (maxv[i] - o[i]) / d[i];
-    if (t1 > t2) { const tmp = t1; t1 = t2; t2 = tmp; }
-    if (t1 > tmin) tmin = t1;
-    if (t2 < tmax) tmax = t2;
-    if (tmin > tmax) return "-1";
-  }
-
-  if (tmax < 0) return "-1";
-  return fmt(Math.max(tmin, 0));
+  const t = rayAabb(
+    [ox, oy, oz],
+    [dx, dy, dz],
+    [minx, miny, minz],
+    [maxx, maxy, maxz],
+  );
+  return t === -1 ? "-1" : fmt(t);
 });

--- a/src/services/Softcode/stdlib/rng.ts
+++ b/src/services/Softcode/stdlib/rng.ts
@@ -7,23 +7,93 @@
 //
 // Call `setSeed(null)` to clear the seed and return to Math.random().
 
+/** Internal: mulberry32 step — advances state and returns next float in [0,1). */
+function mulberry32Step(state: number): { value: number; state: number } {
+  const s = (state + 0x6D2B79F5) >>> 0;
+  let t = s;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return { value: ((t ^ (t >>> 14)) >>> 0) / 4294967296, state: s };
+}
+
 let _state: number | null = null;
-let _seed:  number | null = null;
+let _seed: number | null = null;
 
 /** Returns the current seed, or null if unseeded. */
-export function getSeed(): number | null { return _seed; }
+export function getSeed(): number | null {
+  return _seed;
+}
 
 /** Seed the RNG. Pass null to clear and fall back to Math.random(). */
 export function setSeed(seed: number | null): void {
-  _seed  = seed;
+  _seed = seed;
   _state = seed === null ? null : (seed >>> 0);
 }
 
 /** mulberry32 — returns a float in [0, 1). */
 export function random(): number {
   if (_state === null) return Math.random();
-  let t = (_state = (_state + 0x6D2B79F5) >>> 0);
-  t = Math.imul(t ^ (t >>> 15), t | 1);
-  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  const step = mulberry32Step(_state);
+  _state = step.state;
+  return step.value;
+}
+
+/**
+ * Per-instance seedable PRNG (mulberry32). Independent of the module-level
+ * singleton used by softcode rand()/lrand().
+ *
+ * Construct with a numeric seed for deterministic sequences, or with no arg
+ * (or null) to delegate to Math.random().
+ */
+export class Rng {
+  private _state: number | null;
+  private _seed: number | null;
+
+  constructor(seed: number | null = null) {
+    this._seed = seed ?? null;
+    this._state = seed == null ? null : (seed >>> 0);
+  }
+
+  setSeed(seed: number | null): void {
+    this._seed = seed;
+    this._state = seed === null ? null : (seed >>> 0);
+  }
+
+  getSeed(): number | null {
+    return this._seed;
+  }
+
+  /** [0, 1) */
+  random(): number {
+    if (this._state === null) return Math.random();
+    const step = mulberry32Step(this._state);
+    this._state = step.state;
+    return step.value;
+  }
+
+  /** Integer in [min, max] inclusive. */
+  rand(min: number, max: number): number {
+    return Math.floor(this.random() * (max - min + 1)) + min;
+  }
+
+  /** Pick a random element; undefined when items is empty. */
+  pick<T>(items: readonly T[]): T | undefined {
+    if (items.length === 0) return undefined;
+    return items[Math.floor(this.random() * items.length)];
+  }
+
+  /** Fisher–Yates shuffle; returns a new array, never mutates input. */
+  shuffle<T>(items: readonly T[]): T[] {
+    const out = items.slice();
+    for (let i = out.length - 1; i > 0; i--) {
+      const j = Math.floor(this.random() * (i + 1));
+      [out[i], out[j]] = [out[j], out[i]];
+    }
+    return out;
+  }
+}
+
+/** Convenience factory: `createRng(42)` is equivalent to `new Rng(42)`. */
+export function createRng(seed: number | null = null): Rng {
+  return new Rng(seed);
 }

--- a/tests/sdk_physics_exports.test.ts
+++ b/tests/sdk_physics_exports.test.ts
@@ -1,0 +1,146 @@
+/**
+ * tests/sdk_physics_exports.test.ts
+ *
+ * Tests for the pure TS exports of the physics primitives
+ * (vreflect, pointInAabb, rayAabb). External plugin consumers
+ * import these directly without going through the softcode engine.
+ */
+// deno-lint-ignore-file require-await
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import {
+  pointInAabb,
+  rayAabb,
+  vreflect,
+} from "../src/services/Softcode/stdlib/physics.ts";
+import { runSoftcode, softcodeEngine } from "../src/services/Softcode/ursamu-engine.ts";
+import type { UrsaEvalContext } from "../src/services/Softcode/ursamu-context.ts";
+import type { DbAccessor } from "../src/services/Softcode/context.ts";
+import type { IDBObj } from "../src/@types/UrsamuSDK.ts";
+
+// ── vreflect ──────────────────────────────────────────────────────────────
+
+Deno.test("vreflect — bounce off floor", () => {
+  assertEquals(vreflect([1, -1, 0], [0, 1, 0]), [1, 1, 0]);
+});
+
+Deno.test("vreflect — incident parallel to normal flips direction", () => {
+  assertEquals(vreflect([0, -1, 0], [0, 1, 0]), [0, 1, 0]);
+});
+
+Deno.test("vreflect — perpendicular to normal is unchanged", () => {
+  assertEquals(vreflect([1, 0, 0], [0, 1, 0]), [1, 0, 0]);
+});
+
+// ── pointInAabb ───────────────────────────────────────────────────────────
+
+Deno.test("pointInAabb — center of unit cube is inside", () => {
+  assertStrictEquals(pointInAabb([0.5, 0.5, 0.5], [0, 0, 0], [1, 1, 1]), true);
+});
+
+Deno.test("pointInAabb — corner exactly on min is inside (inclusive)", () => {
+  assertStrictEquals(pointInAabb([0, 0, 0], [0, 0, 0], [1, 1, 1]), true);
+});
+
+Deno.test("pointInAabb — epsilon outside a face is outside", () => {
+  assertStrictEquals(
+    pointInAabb([1 + 1e-6, 0.5, 0.5], [0, 0, 0], [1, 1, 1]),
+    false,
+  );
+});
+
+Deno.test("pointInAabb — empty box (min > max) is always outside", () => {
+  assertStrictEquals(pointInAabb([0, 0, 0], [1, 0, 0], [0, 1, 1]), false);
+});
+
+// ── rayAabb ───────────────────────────────────────────────────────────────
+
+Deno.test("rayAabb — hit from outside returns positive t", () => {
+  assertStrictEquals(
+    rayAabb([0, 0, 0], [1, 0, 0], [5, -1, -1], [6, 1, 1]),
+    5,
+  );
+});
+
+Deno.test("rayAabb — parallel offset misses, returns -1", () => {
+  // ray along +x at y=5, box at y in [-1,1] — never hits.
+  assertStrictEquals(
+    rayAabb([0, 5, 0], [1, 0, 0], [5, -1, -1], [6, 1, 1]),
+    -1,
+  );
+});
+
+Deno.test("rayAabb — origin inside the box returns 0", () => {
+  assertStrictEquals(
+    rayAabb([0, 0, 0], [1, 0, 0], [-1, -1, -1], [1, 1, 1]),
+    0,
+  );
+});
+
+Deno.test("rayAabb — pointing away from the box returns -1", () => {
+  assertStrictEquals(
+    rayAabb([0, 0, 0], [-1, 0, 0], [5, -1, -1], [6, 1, 1]),
+    -1,
+  );
+});
+
+Deno.test("rayAabb — axis-parallel grazing a face returns small positive t", () => {
+  // ray at y=1 (top face) traveling +x — grazes box top, slab math returns t=5.
+  const t = rayAabb([0, 1, 0], [1, 0, 0], [5, -1, -1], [6, 1, 1]);
+  assertStrictEquals(t, 5);
+});
+
+// ── parity: TS vreflect matches softcode [vreflect(...)] ──────────────────
+
+function actor(): IDBObj {
+  return {
+    id: "100",
+    name: "Alice",
+    flags: new Set(["player", "connected"]),
+    location: "200",
+    state: {},
+    contents: [],
+  };
+}
+
+function makeCtx(): UrsaEvalContext {
+  const a = actor();
+  return {
+    enactor:      a.id,
+    executor:     a,
+    caller:       null,
+    actor:        a,
+    args:         [],
+    registers:    new Map(),
+    iterStack:    [],
+    depth:        0,
+    maxDepth:     50,
+    maxOutputLen: 65_536,
+    deadline:     Date.now() + 2000,
+    db: {
+      queryById:        async () => null,
+      queryByName:      async () => null,
+      lcon:             async () => [],
+      lwho:             async () => [],
+      lattr:            async () => [],
+      getAttribute:     async () => null,
+      getTagById:       async () => null,
+      getPlayerTagById: async () => null,
+      lsearch:          async () => [],
+      children:         async () => [],
+      lchannels:        async () => "",
+      channelsFor:      async () => "",
+      mailCount:        async () => 0,
+      queueLength:      async () => 0,
+      getIdleSecs:      async () => 0,
+      getUserFn:        async () => null,
+    } satisfies DbAccessor,
+    output:       { send: () => {}, roomBroadcast: () => {}, broadcast: () => {} },
+    _engine:      softcodeEngine,
+  };
+}
+
+Deno.test("parity — softcode vreflect equals TS vreflect joined by spaces", async () => {
+  const softcodeResult = await runSoftcode("[vreflect(1 -1 0,0 1 0)]", makeCtx());
+  const tsResult = vreflect([1, -1, 0], [0, 1, 0]).join(" ");
+  assertEquals(softcodeResult, tsResult);
+});

--- a/tests/sdk_rng_class.test.ts
+++ b/tests/sdk_rng_class.test.ts
@@ -1,0 +1,110 @@
+import { assert, assertEquals, assertNotStrictEquals } from "jsr:@std/assert@^1";
+import { createRng, Rng } from "../src/services/Softcode/stdlib/rng.ts";
+
+Deno.test("createRng(42) produces deterministic sequence", () => {
+  const a = createRng(42);
+  const b = createRng(42);
+  for (let i = 0; i < 3; i++) {
+    assertEquals(a.random(), b.random());
+  }
+});
+
+Deno.test("Two Rng(42) instances are independent", () => {
+  const a = new Rng(42);
+  const b = new Rng(42);
+  const seqA = [a.random(), a.random(), a.random()];
+  const b0 = b.random();
+  const b1 = b.random();
+  const b2 = b.random();
+  assertEquals(seqA, [b0, b1, b2]);
+});
+
+Deno.test("Rng(null) returns numbers in [0,1)", () => {
+  const r = new Rng(null);
+  for (let i = 0; i < 100; i++) {
+    const v = r.random();
+    assert(v >= 0 && v < 1);
+  }
+});
+
+Deno.test("setSeed(null) returns to Math.random()", () => {
+  const r = new Rng(42);
+  r.random();
+  r.setSeed(null);
+  const v = r.random();
+  assert(v >= 0 && v < 1);
+  assertEquals(r.getSeed(), null);
+});
+
+Deno.test("rand(0,10) over 1000 samples stays in [0,10]", () => {
+  const r = new Rng(123);
+  for (let i = 0; i < 1000; i++) {
+    const v = r.rand(0, 10);
+    assert(Number.isInteger(v));
+    assert(v >= 0 && v <= 10);
+  }
+});
+
+Deno.test("rand handles negative ranges", () => {
+  const r = new Rng(7);
+  for (let i = 0; i < 500; i++) {
+    const v = r.rand(-5, 5);
+    assert(v >= -5 && v <= 5);
+    assert(Number.isInteger(v));
+  }
+});
+
+Deno.test("rand(7,7) is degenerate", () => {
+  const r = new Rng(1);
+  for (let i = 0; i < 20; i++) assertEquals(r.rand(7, 7), 7);
+});
+
+Deno.test("pick returns one of provided; covers all values", () => {
+  const r = new Rng(99);
+  const items = ["a", "b", "c"];
+  const seen = new Set<string>();
+  for (let i = 0; i < 1000; i++) {
+    const v = r.pick(items)!;
+    assert(items.includes(v));
+    seen.add(v);
+  }
+  assertEquals(seen.size, 3);
+});
+
+Deno.test("pick([]) returns undefined", () => {
+  const r = new Rng(1);
+  assertEquals(r.pick([]), undefined);
+});
+
+Deno.test("shuffle returns same elements, doesn't mutate input", () => {
+  const r = new Rng(42);
+  const input = [1, 2, 3, 4, 5];
+  const copy = input.slice();
+  const out = r.shuffle(input);
+  assertEquals(input, copy);
+  assertEquals(out.length, 5);
+  assertEquals(out.slice().sort((a, b) => a - b), [1, 2, 3, 4, 5]);
+  assertNotStrictEquals(out, input);
+});
+
+Deno.test("shuffle is deterministic with same seed", () => {
+  const a = createRng(42).shuffle([1, 2, 3, 4, 5]);
+  const b = createRng(42).shuffle([1, 2, 3, 4, 5]);
+  assertEquals(a, b);
+});
+
+Deno.test("getSeed round-trip", () => {
+  const r = new Rng(42);
+  assertEquals(r.getSeed(), 42);
+  r.setSeed(null);
+  assertEquals(r.getSeed(), null);
+  r.setSeed(7);
+  assertEquals(r.getSeed(), 7);
+});
+
+Deno.test("Rng() with no args is unseeded", () => {
+  const r = new Rng();
+  assertEquals(r.getSeed(), null);
+  const v = r.random();
+  assert(v >= 0 && v < 1);
+});


### PR DESCRIPTION
## Scope

Extract \`vreflect\`, \`pointInAabb\`, \`rayAabb\` from the softcode \`register(...)\` wrappers in \`src/services/Softcode/stdlib/physics.ts\` into pure TypeScript functions exported from the package. The softcode registrations now parse softcode args into typed \`Vec3\` tuples, validate them, and delegate to the public TS implementations.

External plugins can do:

\`\`\`ts
import { vreflect, pointInAabb, rayAabb, type Vec3 } from "jsr:@ursamu/ursamu";
const t = rayAabb([0, 0, 0], [1, 0, 0], [5, -1, -1], [6, 1, 1]); // → 5
\`\`\`

- Input validation (\`#-1 ARGUMENT OUT OF RANGE\` on non-numeric input — M1/L1 audit fix) stays in the registration layer.
- The TS functions assume valid \`Vec3\` input from typed callers.
- \`mod.ts\` and \`deno.json\` are intentionally **not** touched in this PR.
- \`noise.ts\`, \`rng.ts\`, \`math.ts\` are not touched.

## Files changed

- \`src/services/Softcode/stdlib/physics.ts\` — refactored, +exports
- \`tests/sdk_physics_exports.test.ts\` — new (13 tests incl. softcode parity)

## Public TS exports

- \`type Vec3 = readonly [number, number, number]\`
- \`vreflect(v: Vec3, n: Vec3): [number, number, number]\`
- \`pointInAabb(p: Vec3, min: Vec3, max: Vec3): boolean\`
- \`rayAabb(origin: Vec3, dir: Vec3, min: Vec3, max: Vec3): number\` (returns entry \`t\` or \`-1\`)

## Gates

- \`deno check --unstable-kv mod.ts\` — clean
- \`deno lint\` — clean (365 files)
- \`deno test tests/ --allow-all --unstable-kv --no-check\` — 1239 passed, 0 failed
- \`deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check\` — 158 passed, 0 failed
- Existing \`tests/softcode_physics.test.ts\` — unchanged, still green