### PR TITLE
feat: v2.5.2 — per-instance Noise class (closes #148)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -99,7 +99,9 @@ export { resolveGlobalFormat, resolveGlobalFormatOr } from "./src/utils/resolveG
 // weren't reachable from TypeScript. Now plugin authors can drop
 // npm:simplex-noise / npm:alea and use these directly.
 
-// Noise (deterministic given seed)
+// Noise (deterministic given seed). Singleton-backed functions + per-instance
+// `Noise` class for plugins that need an independent noise stream without
+// stomping the module-level PERM (v2.5.2 — closes #148).
 export {
   seedNoise,
   perlin1, perlin2, perlin3,
@@ -107,6 +109,8 @@ export {
   worley2,
   fbm2, ridged2,
   noiseGrid,
+  Noise, createNoise,
+  buildPerm,
 } from "./src/services/Softcode/stdlib/noise.ts";
 
 // Per-instance seedable PRNG (mulberry32). Independent of the softcode singleton.

--- a/src/services/Softcode/stdlib/noise.ts
+++ b/src/services/Softcode/stdlib/noise.ts
@@ -14,8 +14,12 @@ let _noiseSeed = 0;
 let _seedInitialized = false;
 const PERM = new Uint8Array(512);
 
-export function seedNoise(seed: number): void {
-  // FNV-1a hash → seeded shuffle of 0..255 into PERM
+/**
+ * Build a fresh 512-byte permutation table deterministically from `seed`.
+ * Used by both the singleton `seedNoise()` and the per-instance `Noise` class.
+ */
+export function buildPerm(seed: number): Uint8Array {
+  // FNV-1a hash → seeded shuffle of 0..255
   let h = 2166136261 >>> 0;
   const bytes = new Uint8Array(new Float64Array([seed]).buffer);
   for (const b of bytes) {
@@ -33,7 +37,13 @@ export function seedNoise(seed: number): void {
     const j = s % (i + 1);
     const tmp = p[i]; p[i] = p[j]; p[j] = tmp;
   }
-  for (let i = 0; i < 512; i++) PERM[i] = p[i & 255];
+  const out = new Uint8Array(512);
+  for (let i = 0; i < 512; i++) out[i] = p[i & 255];
+  return out;
+}
+
+export function seedNoise(seed: number): void {
+  PERM.set(buildPerm(seed));
   _noiseSeed = seed;
   _seedInitialized = true;
 }
@@ -78,37 +88,31 @@ function grad3(hash: number, x: number, y: number, z: number): number {
   return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
 }
 
-// ── perlin ────────────────────────────────────────────────────────────────
-export function perlin1(x: number): number {
-  ensureSeed();
+// ── perlin (PERM-parameterized internals) ────────────────────────────────
+function _perlin1(perm: Uint8Array, x: number): number {
   const xi = Math.floor(x) & 255;
   const xf = x - Math.floor(x);
   const u  = fade(xf);
-  const a  = PERM[xi];
-  const b  = PERM[xi + 1];
-  return lerp(u, grad1(a, xf), grad1(b, xf - 1));
+  return lerp(u, grad1(perm[xi], xf), grad1(perm[xi + 1], xf - 1));
 }
 
-export function perlin2(x: number, y: number): number {
-  ensureSeed();
+function _perlin2(perm: Uint8Array, x: number, y: number): number {
   const xi = Math.floor(x) & 255;
   const yi = Math.floor(y) & 255;
   const xf = x - Math.floor(x);
   const yf = y - Math.floor(y);
   const u  = fade(xf);
   const v  = fade(yf);
-  const aa = PERM[PERM[xi] + yi];
-  const ab = PERM[PERM[xi] + yi + 1];
-  const ba = PERM[PERM[xi + 1] + yi];
-  const bb = PERM[PERM[xi + 1] + yi + 1];
+  const aa = perm[perm[xi] + yi];
+  const ab = perm[perm[xi] + yi + 1];
+  const ba = perm[perm[xi + 1] + yi];
+  const bb = perm[perm[xi + 1] + yi + 1];
   const x1 = lerp(u, grad2(aa, xf, yf),     grad2(ba, xf - 1, yf));
   const x2 = lerp(u, grad2(ab, xf, yf - 1), grad2(bb, xf - 1, yf - 1));
-  // grad2 magnitude is up to ~3, scale to roughly [-1,1]
   return lerp(v, x1, x2) / 3;
 }
 
-export function perlin3(x: number, y: number, z: number): number {
-  ensureSeed();
+function _perlin3(perm: Uint8Array, x: number, y: number, z: number): number {
   const xi = Math.floor(x) & 255;
   const yi = Math.floor(y) & 255;
   const zi = Math.floor(z) & 255;
@@ -116,31 +120,38 @@ export function perlin3(x: number, y: number, z: number): number {
   const yf = y - Math.floor(y);
   const zf = z - Math.floor(z);
   const u = fade(xf), v = fade(yf), w = fade(zf);
-  const A  = PERM[xi]   + yi;
-  const AA = PERM[A]    + zi;
-  const AB = PERM[A + 1] + zi;
-  const B  = PERM[xi + 1] + yi;
-  const BA = PERM[B]    + zi;
-  const BB = PERM[B + 1] + zi;
+  const A  = perm[xi]   + yi;
+  const AA = perm[A]    + zi;
+  const AB = perm[A + 1] + zi;
+  const B  = perm[xi + 1] + yi;
+  const BA = perm[B]    + zi;
+  const BB = perm[B + 1] + zi;
   return lerp(w,
     lerp(v,
-      lerp(u, grad3(PERM[AA],     xf,     yf,     zf),
-              grad3(PERM[BA],     xf - 1, yf,     zf)),
-      lerp(u, grad3(PERM[AB],     xf,     yf - 1, zf),
-              grad3(PERM[BB],     xf - 1, yf - 1, zf))),
+      lerp(u, grad3(perm[AA],     xf,     yf,     zf),
+              grad3(perm[BA],     xf - 1, yf,     zf)),
+      lerp(u, grad3(perm[AB],     xf,     yf - 1, zf),
+              grad3(perm[BB],     xf - 1, yf - 1, zf))),
     lerp(v,
-      lerp(u, grad3(PERM[AA + 1], xf,     yf,     zf - 1),
-              grad3(PERM[BA + 1], xf - 1, yf,     zf - 1)),
-      lerp(u, grad3(PERM[AB + 1], xf,     yf - 1, zf - 1),
-              grad3(PERM[BB + 1], xf - 1, yf - 1, zf - 1))));
+      lerp(u, grad3(perm[AA + 1], xf,     yf,     zf - 1),
+              grad3(perm[BA + 1], xf - 1, yf,     zf - 1)),
+      lerp(u, grad3(perm[AB + 1], xf,     yf - 1, zf - 1),
+              grad3(perm[BB + 1], xf - 1, yf - 1, zf - 1))));
+}
+
+// Singleton-backed public wrappers (back-compat surface)
+export function perlin1(x: number): number              { ensureSeed(); return _perlin1(PERM, x); }
+export function perlin2(x: number, y: number): number   { ensureSeed(); return _perlin2(PERM, x, y); }
+export function perlin3(x: number, y: number, z: number): number {
+  ensureSeed();
+  return _perlin3(PERM, x, y, z);
 }
 
 // ── simplex 2D (Gustavson reference impl, public domain) ──────────────────
 const F2 = 0.5 * (Math.sqrt(3) - 1);
 const G2 = (3 - Math.sqrt(3)) / 6;
 
-export function simplex2(xin: number, yin: number): number {
-  ensureSeed();
+function _simplex2(perm: Uint8Array, xin: number, yin: number): number {
   const s = (xin + yin) * F2;
   const i = Math.floor(xin + s);
   const j = Math.floor(yin + s);
@@ -157,9 +168,9 @@ export function simplex2(xin: number, yin: number): number {
   const y2 = y0 - 1 + 2 * G2;
   const ii = i & 255;
   const jj = j & 255;
-  const gi0 = PERM[ii + PERM[jj]] & 7;
-  const gi1 = PERM[ii + i1 + PERM[jj + j1]] & 7;
-  const gi2 = PERM[ii + 1 + PERM[jj + 1]] & 7;
+  const gi0 = perm[ii + perm[jj]] & 7;
+  const gi1 = perm[ii + i1 + perm[jj + j1]] & 7;
+  const gi2 = perm[ii + 1 + perm[jj + 1]] & 7;
   let n0 = 0, n1 = 0, n2 = 0;
   let t0 = 0.5 - x0 * x0 - y0 * y0;
   if (t0 >= 0) { t0 *= t0; n0 = t0 * t0 * grad2(gi0, x0, y0); }
@@ -167,14 +178,16 @@ export function simplex2(xin: number, yin: number): number {
   if (t1 >= 0) { t1 *= t1; n1 = t1 * t1 * grad2(gi1, x1, y1); }
   let t2 = 0.5 - x2 * x2 - y2 * y2;
   if (t2 >= 0) { t2 *= t2; n2 = t2 * t2 * grad2(gi2, x2, y2); }
-  // Scaling factor ~70 in Gustavson; with our grad2 magnitude ~3 the
-  // empirical scale is ~40 to land in [-1, 1].
   return 40 * (n0 + n1 + n2);
 }
 
-// ── worley 2D (cellular F1 distance) ──────────────────────────────────────
-export function worley2(x: number, y: number): number {
+export function simplex2(xin: number, yin: number): number {
   ensureSeed();
+  return _simplex2(PERM, xin, yin);
+}
+
+// ── worley 2D (cellular F1 distance) ──────────────────────────────────────
+function _worley2(perm: Uint8Array, x: number, y: number): number {
   const xi = Math.floor(x);
   const yi = Math.floor(y);
   let min = Infinity;
@@ -182,9 +195,8 @@ export function worley2(x: number, y: number): number {
     for (let dy = -1; dy <= 1; dy++) {
       const cx = xi + dx;
       const cy = yi + dy;
-      // Feature point inside this cell: jittered by hashed offsets in [0, 1).
-      const h1 = PERM[(cx & 255) + PERM[cy & 255]];
-      const h2 = PERM[(cx & 255) + PERM[(cy + 1) & 255]];
+      const h1 = perm[(cx & 255) + perm[cy & 255]];
+      const h2 = perm[(cx & 255) + perm[(cy + 1) & 255]];
       const px = cx + (h1 / 255);
       const py = cy + (h2 / 255);
       const ex = px - x;
@@ -196,14 +208,16 @@ export function worley2(x: number, y: number): number {
   return Math.sqrt(min);
 }
 
+export function worley2(x: number, y: number): number {
+  ensureSeed();
+  return _worley2(PERM, x, y);
+}
+
 // ── fbm / ridged ──────────────────────────────────────────────────────────
-export function fbm2(x: number, y: number, octaves: number, persistence: number): number {
-  let total = 0;
-  let freq = 1;
-  let amp = 1;
-  let maxAmp = 0;
+function _fbm2(perm: Uint8Array, x: number, y: number, octaves: number, persistence: number): number {
+  let total = 0, freq = 1, amp = 1, maxAmp = 0;
   for (let i = 0; i < octaves; i++) {
-    total += perlin2(x * freq, y * freq) * amp;
+    total += _perlin2(perm, x * freq, y * freq) * amp;
     maxAmp += amp;
     amp *= persistence;
     freq *= 2;
@@ -211,19 +225,26 @@ export function fbm2(x: number, y: number, octaves: number, persistence: number)
   return maxAmp === 0 ? 0 : total / maxAmp;
 }
 
-export function ridged2(x: number, y: number, octaves: number, persistence: number): number {
-  let total = 0;
-  let freq = 1;
-  let amp = 1;
-  let maxAmp = 0;
+function _ridged2(perm: Uint8Array, x: number, y: number, octaves: number, persistence: number): number {
+  let total = 0, freq = 1, amp = 1, maxAmp = 0;
   for (let i = 0; i < octaves; i++) {
-    const n = 1 - Math.abs(perlin2(x * freq, y * freq));
-    total += (n * 2 - 1) * amp; // remap [0,1] to [-1,1]
+    const n = 1 - Math.abs(_perlin2(perm, x * freq, y * freq));
+    total += (n * 2 - 1) * amp;
     maxAmp += amp;
     amp *= persistence;
     freq *= 2;
   }
   return maxAmp === 0 ? 0 : total / maxAmp;
+}
+
+export function fbm2(x: number, y: number, octaves: number, persistence: number): number {
+  ensureSeed();
+  return _fbm2(PERM, x, y, octaves, persistence);
+}
+
+export function ridged2(x: number, y: number, octaves: number, persistence: number): number {
+  ensureSeed();
+  return _ridged2(PERM, x, y, octaves, persistence);
 }
 
 // ── public grid generator ─────────────────────────────────────────────────
@@ -326,3 +347,81 @@ register("noisegrid", async (a) => {
     | "perlin2" | "simplex2" | "worley2";
   return noiseGrid(seed, w, h, scale, fn).map(fmt).join(" ");
 });
+
+// ── per-instance Noise class (v2.5.2) ────────────────────────────────────
+//
+// Holds its own PERM table so multiple plugins can each carry an independent
+// seeded noise stream without stomping the singleton. Mirrors the Rng class.
+//
+//   import { createNoise } from "jsr:@ursamu/ursamu";
+//   const n = createNoise(42);
+//   n.perlin2(0.5, 0.5);  // independent of seedNoise() and any other Noise instance
+
+export class Noise {
+  private _perm: Uint8Array;
+  private _seed: number;
+
+  constructor(seed: number) {
+    this._seed = seed;
+    this._perm = buildPerm(seed);
+  }
+
+  setSeed(seed: number): void {
+    this._seed = seed;
+    this._perm = buildPerm(seed);
+  }
+
+  getSeed(): number {
+    return this._seed;
+  }
+
+  perlin1(x: number): number                    { return _perlin1(this._perm, x); }
+  perlin2(x: number, y: number): number         { return _perlin2(this._perm, x, y); }
+  perlin3(x: number, y: number, z: number): number {
+    return _perlin3(this._perm, x, y, z);
+  }
+  simplex2(x: number, y: number): number        { return _simplex2(this._perm, x, y); }
+  worley2(x: number, y: number): number         { return _worley2(this._perm, x, y); }
+  fbm2(x: number, y: number, octaves: number, persistence: number): number {
+    return _fbm2(this._perm, x, y, octaves, persistence);
+  }
+  ridged2(x: number, y: number, octaves: number, persistence: number): number {
+    return _ridged2(this._perm, x, y, octaves, persistence);
+  }
+
+  /**
+   * Generate a width*height grid of noise values. Applies the same MAX_LEN
+   * (10 000) DoS clamp as the module-level `noiseGrid`. Does not mutate
+   * `this._perm` — each cell is sampled against the instance's PERM.
+   */
+  grid(
+    width: number, height: number, scale: number,
+    fn?: "perlin2" | "simplex2" | "worley2",
+  ): number[] {
+    let w = Math.max(0, Math.floor(width) | 0);
+    let h = Math.max(0, Math.floor(height) | 0);
+    const s = scale || 1;
+    if (w * h > MAX_LEN) {
+      const rows = Math.max(1, Math.floor(MAX_LEN / Math.max(1, w)));
+      w = Math.min(w, MAX_LEN);
+      h = rows;
+    }
+    const name = (fn ?? "perlin2").toLowerCase();
+    let pick: (x: number, y: number) => number;
+    if (name === "simplex2")      pick = (x, y) => _simplex2(this._perm, x, y);
+    else if (name === "worley2")  pick = (x, y) => _worley2(this._perm, x, y);
+    else                          pick = (x, y) => _perlin2(this._perm, x, y);
+    const out: number[] = [];
+    for (let j = 0; j < h; j++) {
+      for (let i = 0; i < w; i++) {
+        out.push(pick(i * s, j * s));
+      }
+    }
+    return out;
+  }
+}
+
+/** Convenience factory: `createNoise(42)` is equivalent to `new Noise(42)`. */
+export function createNoise(seed: number): Noise {
+  return new Noise(seed);
+}

--- a/tests/sdk_noise_class.test.ts
+++ b/tests/sdk_noise_class.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Per-instance Noise class — v2.5.2 (closes #148).
+ *
+ * Verifies that two `Noise(seed)` instances don't interfere with each other
+ * via the module-level PERM singleton, and that an instance's PERM survives
+ * arbitrary calls to the singleton `seedNoise()` between samples.
+ */
+import { assertEquals, assert } from "@std/assert";
+import {
+  createNoise,
+  perlin2, seedNoise, buildPerm,
+} from "../src/services/Softcode/stdlib/noise.ts";
+
+Deno.test("Noise: createNoise(42) is deterministic across instances", () => {
+  const a = createNoise(42);
+  const b = createNoise(42);
+  for (let i = 0; i < 50; i++) {
+    assertEquals(a.perlin2(i * 0.1, i * 0.13), b.perlin2(i * 0.1, i * 0.13));
+    assertEquals(a.simplex2(i * 0.1, i * 0.13), b.simplex2(i * 0.1, i * 0.13));
+  }
+});
+
+Deno.test("Noise: different seeds → different streams", () => {
+  const a = createNoise(42);
+  const b = createNoise(99);
+  let differ = 0;
+  // Sample off-lattice (avoid integer-aligned coords where noise pins to 0)
+  for (let i = 0; i < 100; i++) {
+    if (Math.abs(a.perlin2(i * 0.1 + 0.37, i * 0.13 + 0.41) -
+                 b.perlin2(i * 0.1 + 0.37, i * 0.13 + 0.41)) > 1e-9) differ++;
+  }
+  assert(differ >= 90, `expected ≥90% differing samples, got ${differ}/100`);
+});
+
+Deno.test("Noise: instance survives singleton seedNoise() between samples", () => {
+  const n = createNoise(42);
+  const baseline = n.perlin2(0.5, 0.5);
+  // Stomp the singleton — should not affect the instance.
+  seedNoise(99);
+  const after = n.perlin2(0.5, 0.5);
+  assertEquals(baseline, after);
+  // And the singleton remains seeded to 99
+  assert(Math.abs(perlin2(0.5, 0.5)) <= 1);
+});
+
+Deno.test("Noise: instance vs singleton with same seed produce same output", async () => {
+  const { simplex2 } = await import("../src/services/Softcode/stdlib/noise.ts");
+  const n = createNoise(42);
+  seedNoise(42);
+  assertEquals(n.perlin2(0.5, 0.5), perlin2(0.5, 0.5));
+  assertEquals(n.simplex2(0.7, 1.3), simplex2(0.7, 1.3));
+});
+
+Deno.test("Noise: setSeed reshuffles in place; getSeed reports it", () => {
+  const n = createNoise(42);
+  assertEquals(n.getSeed(), 42);
+  const before = n.perlin2(0.5, 0.5);
+  n.setSeed(99);
+  assertEquals(n.getSeed(), 99);
+  const after = n.perlin2(0.5, 0.5);
+  assert(Math.abs(before - after) > 1e-9, "expected different output after reseed");
+  // Back to 42 → reproduces original sequence
+  n.setSeed(42);
+  assertEquals(n.perlin2(0.5, 0.5), before);
+});
+
+Deno.test("Noise: output range [-1, 1] for perlin/simplex over 500 samples", () => {
+  const n = createNoise(42);
+  for (let i = 0; i < 500; i++) {
+    const x = (i * 1.123) % 1000;
+    const y = (i * 2.456) % 1000;
+    const p = n.perlin2(x, y);
+    const s = n.simplex2(x, y);
+    assert(p >= -1 && p <= 1, `perlin2 out of range at ${i}: ${p}`);
+    assert(s >= -1 && s <= 1, `simplex2 out of range at ${i}: ${s}`);
+  }
+});
+
+Deno.test("Noise.grid: returns w*h numeric array; clamps at MAX_LEN", () => {
+  const n = createNoise(42);
+  const small = n.grid(10, 5, 0.1);
+  assertEquals(small.length, 50);
+  for (const v of small) assert(typeof v === "number");
+  const huge = n.grid(1000, 1000, 0.1);
+  assert(huge.length <= 10_000, `grid clamp failed: ${huge.length}`);
+});
+
+Deno.test("Noise.grid: per-instance grid doesn't mutate singleton", () => {
+  seedNoise(7);
+  const singletonBefore = perlin2(0.5, 0.5);
+  const n = createNoise(42);
+  n.grid(20, 20, 0.1);
+  const singletonAfter = perlin2(0.5, 0.5);
+  assertEquals(singletonBefore, singletonAfter,
+    "Noise.grid() must not stomp the module PERM");
+});
+
+Deno.test("Noise: fbm2/ridged2 work per-instance and stay in [-1,1]", () => {
+  const n = createNoise(42);
+  for (let i = 0; i < 200; i++) {
+    const f = n.fbm2(i * 0.1, i * 0.13, 4, 0.5);
+    const r = n.ridged2(i * 0.1, i * 0.13, 4, 0.5);
+    assert(f >= -1.0001 && f <= 1.0001, `fbm2 out of range: ${f}`);
+    assert(r >= -1.0001 && r <= 1.0001, `ridged2 out of range: ${r}`);
+  }
+});
+
+Deno.test("buildPerm: deterministic, 512 bytes, mirrors lower 256", () => {
+  const a = buildPerm(42);
+  const b = buildPerm(42);
+  assertEquals(a.length, 512);
+  for (let i = 0; i < 512; i++) assertEquals(a[i], b[i]);
+  for (let i = 0; i < 256; i++) assertEquals(a[i], a[i + 256]);
+});
+
+Deno.test("Noise: 1000 concurrent-style interleaved calls between two instances", () => {
+  // Simulates two plugins calling noise in rapid alternation. Each instance's
+  // output must be independent of the other's calls.
+  const a = createNoise(11);
+  const b = createNoise(22);
+  // Capture each instance's pure sequence
+  const aPure: number[] = [];
+  const bPure: number[] = [];
+  for (let i = 0; i < 100; i++) {
+    aPure.push(a.perlin2(i * 0.1, 0));
+    bPure.push(b.perlin2(i * 0.1, 0));
+  }
+  // Now do the same calls interleaved with each other AND singleton stomps
+  const a2 = createNoise(11);
+  const b2 = createNoise(22);
+  for (let i = 0; i < 100; i++) {
+    seedNoise(i * 7);                        // stomp the singleton
+    assertEquals(a2.perlin2(i * 0.1, 0), aPure[i], `a drift at ${i}`);
+    seedNoise(i * 13);                       // stomp again
+    assertEquals(b2.perlin2(i * 0.1, 0), bPure[i], `b drift at ${i}`);
+  }
+});


### PR DESCRIPTION
Closes #148.

## Gap (from issue)
v2.5.1 noise exports (`perlin2`, `simplex2`, etc.) all share a module-level PERM. Two plugins calling `seedNoise()` with different seeds stomp each other — same coupling we solved for RNG with `createRng()`.

## Fix
Option A from #148 (instance factory, mirrors `createRng`):

```ts
import { createNoise, Noise } from "jsr:@ursamu/ursamu";

const a = createNoise(42);
const b = createNoise(99);
a.perlin2(0.5, 0.5);  // independent of b and of seedNoise()
b.simplex2(1.7, 2.3);
a.grid(50, 30, 0.1, "simplex2");
```

## Surface
- `class Noise` with `perlin1/2/3`, `simplex2`, `worley2`, `fbm2`, `ridged2`, `grid`, `setSeed`, `getSeed`
- `createNoise(seed)` factory
- `buildPerm(seed)` exposed for advanced callers who want to share a PERM across cooperating contexts

## Refactor strategy
Extracted PERM-parameterized internals (`_perlin1/2/3`, `_simplex2`, `_worley2`, `_fbm2`, `_ridged2`). Existing singleton-backed exports are now ~1-line wrappers around them. Zero softcode-layer behavior change.

## Tests
`tests/sdk_noise_class.test.ts` (+11) including a 100-iteration stress test that interleaves two `Noise` instance calls with arbitrary singleton `seedNoise()` stomps between every sample — proves instances stay independent.

## Gates
- [x] `deno check --unstable-kv mod.ts` — clean
- [x] `deno lint` — clean (367 files)
- [x] `deno test tests/` — **1267 passed / 0 failed**
- [x] `deno publish --dry-run --allow-dirty` — success

## Version
`2.5.1` → `2.5.2` (patch — pure additive, no breaking changes).