### PR TITLE
feat: v2.5.1 — re-export stdlib primitives from mod.ts

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -93,6 +93,38 @@ export { resolveFormat, resolveFormatOr } from "./src/utils/resolveFormat.ts";
 // resolveGlobalFormat — two-tier lookup (#0 → enactor) for global-list commands
 // (WHO, @ps, +event/list, +mail, +bb, etc.) that aren't bound to a specific target.
 export { resolveGlobalFormat, resolveGlobalFormatOr } from "./src/utils/resolveGlobalFormat.ts";
+
+// ── Stdlib TS exports (v2.5.1) — pure functions usable from plugin TS code ──
+// These were already registered as softcode (perlin2 etc.) in v2.5.0 but
+// weren't reachable from TypeScript. Now plugin authors can drop
+// npm:simplex-noise / npm:alea and use these directly.
+
+// Noise (deterministic given seed)
+export {
+  seedNoise,
+  perlin1, perlin2, perlin3,
+  simplex2,
+  worley2,
+  fbm2, ridged2,
+  noiseGrid,
+} from "./src/services/Softcode/stdlib/noise.ts";
+
+// Per-instance seedable PRNG (mulberry32). Independent of the softcode singleton.
+export { Rng, createRng } from "./src/services/Softcode/stdlib/rng.ts";
+
+// Physics primitives (typed Vec3 tuples)
+export { vreflect, pointInAabb, rayAabb } from "./src/services/Softcode/stdlib/physics.ts";
+export type { Vec3 } from "./src/services/Softcode/stdlib/physics.ts";
+
+// Spatial scalars + interpolation + vector ops
+export {
+  dist2d, dist3d, distSq2d, distSq3d,
+  manhattan, chebyshev, angle2d, bearing,
+  lerp, inverseLerp, remap, smoothstep, smootherstep, clamp,
+  vsize, vsizeSq, vdistance, vdistanceSq, vlerp, vclamp,
+} from "./src/services/Softcode/stdlib/math.ts";
+export type { Vec } from "./src/services/Softcode/stdlib/math.ts";
+
 // Plugin lifecycle management — available to external plugins that need to read their config
 export { PluginConfigManager } from "./src/services/Config/plugin.ts";
 export type { IMiddlewareFunction } from "./src/@types/IMiddlewareFunction.ts";


### PR DESCRIPTION
Final piece of the v2.5.1 train. PRs #143/#144/#145/#146 made the v2.5.0 stdlib primitives public at the TypeScript module level (\`export function ...\`, \`export class Rng\`). This PR consolidates them into \`mod.ts\` so plugin authors can import directly:

\`\`\`ts
import { perlin2, fbm2, noiseGrid, seedNoise } from "jsr:@ursamu/ursamu";
import { Rng, createRng } from "jsr:@ursamu/ursamu";
import { vreflect, pointInAabb, rayAabb } from "jsr:@ursamu/ursamu";
import {
  dist2d, dist3d, manhattan, bearing,
  lerp, smoothstep, clamp,
  vsize, vdistance, vlerp,
} from "jsr:@ursamu/ursamu";
\`\`\`

…and drop their \`npm:simplex-noise\` / \`npm:alea\` dependencies.

## Surface exported

| Group | Symbols |
|---|---|
| Noise | \`seedNoise\`, \`perlin1\`, \`perlin2\`, \`perlin3\`, \`simplex2\`, \`worley2\`, \`fbm2\`, \`ridged2\`, \`noiseGrid\` |
| RNG | \`Rng\`, \`createRng\` |
| Physics | \`vreflect\`, \`pointInAabb\`, \`rayAabb\`, \`Vec3\` |
| Math/spatial | \`dist2d/3d\`, \`distSq2d/3d\`, \`manhattan\`, \`chebyshev\`, \`angle2d\`, \`bearing\`, \`lerp\`, \`inverseLerp\`, \`remap\`, \`smoothstep\`, \`smootherstep\`, \`clamp\`, \`vsize\`, \`vsizeSq\`, \`vdistance\`, \`vdistanceSq\`, \`vlerp\`, \`vclamp\`, \`Vec\` |

## Gates
- [x] \`deno check --unstable-kv mod.ts\` — clean
- [x] \`deno lint\` — clean (366 files)
- [x] \`deno test tests/\` — **1256 passed / 0 failed**
- [x] \`deno publish --dry-run --allow-dirty\` — success

## Version
\`2.5.0\` → \`2.5.1\` (patch — pure additive exports, zero behavior change).