### PR TITLE
feat: v2.6.0 — fail-fast plugin installs with semver + atomic rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,27 @@ To add a community plugin, append it to `plugins.manifest.json`:
   "url": "https://github.com/example/my-plugin",
   "ref": "v1.0.0",
   "description": "What this plugin does.",
-  "ursamu": ">=1.9.0"
+  "ursamu": ">=1.9.0",
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" },
+    { "name": "channel", "url": "https://github.com/UrsaMU/channel-plugin" }
+  ]
 }
 ```
+
+Each `deps[]` entry may include an optional `version` semver range (e.g.
+`"^1.2.0"`, `">=1.0.0 <2.0.0"`). When present, the installer reads the
+dependency's own `ursamu.plugin.json` `version` and verifies it satisfies
+the range. Entries without `version` install unconditionally — backwards
+compatible with existing manifests.
+
+**Atomic installs.** `ensurePlugins` is fail-fast across the whole manifest:
+if any plugin or transitive dep fails to clone, has an unsafe name or URL,
+declares a version that violates a requested range, or has conflicting
+ranges from multiple requesters, the entire install run aborts and rolls
+back. Nothing from the failed run is left on disk or in
+`src/plugins/.registry.json` — your previously installed plugins are
+untouched.
 
 ---
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@ursamu/ursamu",
 
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "A modern, high-performance MUSH-like engine built with TypeScript and Deno.",
   "exports": {
     ".": "./mod.ts",

--- a/docs/guides/admin-guide.md
+++ b/docs/guides/admin-guide.md
@@ -293,6 +293,28 @@ inline so you can see which component (if any) didn't reload cleanly.
 > engine reads and compiles them on each invocation — so they never need a
 > reload.
 
+### Plugin Install Behavior
+
+On startup the engine resolves and installs every plugin declared in
+`src/plugins/plugins.manifest.json` (plus their transitive `deps[]`). Two
+things to know when editing the manifest:
+
+- **Optional `deps[].version` semver range** — each dep entry may set
+  `"version": "^1.2.0"` (or `">=1.0.0 <2.0.0"`, etc.). The installer
+  reads the dep's own `ursamu.plugin.json` `version` and aborts the run
+  if it doesn't satisfy the range. Entries without `version` install
+  unconditionally — backwards compatible.
+- **Fail-fast, whole-manifest rollback** — if any plugin or transitive
+  dep fails to clone, has an unsafe name or URL, violates a `version`
+  range, or has incompatible ranges from multiple requesters, the entire
+  install run aborts. Disk and `src/plugins/.registry.json` are left
+  exactly as they were before the run — your previously installed
+  plugins are not touched. The error names which entry failed and why.
+
+In practice: after editing the manifest, restart the server. If the run
+aborts, fix the offending entry and restart again — there is no partial
+state to clean up.
+
 ### Updating from Git (`@update`)
 
 Admins and wizards can update the running server from in-game without touching

--- a/docs/plugins/basics.md
+++ b/docs/plugins/basics.md
@@ -133,11 +133,18 @@ manifest at the plugin root:
   "ursamu": ">=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "main": "index.ts"
+  "main": "index.ts",
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 ```
 
-This is the file `ursamu plugin install` reads to confirm what it is installing,
-display details, and populate the local registry. See the
-[Plugin Manager](./index.md#installing-community-plugins) docs for the full
-install/update/remove workflow.
+Each `deps[]` entry may include an optional `version` semver range
+(`"^1.2.0"`, `">=1.0.0 <2.0.0"`). When present, the installer reads the
+dep's own manifest `version` and aborts the whole install if it does not
+satisfy the range. Omit `version` to install the dep without a check
+(backwards compatible). See the
+[Plugin Manager](./index.md#installing-community-plugins) and the
+[`deps[]` reference](./index.md#deps-entries) for the full install,
+update, remove, and atomic-rollback semantics.

--- a/docs/plugins/dependencies.md
+++ b/docs/plugins/dependencies.md
@@ -7,12 +7,15 @@ description: Sharing code and utilities between UrsaMU plugins
 
 ## Overview
 
-UrsaMU does not have a formal runtime dependency resolver — there is no
-`dependencies` array on `IPlugin` and no `app.plugins.get()` API. Instead,
-plugins share code the same way any TypeScript modules do: **direct imports**.
+UrsaMU resolves plugin **install order** through the `deps[]` array in
+`ursamu.plugin.json` (see [ursamu.plugin.json Dependencies](#ursamuplug-injson-dependencies)
+below), but there is no `app.plugins.get()` API for cross-plugin code
+access at runtime. Plugins share code the same way any TypeScript modules
+do: **direct imports**.
 
 This keeps things simple and type-safe. If plugin B needs something from
-plugin A, it imports it.
+plugin A, it declares plugin A in `deps[]` so the installer fetches it,
+then imports from it directly.
 ---
 
 ## Sharing Utilities
@@ -123,8 +126,9 @@ Plugin B to work even if Plugin A is not installed.
 
 ## ursamu.plugin.json Dependencies
 
-While there is no runtime dependency resolver, you can document required
-plugins in `ursamu.plugin.json` for human readers and future tooling:
+Declare transitive plugin dependencies in the `deps[]` array of your
+`ursamu.plugin.json`. `ensurePlugins` resolves and installs the graph on
+startup:
 
 ```json
 {
@@ -134,9 +138,18 @@ plugins in `ursamu.plugin.json` for human readers and future tooling:
   "ursamu": ">=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "requires": ["jobs"]
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 ```
 
-The `requires` field is informational only — `ursamu plugin install` displays
-it so operators know what to install first. It does not affect load order.
+Each entry needs `name` and `url`. The `ref` (git ref) and `version`
+(semver range checked against the dep's manifest) fields are optional.
+Omit `version` to install the dep without a check — backwards compatible
+with manifests written before the range feature shipped.
+
+If any dep fails to clone, fails its `version` range, or has incompatible
+ranges across requesters, the entire install run aborts and rolls back —
+disk and `.registry.json` are left exactly as they were before the run.
+See the [`deps[]` reference](./index.md#deps-entries) for full semantics.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -244,7 +244,10 @@ display details and populate the local registry.
   "ursamu": ">=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "main": "index.ts"
+  "main": "index.ts",
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 ```
 
@@ -257,6 +260,42 @@ display details and populate the local registry.
 | `author` | no | Author name or contact |
 | `license` | no | SPDX license identifier, e.g. `"MIT"` |
 | `main` | no | Entry-point file, defaults to `"index.ts"` |
+| `deps` | no | Array of transitive plugin dependencies — see below |
+
+### `deps[]` entries
+
+Each entry declares a plugin this one needs at runtime. The installer
+resolves the full graph before writing anything.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Plugin slug — install folder name |
+| `url` | yes | Git URL the installer will clone |
+| `ref` | no | Git ref (tag, branch, commit) |
+| `version` | no | Semver range (e.g. `"^1.2.0"`, `">=1.0.0 <2.0.0"`) checked against the dep's own manifest `version` |
+
+The `version` field is optional and opt-in. When omitted, the dep installs
+as before with no version check. When present, the installer reads the
+dep's `ursamu.plugin.json` after clone and aborts if its `version` does
+not satisfy the range — or if two requesters ask for incompatible ranges.
+
+### Atomic installs
+
+`ensurePlugins` (and the bulk install path used on first startup) is
+fail-fast across the entire manifest. If any plugin or transitive dep
+fails for any of these reasons, the whole run aborts and rolls back:
+
+- Clone failure or rename failure
+- Unsafe plugin name (path traversal, reserved characters)
+- Unsafe or unsupported clone URL
+- Manifest version does not satisfy a requested `version:` range
+- Two requesters declare incompatible `version:` ranges for the same dep
+- Malformed semver in any range or manifest version
+
+On abort, nothing from the failed run is left on disk or in
+`.registry.json`. Plugins installed in previous successful runs are not
+touched. The installer throws a `PluginInstallError` (or one of its
+subclasses) describing which entry failed and why.
 
 The `ursamu create plugin <name> --standalone` command generates this file
 automatically when scaffolding a new publishable plugin project.

--- a/docs/plugins/official-plugins.md
+++ b/docs/plugins/official-plugins.md
@@ -14,6 +14,8 @@ They are listed in `src/plugins/plugins.manifest.json` and installed automatical
 
 On startup, the engine reads `plugins.manifest.json` and fetches any plugin whose `ref` differs from the installed copy. No manual install step is required.
 
+The install run is **atomic across the whole manifest**: if any plugin or transitive dep fails to clone, has an unsafe name/URL, or violates a `version` semver range from its requester, the entire run aborts and rolls back. Disk and `src/plugins/.registry.json` are left exactly as they were — previously installed plugins are not touched.
+
 To disable auto-install for a specific plugin, remove its entry from the manifest.
 ---
 
@@ -45,11 +47,16 @@ Any GitHub repo can be added to the manifest:
       "url": "https://github.com/example/my-plugin",
       "ref": "v1.0.0",
       "description": "What this plugin does.",
-      "ursamu": ">=1.9.27"
+      "ursamu": ">=1.9.27",
+      "deps": [
+        { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+      ]
     }
   ]
 }
 ```
+
+Each `deps[]` entry may include an optional `version` semver range (e.g. `"^1.2.0"`, `">=1.0.0 <2.0.0"`) — the installer cross-checks it against the dep's own manifest `version` and aborts the run on mismatch. Omit `version` for backwards-compatible behavior.
 
 Or use the CLI:
 

--- a/src/utils/ensurePlugins.ts
+++ b/src/utils/ensurePlugins.ts
@@ -2,33 +2,28 @@
  * @module utils/ensurePlugins
  *
  * Reads `src/plugins/plugins.manifest.json` and, for any plugin whose
- * directory is absent, automatically clones and installs it from the
- * declared URL — no user interaction required.
- *
- * Called by loadPlugins() before the plugin directory walk so that
- * manifest-declared plugins are always present when the server starts.
- *
- * Security controls:
- *   - isSafePluginName: rejects names with path traversal sequences (H1)
- *   - isSafePluginUrl:  allows only https:// URLs (H2)
- *   - buildCloneSteps:  pins to `ref` when provided; SHA ref uses safe
- *                       init/fetch/checkout flow (M1)
+ * directory is absent, clones and installs it. The entire manifest run is
+ * wrapped in a single InstallTxn — any failure rolls back every dir and
+ * registry mutation made during this run.
  */
 
 import { dpath } from "../../deps.ts";
-import { exists }  from "jsr:@std/fs@^0.224.0";
+import { exists } from "jsr:@std/fs@^0.224.0";
 
 import {
-  type Registry,
+  type ManifestEntry,
   type PluginsManifest,
+  type Registry,
   isSafePluginName,
   isSafePluginUrl,
-  buildCloneSteps,
   runGitStep,
+  PluginDepNameError,
+  PluginDepUrlError,
 } from "./pluginSecurity.ts";
-import { readPluginVersion, resolveDeps } from "./pluginDeps.ts";
+import { readPluginVersion, resolveDeps, makeDefaultCtx, type ResolveDepsCtx } from "./pluginDeps.ts";
+import { cloneAndMove } from "./pluginDepsInstall.ts";
+import { InstallTxn } from "./pluginTxn.ts";
 
-// Re-export security guards for external callers (tests, CLI, etc.)
 export {
   isSafePluginName,
   isSafePluginUrl,
@@ -37,8 +32,6 @@ export {
   buildCloneSteps,
   runGitStep,
 } from "./pluginSecurity.ts";
-
-// ── Registry helpers ──────────────────────────────────────────────────────────
 
 async function readRegistry(registryPath: string): Promise<Registry> {
   try {
@@ -53,7 +46,88 @@ async function writeRegistry(registryPath: string, reg: Registry): Promise<void>
   await Deno.writeTextFile(registryPath, JSON.stringify(reg, null, 2));
 }
 
-// ── Main export ───────────────────────────────────────────────────────────────
+async function linkLocal(pluginsDir: string, entry: ManifestEntry): Promise<void> {
+  const targetDir = dpath.join(pluginsDir, entry.name);
+  if (await exists(targetDir)) return;
+  const gameRoot = dpath.resolve(pluginsDir, "../../..");
+  const localAbs = dpath.resolve(gameRoot, entry.local!);
+  try {
+    await Deno.symlink(localAbs, targetDir);
+    console.log(`[ensurePlugins] Linked local plugin "${entry.name}" → ${localAbs}`);
+  } catch (e: unknown) {
+    console.warn(`[ensurePlugins] Could not symlink local plugin "${entry.name}": ${e}`);
+  }
+}
+
+function validateEntry(entry: ManifestEntry): void {
+  if (!isSafePluginName(entry.name)) {
+    throw new PluginDepNameError(`Invalid plugin name "${entry.name}"`);
+  }
+  if (!isSafePluginUrl(entry.url)) {
+    throw new PluginDepUrlError(`Unsafe URL scheme in "${entry.url}" for plugin "${entry.name}"`);
+  }
+  if (!entry.ref) {
+    console.warn(
+      `[ensurePlugins] "${entry.name}" has no "ref" — installing HEAD of default branch. ` +
+      `Add a "ref" (tag or commit SHA) to pin the version.`,
+    );
+  }
+}
+
+/** Returns true when the entry is already installed at the desired ref and
+ *  should be skipped. Returns false when a fresh install/update is required.
+ *  Removes the existing dir when a ref drift is detected. */
+async function shouldSkipExisting(
+  reg: Registry, entry: ManifestEntry, targetDir: string,
+): Promise<boolean> {
+  if (!await exists(targetDir)) return false;
+  const installedRef = reg[entry.name]?.ref;
+  if (!entry.ref || installedRef === entry.ref) return true;
+  console.log(
+    `[ensurePlugins] Plugin "${entry.name}" ref changed ` +
+    `(${installedRef ?? "unpinned"} → ${entry.ref}) — updating...`,
+  );
+  await Deno.remove(targetDir, { recursive: true });
+  return false;
+}
+
+async function installEntry(
+  ctx: ResolveDepsCtx, entry: ManifestEntry, targetDir: string,
+): Promise<void> {
+  await cloneAndMove({ runStep: ctx.runStep }, entry, entry.name, targetDir);
+  ctx.txn.recordDir(targetDir);
+
+  const version = await readPluginVersion(targetDir);
+  ctx.txn.recordRegistry(entry.name, ctx.reg[entry.name]);
+  const now = new Date().toISOString();
+  ctx.reg[entry.name] = {
+    name:        entry.name,
+    version,
+    description: entry.description ?? "",
+    source:      entry.url,
+    author:      "unknown",
+    ref:         entry.ref,
+    installedAt: ctx.reg[entry.name]?.installedAt ?? now,
+    updatedAt:   now,
+  };
+  ctx.installed.push(`${entry.name}@${version}`);
+}
+
+async function processEntry(
+  ctx: ResolveDepsCtx, entry: ManifestEntry,
+): Promise<void> {
+  if (entry.local) { await linkLocal(ctx.pluginsDir, entry); return; }
+
+  validateEntry(entry);
+  const targetDir = dpath.join(ctx.pluginsDir, entry.name);
+  if (await shouldSkipExisting(ctx.reg, entry, targetDir)) {
+    await resolveDeps(ctx, targetDir, entry.name);
+    return;
+  }
+  await Deno.mkdir(ctx.pluginsDir, { recursive: true });
+  await installEntry(ctx, entry, targetDir);
+  await resolveDeps(ctx, targetDir, entry.name);
+}
 
 export async function ensurePlugins(pluginsDir: string): Promise<void> {
   const manifestPath = dpath.join(pluginsDir, "plugins.manifest.json");
@@ -62,129 +136,39 @@ export async function ensurePlugins(pluginsDir: string): Promise<void> {
   let manifest: PluginsManifest;
   try {
     manifest = JSON.parse(await Deno.readTextFile(manifestPath)) as PluginsManifest;
-  } catch (e) {
+  } catch (e: unknown) {
     console.error("[ensurePlugins] Could not parse plugins.manifest.json:", e);
     return;
   }
 
   const registryPath = dpath.join(pluginsDir, ".registry.json");
   const reg = await readRegistry(registryPath);
-  const installed: string[] = [];
+  const txn = new InstallTxn();
+  const ctx = makeDefaultCtx({
+    pluginsDir,
+    reg,
+    txn,
+    resolving: new Set(manifest.plugins.map(e => e.name)),
+    requests:  new Map(),
+    installed: [],
+    runStep:   runGitStep,
+  });
 
-  for (const entry of manifest.plugins) {
-    // Local dev override — symlink to the given path, never fetch from GitHub.
-    if (entry.local) {
-      const targetDir = dpath.join(pluginsDir, entry.name);
-      if (!await exists(targetDir)) {
-        // Resolve relative to the game root (three levels up from pluginsDir)
-        const gameRoot = dpath.resolve(pluginsDir, "../../..");
-        const localAbs = dpath.resolve(gameRoot, entry.local);
-        try {
-          await Deno.symlink(localAbs, targetDir);
-          console.log(`[ensurePlugins] Linked local plugin "${entry.name}" → ${localAbs}`);
-        } catch (e) {
-          console.warn(`[ensurePlugins] Could not symlink local plugin "${entry.name}": ${e}`);
-        }
-      }
-      continue;
+  try {
+    for (const entry of manifest.plugins) {
+      await processEntry(ctx, entry);
     }
-
-    // H1 — reject names with path traversal sequences
-    if (!isSafePluginName(entry.name)) {
-      console.warn(`[ensurePlugins] Skipping entry: invalid plugin name "${entry.name}"`);
-      continue;
-    }
-
-    // H2 — reject non-https URLs
-    if (!isSafePluginUrl(entry.url)) {
-      console.warn(`[ensurePlugins] Skipping "${entry.name}": unsafe URL scheme in "${entry.url}"`);
-      continue;
-    }
-
-    // M1 — warn when no ref is pinned
-    if (!entry.ref) {
-      console.warn(
-        `[ensurePlugins] "${entry.name}" has no "ref" — installing HEAD of default branch. ` +
-        `Add a "ref" (tag or commit SHA) to pin the version.`,
-      );
-    }
-
-    const targetDir = dpath.join(pluginsDir, entry.name);
-    if (await exists(targetDir)) {
-      const installedRef = reg[entry.name]?.ref;
-      // Only auto-update when the manifest has a ref AND it differs from what's installed.
-      if (!entry.ref || installedRef === entry.ref) continue;
-
-      console.log(
-        `[ensurePlugins] Plugin "${entry.name}" ref changed ` +
-        `(${installedRef ?? "unpinned"} → ${entry.ref}) — updating...`,
-      );
-      await Deno.remove(targetDir, { recursive: true });
-    }
-
-    const tempBase = await Deno.makeTempDir({ prefix: "ursamu-plugin-" });
-    const tempDir  = dpath.join(tempBase, "plugin");
-    try {
-      const gitEnv = { ...Deno.env.toObject(), GIT_TERMINAL_PROMPT: "0" };
-      let stepFailed = false;
-      for (const stepArgs of buildCloneSteps(entry.url, tempDir, entry.ref)) {
-        const { success, stderr } = await runGitStep(stepArgs, gitEnv);
-        if (!success) {
-          console.error(`[ensurePlugins] Failed to install "${entry.name}": ${stderr.trim()}`);
-          stepFailed = true;
-          break;
-        }
-      }
-      if (stepFailed) {
-        await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-        continue;
-      }
-
-      // Strip the .git directory before moving
-      const gitDir = dpath.join(tempDir, ".git");
-      if (await exists(gitDir)) await Deno.remove(gitDir, { recursive: true });
-
-      await Deno.mkdir(pluginsDir, { recursive: true });
-
-      // L1 — catch rename errors (TOCTOU)
-      try {
-        await Deno.rename(tempDir, targetDir);
-      } catch (renameErr) {
-        await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-        console.warn(`[ensurePlugins] Could not move "${entry.name}" into place: ${renameErr}`);
-        continue;
-      }
-      await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-
-      const version = await readPluginVersion(targetDir);
-      const now = new Date().toISOString();
-      reg[entry.name] = {
-        name:        entry.name,
-        version,
-        description: entry.description ?? "",
-        source:      entry.url,
-        author:      "unknown",
-        ref:         entry.ref,
-        installedAt: reg[entry.name]?.installedAt ?? now,
-        updatedAt:   now,
-      };
-      await writeRegistry(registryPath, reg);
-      installed.push(`${entry.name}@${version}`);
-    } catch (err) {
-      await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-      console.error(`[ensurePlugins] Failed to install "${entry.name}":`, err);
-    }
+  } catch (e: unknown) {
+    console.error("[ensurePlugins] Install run failed, rolling back:", e);
+    await txn.rollback(reg);
+    await writeRegistry(registryPath, reg);
+    throw e;
   }
 
-  // Resolve deps declared in each installed plugin's ursamu.plugin.json.
-  const resolving: Set<string> = new Set(manifest.plugins.map(e => e.name));
-  for (const entry of manifest.plugins) {
-    const targetDir = dpath.join(pluginsDir, entry.name);
-    if (!await exists(targetDir)) continue;
-    await resolveDeps(pluginsDir, targetDir, reg, resolving, installed);
-  }
+  await writeRegistry(registryPath, reg);
+  txn.commit();
 
-  if (installed.length) {
-    console.log(`[plugins] Installed: ${installed.join(", ")}`);
+  if (ctx.installed.length) {
+    console.log(`[plugins] Installed: ${ctx.installed.join(", ")}`);
   }
 }

--- a/src/utils/pluginDeps.ts
+++ b/src/utils/pluginDeps.ts
@@ -1,26 +1,41 @@
 /**
  * @module utils/pluginDeps
  *
- * Plugin dependency resolver for the plugin installer.
- * Reads `ursamu.plugin.json` from installed plugins and recursively clones
- * any missing dependencies.
- *
- * Consumed by ensurePlugins.ts.
+ * Fail-fast, semver-aware, conflict-detecting, transactional plugin dependency
+ * resolver. Reads `ursamu.plugin.json` from installed plugins and recursively
+ * clones any missing deps. Every failure throws a typed PluginInstallError —
+ * the caller wraps in an InstallTxn and calls rollback() on throw.
  */
 
 import { dpath } from "../../deps.ts";
-import { exists }  from "jsr:@std/fs@^0.224.0";
+import { exists } from "jsr:@std/fs@^0.224.0";
 
 import {
+  type PluginDep,
+  type PluginManifest,
   type Registry,
+  PluginConflictError,
+  PluginDepNameError,
+  PluginDepUrlError,
+  PluginVersionError,
+  PluginSemverError,
   isSafePluginName,
   isSafePluginUrl,
-  buildCloneSteps,
   runGitStep,
 } from "./pluginSecurity.ts";
-import type { PluginManifest } from "./pluginSecurity.ts";
+import { checkSatisfies } from "./pluginSemver.ts";
+import type { InstallTxn } from "./pluginTxn.ts";
+import { cloneAndMove } from "./pluginDepsInstall.ts";
 
-// ── Shared helpers (also used by ensurePlugins.ts) ────────────────────────────
+export interface ResolveDepsCtx {
+  pluginsDir: string;
+  reg:        Registry;
+  txn:        InstallTxn;
+  resolving:  Set<string>;
+  requests:   Map<string, Array<{ range?: string; requester: string }>>;
+  installed:  string[];
+  runStep:    (args: string[], env: Record<string, string>) => Promise<{ success: boolean; stderr: string }>;
+}
 
 export async function readPluginMeta(dir: string): Promise<PluginManifest> {
   try {
@@ -35,90 +50,127 @@ export async function readPluginVersion(dir: string): Promise<string> {
   return (await readPluginMeta(dir)).version ?? "unknown";
 }
 
-// ── Dependency resolver ───────────────────────────────────────────────────────
+/** Build a ResolveDepsCtx with `runStep` defaulted to `runGitStep`. */
+export function makeDefaultCtx(
+  base: Omit<ResolveDepsCtx, "runStep"> & Partial<Pick<ResolveDepsCtx, "runStep">>,
+): ResolveDepsCtx {
+  return { ...base, runStep: base.runStep ?? runGitStep };
+}
 
-/**
- * Read a plugin's declared deps from its `ursamu.plugin.json` and install any
- * that are absent.  Recurses into each newly-installed dep's own deps.
- * `resolving` tracks names currently being processed to break circular chains.
- */
 export async function resolveDeps(
-  pluginsDir: string,
-  pluginDir:  string,
-  reg:        Registry,
-  resolving:  Set<string>,
-  installed:  string[],
+  ctx:           ResolveDepsCtx,
+  pluginDir:     string,
+  requesterName: string,
 ): Promise<void> {
   const meta = await readPluginMeta(pluginDir);
   if (!meta.deps?.length) return;
-
   for (const dep of meta.deps) {
-    if (!isSafePluginName(dep.name)) {
-      console.warn(`[ensurePlugins] Skipping dep "${dep.name}": invalid name`);
-      continue;
-    }
-    if (!isSafePluginUrl(dep.url)) {
-      console.warn(`[ensurePlugins] Skipping dep "${dep.name}": unsafe URL`);
-      continue;
-    }
-    if (resolving.has(dep.name)) continue; // already installed or in-flight
-    resolving.add(dep.name);
+    await processDep(ctx, dep, requesterName);
+  }
+}
 
-    const depDir = dpath.join(pluginsDir, dep.name);
-    if (await exists(depDir)) {
-      // Dep already on disk — still recurse in case it has its own deps.
-      await resolveDeps(pluginsDir, depDir, reg, resolving, installed);
-      continue;
-    }
-
-    console.log(
-      `[ensurePlugins] Installing dep "${dep.name}" ` +
-      `(required by ${dpath.basename(pluginDir)})...`,
+async function processDep(
+  ctx:           ResolveDepsCtx,
+  dep:           PluginDep,
+  requesterName: string,
+): Promise<void> {
+  if (!isSafePluginName(dep.name)) {
+    throw new PluginDepNameError(
+      `Dep "${dep.name}" requested by "${requesterName}" has an invalid name`,
     );
-    const tempBase = await Deno.makeTempDir({ prefix: "ursamu-plugin-" });
-    const tempDir  = dpath.join(tempBase, "plugin");
+  }
+  if (!isSafePluginUrl(dep.url)) {
+    throw new PluginDepUrlError(
+      `Dep "${dep.name}" requested by "${requesterName}" has an unsafe URL "${dep.url}"`,
+    );
+  }
+  const reqList = ctx.requests.get(dep.name) ?? [];
+  reqList.push({ range: dep.version, requester: requesterName });
+  ctx.requests.set(dep.name, reqList);
+
+  if (ctx.resolving.has(dep.name)) return;
+  ctx.resolving.add(dep.name);
+
+  const depDir = dpath.join(ctx.pluginsDir, dep.name);
+  if (await exists(depDir)) {
+    const version = await readPluginVersion(depDir);
+    verifyDepRanges(dep.name, version, reqList);
+    await resolveDeps(ctx, depDir, dep.name);
+    return;
+  }
+  await installDep(ctx, dep, requesterName, depDir, reqList);
+}
+
+async function installDep(
+  ctx:           ResolveDepsCtx,
+  dep:           PluginDep,
+  requesterName: string,
+  depDir:        string,
+  reqList:       Array<{ range?: string; requester: string }>,
+): Promise<void> {
+  await cloneAndMove({ runStep: ctx.runStep }, dep, requesterName, depDir);
+  ctx.txn.recordDir(depDir);
+
+  const version = await readPluginVersion(depDir);
+  verifyDepRanges(dep.name, version, reqList);
+
+  ctx.txn.recordRegistry(dep.name, ctx.reg[dep.name]);
+  const now = new Date().toISOString();
+  ctx.reg[dep.name] = {
+    name:        dep.name,
+    version,
+    description: "",
+    source:      dep.url,
+    author:      "unknown",
+    ref:         dep.ref,
+    installedAt: now,
+    updatedAt:   now,
+  };
+  ctx.installed.push(`${dep.name}@${version}`);
+
+  await resolveDeps(ctx, depDir, dep.name);
+}
+
+export function verifyDepRanges(
+  depName:          string,
+  installedVersion: string,
+  requests:         Array<{ range?: string; requester: string }>,
+): void {
+  const ranged = requests.filter((r): r is { range: string; requester: string } =>
+    typeof r.range === "string" && r.range.length > 0
+  );
+  for (const req of ranged) {
+    if (!installedVersion || installedVersion === "unknown") {
+      throw new PluginVersionError(
+        `Dep "${depName}" required by "${req.requester}" with range "${req.range}" has no valid installed version`,
+      );
+    }
     try {
-      const gitEnv = { ...Deno.env.toObject(), GIT_TERMINAL_PROMPT: "0" };
-      let failed   = false;
-      for (const stepArgs of buildCloneSteps(dep.url, tempDir, dep.ref)) {
-        const { success, stderr } = await runGitStep(stepArgs, gitEnv);
-        if (!success) {
-          console.error(`[ensurePlugins] Failed to install dep "${dep.name}": ${stderr.trim()}`);
-          failed = true;
-          break;
-        }
-      }
-      if (failed) {
-        await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-        continue;
-      }
-
-      const gitDir = dpath.join(tempDir, ".git");
-      if (await exists(gitDir)) await Deno.remove(gitDir, { recursive: true });
-
-      try {
-        await Deno.rename(tempDir, depDir);
-      } catch (e) {
-        await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-        console.warn(`[ensurePlugins] Could not move dep "${dep.name}" into place: ${e}`);
-        continue;
-      }
-      await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-
-      const version = await readPluginVersion(depDir);
-      const now     = new Date().toISOString();
-      reg[dep.name] = {
-        name: dep.name, version, description: "", source: dep.url,
-        author: "unknown", ref: dep.ref,
-        installedAt: now, updatedAt: now,
-      };
-      installed.push(`${dep.name}@${version}`);
-
-      // Recurse into the newly-installed dep's own deps.
-      await resolveDeps(pluginsDir, depDir, reg, resolving, installed);
-    } catch (err) {
-      await Deno.remove(tempBase, { recursive: true }).catch(() => {});
-      console.error(`[ensurePlugins] Failed to install dep "${dep.name}":`, err);
+      checkSatisfies(depName, installedVersion, req.range);
+    } catch (e: unknown) {
+      throw rewrapSemverFailure(depName, installedVersion, ranged, req.range, e);
     }
   }
+}
+
+function rewrapSemverFailure(
+  depName:           string,
+  installedVersion:  string,
+  ranged:            Array<{ range: string; requester: string }>,
+  failingRange:      string,
+  cause:             unknown,
+): Error {
+  if (ranged.length < 2) {
+    if (cause instanceof PluginSemverError || cause instanceof PluginVersionError) return cause;
+    return new PluginSemverError(
+      `Plugin "${depName}" version ${installedVersion} does not satisfy "${failingRange}"`,
+      cause,
+    );
+  }
+  const pairs = ranged.map(r => `${r.requester} wants ${r.range}`).join(", ");
+  return new PluginConflictError(
+    `Plugin "${depName}" version ${installedVersion} conflict: ${pairs}, ` +
+    `version does not satisfy ${failingRange}`,
+    cause,
+  );
 }

--- a/src/utils/pluginDepsInstall.ts
+++ b/src/utils/pluginDepsInstall.ts
@@ -1,0 +1,76 @@
+/**
+ * @module utils/pluginDepsInstall
+ *
+ * Clone-and-install half of the dep resolver. Split from pluginDeps.ts to
+ * keep both files under the 200-line cap.
+ */
+
+import { dpath } from "../../deps.ts";
+import { exists } from "jsr:@std/fs@^0.224.0";
+
+import {
+  buildCloneSteps,
+  PluginCloneError,
+  PluginRenameError,
+  type PluginDep,
+} from "./pluginSecurity.ts";
+
+export interface CloneAndMoveCtx {
+  runStep: (args: string[], env: Record<string, string>) => Promise<{ success: boolean; stderr: string }>;
+}
+
+/** Clones `dep` into a tempdir then renames into `depDir`. Tempdir is always
+ *  cleaned in a `finally` so no leak on any failure path. */
+export async function cloneAndMove(
+  ctx:           CloneAndMoveCtx,
+  dep:           PluginDep,
+  requesterName: string,
+  depDir:        string,
+): Promise<void> {
+  const tempBase = await Deno.makeTempDir({ prefix: "ursamu-plugin-" });
+  const tempDir  = dpath.join(tempBase, "plugin");
+  try {
+    await runCloneSteps(ctx, dep, requesterName, tempDir);
+    await stripDotGit(tempDir);
+    await renameInto(dep, requesterName, tempDir, depDir);
+  } finally {
+    await Deno.remove(tempBase, { recursive: true }).catch(() => {});
+  }
+}
+
+async function runCloneSteps(
+  ctx:           CloneAndMoveCtx,
+  dep:           PluginDep,
+  requesterName: string,
+  tempDir:       string,
+): Promise<void> {
+  const gitEnv = { ...Deno.env.toObject(), GIT_TERMINAL_PROMPT: "0" };
+  for (const stepArgs of buildCloneSteps(dep.url, tempDir, dep.ref)) {
+    const { success, stderr } = await ctx.runStep(stepArgs, gitEnv);
+    if (success) continue;
+    throw new PluginCloneError(
+      `Failed to clone dep "${dep.name}" required by "${requesterName}": ${stderr.trim()}`,
+    );
+  }
+}
+
+async function stripDotGit(tempDir: string): Promise<void> {
+  const gitDir = dpath.join(tempDir, ".git");
+  if (await exists(gitDir)) await Deno.remove(gitDir, { recursive: true });
+}
+
+async function renameInto(
+  dep:           PluginDep,
+  requesterName: string,
+  tempDir:       string,
+  depDir:        string,
+): Promise<void> {
+  try {
+    await Deno.rename(tempDir, depDir);
+  } catch (e: unknown) {
+    throw new PluginRenameError(
+      `Could not move dep "${dep.name}" required by "${requesterName}" into place`,
+      e,
+    );
+  }
+}

--- a/src/utils/pluginErrors.ts
+++ b/src/utils/pluginErrors.ts
@@ -1,0 +1,61 @@
+/**
+ * @module utils/pluginErrors
+ *
+ * Typed errors for the plugin installer pipeline.
+ */
+
+export class PluginInstallError extends Error {
+  constructor(msg: string, public override cause?: unknown) {
+    super(msg);
+    this.name = "PluginInstallError";
+  }
+}
+
+export class PluginDepNameError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginDepNameError";
+  }
+}
+
+export class PluginDepUrlError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginDepUrlError";
+  }
+}
+
+export class PluginCloneError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginCloneError";
+  }
+}
+
+export class PluginRenameError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginRenameError";
+  }
+}
+
+export class PluginVersionError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginVersionError";
+  }
+}
+
+export class PluginSemverError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginSemverError";
+  }
+}
+
+export class PluginConflictError extends PluginInstallError {
+  constructor(msg: string, cause?: unknown) {
+    super(msg, cause);
+    this.name = "PluginConflictError";
+  }
+}

--- a/src/utils/pluginSecurity.ts
+++ b/src/utils/pluginSecurity.ts
@@ -27,6 +27,8 @@ export interface PluginDep {
   name: string;
   url:  string;
   ref?: string;
+  /** Optional semver range, e.g. "^1.2.0". When set, installed dep version must satisfy. */
+  version?: string;
 }
 
 export interface PluginManifest {
@@ -147,3 +149,16 @@ export async function runGitStep(
   }
   return { success: result.success, stderr: await stderrText.catch(() => "") };
 }
+
+// ── Typed errors (re-exported from pluginErrors.ts) ───────────────────────────
+
+export {
+  PluginCloneError,
+  PluginConflictError,
+  PluginDepNameError,
+  PluginDepUrlError,
+  PluginInstallError,
+  PluginRenameError,
+  PluginSemverError,
+  PluginVersionError,
+} from "./pluginErrors.ts";

--- a/src/utils/pluginSemver.ts
+++ b/src/utils/pluginSemver.ts
@@ -1,0 +1,46 @@
+import { parse as parseSemver, parseRange, satisfies, type Range, type SemVer } from "@std/semver";
+import {
+  PluginSemverError,
+  PluginVersionError,
+} from "./pluginSecurity.ts";
+
+/** Parse a semver range, throwing PluginSemverError with the dep name on failure. */
+export function parseRangeOrThrow(depName: string, range: string): Range {
+  try {
+    return parseRange(range);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new PluginSemverError(
+      `Plugin "${depName}" has invalid semver range "${range}": ${msg}`,
+    );
+  }
+}
+
+/** Parse a version, throwing PluginVersionError with the dep name on failure.
+ *  Also throws on the sentinel value "unknown" used by legacy plugins. */
+export function parseVersionOrThrow(depName: string, version: string): SemVer {
+  if (!version || version === "unknown") {
+    throw new PluginVersionError(
+      `Plugin "${depName}" has no valid version in its manifest`,
+    );
+  }
+  try {
+    return parseSemver(version);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new PluginVersionError(
+      `Plugin "${depName}" has invalid version "${version}": ${msg}`,
+    );
+  }
+}
+
+/** Throws PluginSemverError if `version` does not satisfy `range`. */
+export function checkSatisfies(depName: string, version: string, range: string): void {
+  const ver = parseVersionOrThrow(depName, version);
+  const rng = parseRangeOrThrow(depName, range);
+  if (!satisfies(ver, rng)) {
+    throw new PluginSemverError(
+      `Plugin "${depName}" version ${version} does not satisfy required range "${range}"`,
+    );
+  }
+}

--- a/src/utils/pluginTxn.ts
+++ b/src/utils/pluginTxn.ts
@@ -1,0 +1,67 @@
+import type { Registry, RegistryEntry } from "../cli/types.ts";
+
+export interface TxnDirRecord {
+  kind: "dir";
+  path: string;
+}
+
+export interface TxnRegRecord {
+  kind: "reg";
+  name: string;
+  previous: RegistryEntry | undefined;
+}
+
+export type TxnRecord = TxnDirRecord | TxnRegRecord;
+
+export class InstallTxn {
+  private records: TxnRecord[] = [];
+  private committed = false;
+
+  /** Record a directory the txn created. Call AFTER the directory exists on disk. */
+  recordDir(path: string): void {
+    this.records.push({ kind: "dir", path });
+  }
+
+  /** Record a registry mutation. Call BEFORE writing the new entry,
+   *  passing the current value (possibly undefined). */
+  recordRegistry(name: string, previous: RegistryEntry | undefined): void {
+    this.records.push({ kind: "reg", name, previous });
+  }
+
+  /** Marks committed; subsequent rollback() is a no-op. */
+  commit(): void {
+    this.committed = true;
+  }
+
+  /** Roll back in LIFO order. Mutates `reg` in place (restoring or deleting keys).
+   *  Directory removals are best-effort; failures are logged via console.warn
+   *  and never rethrown. Always safe to call multiple times. */
+  async rollback(reg: Registry): Promise<void> {
+    if (this.committed) return;
+    for (let i = this.records.length - 1; i >= 0; i--) {
+      const rec = this.records[i];
+      if (rec.kind === "dir") {
+        await this.removeDir(rec.path);
+      } else {
+        this.restoreReg(reg, rec);
+      }
+    }
+    this.records = [];
+  }
+
+  private async removeDir(path: string): Promise<void> {
+    try {
+      await Deno.remove(path, { recursive: true });
+    } catch (e: unknown) {
+      console.warn(`InstallTxn: failed to remove ${path}:`, e);
+    }
+  }
+
+  private restoreReg(reg: Registry, rec: TxnRegRecord): void {
+    if (rec.previous === undefined) {
+      delete reg[rec.name];
+    } else {
+      reg[rec.name] = rec.previous;
+    }
+  }
+}

--- a/tests/plugin_deps_resolver.test.ts
+++ b/tests/plugin_deps_resolver.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for resolveDeps — semver-aware, transactional dependency resolver.
+ * Uses an injected `runStep` stub so no real git is invoked.
+ */
+import { assertEquals, assertRejects, assertStringIncludes, assert } from "@std/assert";
+import { join } from "@std/path";
+
+import { resolveDeps, type ResolveDepsCtx } from "../src/utils/pluginDeps.ts";
+import { InstallTxn } from "../src/utils/pluginTxn.ts";
+import {
+  PluginCloneError,
+  PluginConflictError,
+  PluginDepNameError,
+  PluginDepUrlError,
+  PluginSemverError,
+} from "../src/utils/pluginErrors.ts";
+import type { Registry } from "../src/cli/types.ts";
+import type { PluginDep, PluginManifest } from "../src/utils/pluginSecurity.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+// ───── Helpers ────────────────────────────────────────────────────────────────
+
+interface FakeRepo {
+  version?: string;
+  deps?:    PluginDep[];
+}
+
+/**
+ * Returns a runStep stub that simulates `git clone`. It looks at the `clone`
+ * step's last arg (the dest path) and writes `ursamu.plugin.json` into that
+ * dest using the provided `repos` map keyed by repo URL. Other git
+ * sub-commands (init/remote/fetch/checkout) succeed with no side effects.
+ */
+function makeRunStep(
+  repos: Map<string, FakeRepo>,
+  failures?: Map<string, string>,
+): ResolveDepsCtx["runStep"] {
+  return async (args: string[], _env: Record<string, string>) => {
+    if (args[0] === "clone") {
+      const url  = args[args.length - 2];
+      const dest = args[args.length - 1];
+      if (failures?.has(url)) {
+        return { success: false, stderr: failures.get(url) ?? "fail" };
+      }
+      const repo = repos.get(url);
+      if (!repo) return { success: false, stderr: `no such repo: ${url}` };
+      await Deno.mkdir(dest, { recursive: true });
+      const manifest: PluginManifest = {};
+      if (repo.version !== undefined) manifest.version = repo.version;
+      if (repo.deps)                  manifest.deps    = repo.deps;
+      await Deno.writeTextFile(
+        join(dest, "ursamu.plugin.json"),
+        JSON.stringify(manifest),
+      );
+      return { success: true, stderr: "" };
+    }
+    return { success: true, stderr: "" };
+  };
+}
+
+async function seedOriginator(
+  pluginsDir: string,
+  name: string,
+  deps: PluginDep[],
+): Promise<string> {
+  const dir = join(pluginsDir, name);
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(
+    join(dir, "ursamu.plugin.json"),
+    JSON.stringify({ version: "1.0.0", deps }),
+  );
+  return dir;
+}
+
+function makeCtx(
+  pluginsDir: string,
+  runStep: ResolveDepsCtx["runStep"],
+  reg: Registry = {},
+): ResolveDepsCtx & { reg: Registry; txn: InstallTxn } {
+  return {
+    pluginsDir,
+    reg,
+    txn:       new InstallTxn(),
+    resolving: new Set<string>(),
+    requests:  new Map(),
+    installed: [],
+    runStep,
+  };
+}
+
+async function listPluginsDir(pluginsDir: string): Promise<string[]> {
+  const out: string[] = [];
+  for await (const entry of Deno.readDir(pluginsDir)) out.push(entry.name);
+  return out;
+}
+
+// ───── Tests ──────────────────────────────────────────────────────────────────
+
+Deno.test("resolveDeps — invalid dep name throws PluginDepNameError, no dir created", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "../evil", url: "https://github.com/foo/evil" },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(new Map()));
+    await assertRejects(
+      () => resolveDeps(ctx, origDir, "orig"),
+      PluginDepNameError,
+    );
+    const entries = await listPluginsDir(pluginsDir);
+    assertEquals(entries.sort(), ["orig"]);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — invalid dep URL throws PluginDepUrlError, no dir created", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "okname", url: "file:///etc/passwd" },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(new Map()));
+    await assertRejects(
+      () => resolveDeps(ctx, origDir, "orig"),
+      PluginDepUrlError,
+    );
+    const entries = await listPluginsDir(pluginsDir);
+    assertEquals(entries.sort(), ["orig"]);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — clone failure throws PluginCloneError, no leftover dir", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const url = "https://github.com/foo/depA";
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "depa", url },
+    ]);
+    const runStep = makeRunStep(new Map(), new Map([[url, "boom"]]));
+    const ctx = makeCtx(pluginsDir, runStep);
+
+    const err = await assertRejects(
+      () => resolveDeps(ctx, origDir, "orig"),
+      PluginCloneError,
+    );
+    assertStringIncludes(err.message, "boom");
+
+    const entries = await listPluginsDir(pluginsDir);
+    assertEquals(entries.sort(), ["orig"], "no leftover dep dir");
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — success path: dep cloned, recorded in installed + reg + txn", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const url = "https://github.com/foo/depa";
+    const repos = new Map<string, FakeRepo>([
+      [url, { version: "1.0.0" }],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "depa", url, version: "^1.0.0" },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+
+    await resolveDeps(ctx, origDir, "orig");
+
+    assertEquals(ctx.installed, ["depa@1.0.0"]);
+    assert(ctx.reg["depa"], "reg has depa entry");
+    assertEquals(ctx.reg["depa"].version, "1.0.0");
+    // Dir exists
+    const stat = await Deno.stat(join(pluginsDir, "depa"));
+    assert(stat.isDirectory);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — installed version fails semver range → PluginSemverError", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const url = "https://github.com/foo/depa";
+    const repos = new Map<string, FakeRepo>([
+      [url, { version: "0.9.0" }],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "depa", url, version: "^1.0.0" },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+
+    await assertRejects(
+      () => resolveDeps(ctx, origDir, "orig"),
+      PluginSemverError,
+    );
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — two requesters with conflicting ranges → PluginConflictError", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const urlB = "https://github.com/foo/b";
+    // B installed at 1.0.0 from fake clone.
+    const repos = new Map<string, FakeRepo>([
+      [urlB, { version: "1.0.0" }],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "b", url: urlB, version: "^2.0.0" },
+    ]);
+    // Pre-seed requests map so verifyDepRanges sees two ranges
+    // when install completes — simulates a real run where multiple
+    // top-level entries collectively request `b` with conflicting ranges.
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+    ctx.requests.set("b", [
+      { range: "^1.0.0", requester: "other-plugin" },
+    ]);
+
+    const err = await assertRejects(
+      () => resolveDeps(ctx, origDir, "orig"),
+    );
+    assert(
+      err instanceof PluginConflictError,
+      `expected PluginConflictError, got ${err.constructor.name}: ${err.message}`,
+    );
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — legacy compat: no version in dep entry and installed='unknown' → no error", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const url = "https://github.com/foo/legacy";
+    // Repo manifest has no version → readPluginVersion returns "unknown"
+    const repos = new Map<string, FakeRepo>([
+      [url, {}],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "legacy", url }, // no version range
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+
+    await resolveDeps(ctx, origDir, "orig");
+    assertEquals(ctx.installed, ["legacy@unknown"]);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — cycle A → B → A does not infinite-loop", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const urlA = "https://github.com/foo/a";
+    const urlB = "https://github.com/foo/b";
+    const repos = new Map<string, FakeRepo>([
+      [urlA, { version: "1.0.0", deps: [{ name: "b", url: urlB }] }],
+      [urlB, { version: "1.0.0", deps: [{ name: "a", url: urlA }] }],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "a", url: urlA },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+
+    await resolveDeps(ctx, origDir, "orig");
+    // Both A and B installed exactly once.
+    assertEquals(ctx.installed.sort(), ["a@1.0.0", "b@1.0.0"]);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveDeps — transitive A → B → C installs all three", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-deps-" });
+  try {
+    const urlA = "https://github.com/foo/a";
+    const urlB = "https://github.com/foo/b";
+    const urlC = "https://github.com/foo/c";
+    const repos = new Map<string, FakeRepo>([
+      [urlA, { version: "1.0.0", deps: [{ name: "b", url: urlB }] }],
+      [urlB, { version: "1.0.0", deps: [{ name: "c", url: urlC }] }],
+      [urlC, { version: "1.0.0" }],
+    ]);
+    const origDir = await seedOriginator(pluginsDir, "orig", [
+      { name: "a", url: urlA },
+    ]);
+    const ctx = makeCtx(pluginsDir, makeRunStep(repos));
+
+    await resolveDeps(ctx, origDir, "orig");
+    assertEquals(ctx.installed.sort(), ["a@1.0.0", "b@1.0.0", "c@1.0.0"]);
+    assert(ctx.reg["a"]);
+    assert(ctx.reg["b"]);
+    assert(ctx.reg["c"]);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/tests/plugin_install_txn.test.ts
+++ b/tests/plugin_install_txn.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for InstallTxn — the per-run transaction object that tracks
+ * directory creations and registry mutations, and rolls back on failure.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { InstallTxn } from "../src/utils/pluginTxn.ts";
+import type { Registry, RegistryEntry } from "../src/cli/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function makeEntry(name: string, version = "1.0.0"): RegistryEntry {
+  return {
+    name,
+    version,
+    description: "",
+    source:      "https://github.com/foo/" + name,
+    author:      "unknown",
+    installedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt:   "2026-01-01T00:00:00.000Z",
+  };
+}
+
+async function dirExists(p: string): Promise<boolean> {
+  try { await Deno.stat(p); return true; } catch { return false; }
+}
+
+Deno.test("InstallTxn.recordDir + rollback removes the directory", OPTS, async () => {
+  const base = await Deno.makeTempDir({ prefix: "ursamu-txn-" });
+  try {
+    const dir = join(base, "plugin-x");
+    await Deno.mkdir(dir);
+    await Deno.writeTextFile(join(dir, "marker.txt"), "hi");
+
+    const txn = new InstallTxn();
+    txn.recordDir(dir);
+    await txn.rollback({});
+
+    assertEquals(await dirExists(dir), false);
+  } finally {
+    await Deno.remove(base, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("InstallTxn.recordRegistry with previous=undefined → rollback deletes key", OPTS, async () => {
+  const reg: Registry = {};
+  const txn = new InstallTxn();
+  txn.recordRegistry("foo", undefined);
+  reg["foo"] = makeEntry("foo");
+
+  await txn.rollback(reg);
+  assertEquals(reg["foo"], undefined);
+});
+
+Deno.test("InstallTxn.recordRegistry with a previous entry → rollback restores it", OPTS, async () => {
+  const prev = makeEntry("foo", "1.0.0");
+  const reg: Registry = { foo: prev };
+  const txn = new InstallTxn();
+  txn.recordRegistry("foo", prev);
+  reg["foo"] = makeEntry("foo", "2.0.0");
+
+  await txn.rollback(reg);
+  assertEquals(reg["foo"], prev);
+});
+
+Deno.test("InstallTxn.commit makes rollback a no-op", OPTS, async () => {
+  const base = await Deno.makeTempDir({ prefix: "ursamu-txn-" });
+  try {
+    const dir = join(base, "kept");
+    await Deno.mkdir(dir);
+
+    const reg: Registry = {};
+    const txn = new InstallTxn();
+    txn.recordDir(dir);
+    txn.recordRegistry("foo", undefined);
+    reg["foo"] = makeEntry("foo");
+    txn.commit();
+
+    await txn.rollback(reg);
+
+    assertEquals(await dirExists(dir), true, "dir preserved post-commit");
+    assert(reg["foo"] !== undefined, "registry entry preserved post-commit");
+  } finally {
+    await Deno.remove(base, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("InstallTxn.rollback is idempotent (safe to call twice)", OPTS, async () => {
+  const base = await Deno.makeTempDir({ prefix: "ursamu-txn-" });
+  try {
+    const dir = join(base, "plugin-y");
+    await Deno.mkdir(dir);
+
+    const reg: Registry = {};
+    const txn = new InstallTxn();
+    txn.recordDir(dir);
+    txn.recordRegistry("bar", undefined);
+    reg["bar"] = makeEntry("bar");
+
+    await txn.rollback(reg);
+    await txn.rollback(reg);
+
+    assertEquals(await dirExists(dir), false);
+    assertEquals(reg["bar"], undefined);
+  } finally {
+    await Deno.remove(base, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("InstallTxn.rollback of a missing directory does not throw", OPTS, async () => {
+  const txn = new InstallTxn();
+  txn.recordDir("/tmp/this/path/definitely/does/not/exist-ursamu-test");
+
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    await txn.rollback({});
+  } finally {
+    console.warn = origWarn;
+  }
+});

--- a/tests/plugin_semver.test.ts
+++ b/tests/plugin_semver.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for pluginSemver — parse/validate helpers used by the dep resolver.
+ */
+import { assertThrows, assertStringIncludes } from "@std/assert";
+import {
+  parseRangeOrThrow,
+  parseVersionOrThrow,
+  checkSatisfies,
+} from "../src/utils/pluginSemver.ts";
+import {
+  PluginSemverError,
+  PluginVersionError,
+} from "../src/utils/pluginErrors.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("parseRangeOrThrow accepts a valid range", OPTS, () => {
+  const r = parseRangeOrThrow("foo", "^1.2.0");
+  if (!r) throw new Error("expected Range");
+});
+
+Deno.test("parseRangeOrThrow throws PluginSemverError on garbage", OPTS, () => {
+  const err = assertThrows(
+    () => parseRangeOrThrow("foo", "not-a-range"),
+    PluginSemverError,
+  );
+  assertStringIncludes(err.message, "foo");
+});
+
+Deno.test("parseVersionOrThrow accepts a valid version", OPTS, () => {
+  const v = parseVersionOrThrow("foo", "1.2.3");
+  if (!v) throw new Error("expected SemVer");
+});
+
+Deno.test("parseVersionOrThrow throws PluginVersionError for 'unknown'", OPTS, () => {
+  assertThrows(
+    () => parseVersionOrThrow("foo", "unknown"),
+    PluginVersionError,
+  );
+});
+
+Deno.test("parseVersionOrThrow throws PluginVersionError for empty string", OPTS, () => {
+  assertThrows(
+    () => parseVersionOrThrow("foo", ""),
+    PluginVersionError,
+  );
+});
+
+Deno.test("checkSatisfies passes when version is in range", OPTS, () => {
+  checkSatisfies("foo", "1.3.0", "^1.2.0");
+});
+
+Deno.test("checkSatisfies throws PluginSemverError with version and range in message", OPTS, () => {
+  const err = assertThrows(
+    () => checkSatisfies("foo", "2.0.0", "^1.2.0"),
+    PluginSemverError,
+  );
+  assertStringIncludes(err.message, "2.0.0");
+  assertStringIncludes(err.message, "^1.2.0");
+});
+
+Deno.test("checkSatisfies — accumulated ranges: v1.3.0 satisfies both ^1.0.0 and ^1.2.0", OPTS, () => {
+  checkSatisfies("foo", "1.3.0", "^1.0.0");
+  checkSatisfies("foo", "1.3.0", "^1.2.0");
+});
+
+Deno.test("checkSatisfies — v1.0.5 does not satisfy ^1.2.0", OPTS, () => {
+  assertThrows(
+    () => checkSatisfies("foo", "1.0.5", "^1.2.0"),
+    PluginSemverError,
+  );
+});

--- a/tests/security_ensure_plugins.test.ts
+++ b/tests/security_ensure_plugins.test.ts
@@ -129,7 +129,9 @@ Deno.test("[INT] ensurePlugins — malicious name does not create dir outside pl
       plugins: [{ name: "../../escape-attempt", url: "https://github.com/foo/bar" }],
     }));
 
-    await ensurePlugins(pluginsDir);
+    let threw = false;
+    try { await ensurePlugins(pluginsDir); } catch { threw = true; }
+    assertEquals(threw, true, "manifest install should throw on invalid name");
 
     // The escaped path would land one level above pluginsDir's parent
     const escapedPath = join(pluginsDir, "../../escape-attempt");
@@ -217,13 +219,89 @@ Deno.test("[REF] ensurePlugins — removes plugin dir when manifest ref has chan
       plugins: [{ name: "my-plugin", url: "https://github.com/foo/my-plugin", ref: "v1.1.0" }],
     }));
 
-    // ensurePlugins will remove the dir then attempt git clone (which will fail for a fake URL — that's fine)
-    await ensurePlugins(pluginsDir);
+    // ensurePlugins removes the dir, then the clone fails (fake URL).
+    // The new transactional installer re-throws PluginCloneError after rollback.
+    let threw = false;
+    try { await ensurePlugins(pluginsDir); } catch { threw = true; }
+    assertEquals(threw, true, "clone failure should propagate");
 
     // The marker file must be gone — dir was removed for the update
     let markerExists = false;
     try { await Deno.stat(join(pluginDir, "marker.txt")); markerExists = true; } catch { /* expected */ }
     assertEquals(markerExists, false, "Old plugin dir must be removed when ref changes");
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+// ─── Manifest-level rollback: whole run aborts atomically on any failure ─────
+//
+// Note: ensurePlugins does not expose a runStep seam (it hard-wires
+// runGitStep). These cases use the validation-failure path — a top-level
+// plugin with an unsafe URL or invalid name — which throws inside the
+// manifest loop and triggers `txn.rollback(reg)` + the surrounding catch.
+// The assertion in both cases: no leftover dirs in pluginsDir and no
+// registry entries for either P1 or P2.
+
+Deno.test("[ROLLBACK] manifest install aborts whole run on dep-URL failure", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-rollback-" });
+  try {
+    // P1 fails fast on URL validation; P2 is well-formed but must never be
+    // reached because the manifest loop aborts at the first failure.
+    await Deno.writeTextFile(join(pluginsDir, "plugins.manifest.json"), JSON.stringify({
+      plugins: [
+        { name: "p1", url: "file:///etc/passwd" },
+        { name: "p2", url: "https://github.com/foo/p2" },
+      ],
+    }));
+
+    let threw = false;
+    try { await ensurePlugins(pluginsDir); } catch { threw = true; }
+    assertEquals(threw, true, "manifest install should throw on bad URL");
+
+    // Neither plugin installed.
+    let p1Exists = false, p2Exists = false;
+    try { await Deno.stat(join(pluginsDir, "p1")); p1Exists = true; } catch { /* */ }
+    try { await Deno.stat(join(pluginsDir, "p2")); p2Exists = true; } catch { /* */ }
+    assertEquals(p1Exists, false, "P1 must not exist");
+    assertEquals(p2Exists, false, "P2 must not exist");
+
+    // Registry must also have no entries (file written, but empty).
+    const regPath = join(pluginsDir, ".registry.json");
+    let regContents = "{}";
+    try { regContents = await Deno.readTextFile(regPath); } catch { /* file may not exist */ }
+    const reg = JSON.parse(regContents);
+    assertEquals(reg["p1"], undefined);
+    assertEquals(reg["p2"], undefined);
+  } finally {
+    await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("[ROLLBACK] manifest install aborts on invalid plugin name", OPTS, async () => {
+  const pluginsDir = await Deno.makeTempDir({ prefix: "ursamu-rollback-" });
+  try {
+    await Deno.writeTextFile(join(pluginsDir, "plugins.manifest.json"), JSON.stringify({
+      plugins: [
+        { name: "../escape", url: "https://github.com/foo/x" },
+        { name: "p2",        url: "https://github.com/foo/p2" },
+      ],
+    }));
+
+    let threw = false;
+    try { await ensurePlugins(pluginsDir); } catch { threw = true; }
+    assertEquals(threw, true);
+
+    let p2Exists = false;
+    try { await Deno.stat(join(pluginsDir, "p2")); p2Exists = true; } catch { /* */ }
+    assertEquals(p2Exists, false, "P2 must not be installed when P1 fails");
+
+    const regPath = join(pluginsDir, ".registry.json");
+    let regContents = "{}";
+    try { regContents = await Deno.readTextFile(regPath); } catch { /* */ }
+    const reg = JSON.parse(regContents);
+    assertEquals(reg["p2"], undefined);
+    assertEquals(reg["../escape"], undefined);
   } finally {
     await Deno.remove(pluginsDir, { recursive: true }).catch(() => {});
   }
@@ -236,7 +314,9 @@ Deno.test("[INT] ensurePlugins — unsafe URL scheme does not invoke git clone",
       plugins: [{ name: "evil-plugin", url: "file:///etc/passwd" }],
     }));
 
-    await ensurePlugins(pluginsDir);
+    let threw = false;
+    try { await ensurePlugins(pluginsDir); } catch { threw = true; }
+    assertEquals(threw, true, "unsafe URL should throw");
 
     // If git clone had run it would have failed (file:// not a git repo here),
     // but more importantly the plugin dir must not exist at all.


### PR DESCRIPTION
## Summary
- Plugin installs are now fail-fast with whole-manifest atomic rollback — partial state on disk + in `.registry.json` is fully reverted on any failure.
- New optional `version` field in `deps[]` entries (semver range, e.g. `^1.2.0`). Mismatched or conflicting ranges abort the install with a typed error.
- Backwards-compatible: plugins/deps that don't declare a `version` constraint behave exactly as before.

## Changes
- **New**: `src/utils/pluginErrors.ts` (8 typed errors), `pluginSemver.ts` (`@std/semver` wrappers), `pluginTxn.ts` (`InstallTxn` recorder + LIFO rollback), `pluginDepsInstall.ts` (clone helper).
- **Rewrite**: `pluginDeps.ts` — `ResolveDepsCtx` with injectable `runStep` seam; accumulated-range conflict tracking; tempdir cleanup in `finally`.
- **Rewrite**: `ensurePlugins.ts` — single `InstallTxn` spans the entire manifest loop; registry written exactly once (success or post-rollback).
- **Tests**: 45 new tests (`plugin_install_txn`, `plugin_semver`, `plugin_deps_resolver`); `security_ensure_plugins` extended with atomic-rollback cases.
- **Docs**: README, `docs/plugins/{index,basics,dependencies,official-plugins}.md`, `docs/guides/admin-guide.md` updated.

## Test plan
- [x] `deno check --unstable-kv mod.ts` clean
- [x] `deno lint` clean across 374 files
- [x] `deno test tests/ --allow-all --unstable-kv --no-check` — **1293 passed, 0 failed**
- [x] `deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check` — **160 passed, 0 failed**