### PR TITLE
docs: full v2.6.0 refresh (audit + restructure across 32 files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # UrsaMU
 
-### The Next-Generation MU* Engine
-
 ![ursamu header](https://raw.githubusercontent.com/ursamu/ursamu/main/ursamu_github_banner.png)
 
 [![JSR](https://jsr.io/badges/@ursamu/ursamu)](https://jsr.io/@ursamu/ursamu)
-[![Version](https://img.shields.io/badge/version-2.4.0-blue)](https://github.com/UrsaMU/ursamu/releases)
+[![Version](https://img.shields.io/badge/version-2.6.0-blue)](https://github.com/UrsaMU/ursamu/releases)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Deno](https://img.shields.io/badge/deno-2.x-black)](https://deno.land)
 
-UrsaMU is a modern, high-performance MUSH-like server built with **TypeScript** and **Deno**. It replaces decades-old C-based MU* engines (PennMUSH, RhostMUSH, MUX2) with a fully sandboxed scripting system, a plugin-first architecture, and a clean REST API — all with zero external database dependencies.
+A modern MUSH-like server in TypeScript/Deno. Full TinyMUX 2.x softcode
+engine, sandboxed scripting in Web Workers, plugin-first architecture,
+versioned REST API, and zero external database dependencies — Deno KV is
+the only persistence layer.
 
 ---
 
@@ -19,10 +20,11 @@ UrsaMU is a modern, high-performance MUSH-like server built with **TypeScript** 
 - [Features](#features)
 - [Architecture](#architecture)
 - [Configuration](#configuration)
-- [Available Scripts](#available-scripts)
-- [Official Plugins](#official-plugins)
+- [Tasks](#tasks)
+- [Plugins](#plugins)
 - [Plugin Development](#plugin-development)
 - [REST API](#rest-api)
+- [Stdlib (v2.5.1+)](#stdlib-v251)
 - [Docker](#docker)
 - [Production Deployment](#production-deployment)
 - [Testing](#testing)
@@ -34,38 +36,29 @@ UrsaMU is a modern, high-performance MUSH-like server built with **TypeScript** 
 
 ## Quick Start
 
-> **Prerequisites:** [Deno](https://deno.land) v1.40+ must be installed.
->
-> ```bash
-> # Mac / Linux
-> curl -fsSL https://deno.land/install.sh | sh
->
-> # Windows (PowerShell)
-> irm https://deno.land/install.ps1 | iex
-> ```
-
-### New game from JSR (recommended)
+Prerequisite: [Deno](https://deno.land) 2.x.
 
 ```bash
-# Scaffold a new game project
+# Scaffold a new game project from JSR
 deno run -A jsr:@ursamu/ursamu/cli create my-game
 cd my-game
 
-# Start the server (interactive first-run setup)
+# Start the supervised server (first run prompts for a superuser)
 deno task start
 ```
 
-On first run you will be prompted to create a superuser account. After that the server listens on:
+Default listeners:
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | `4201` | Telnet | Legacy MU* clients |
-| `4202` | WebSocket | Web clients (raw WS) |
+| `4202` | WebSocket | Raw WS clients |
 | `4203` | HTTP / WS | REST API + JWT WebSocket |
 
-Connect with any Telnet client (`telnet localhost 4201`) or point a web client at `ws://localhost:4203?token=<jwt>`.
+Connect with `telnet localhost 4201`, or point a web client at
+`ws://localhost:4203?token=<jwt>&client=web`.
 
-### Clone and run from source
+### From source
 
 ```bash
 git clone https://github.com/UrsaMU/ursamu.git
@@ -77,21 +70,81 @@ deno task start
 
 ## Features
 
-- **Plugin ecosystem** — drop a folder in `src/plugins/` and commands, REST routes, and a private DB namespace register automatically; 10 official plugins ship out of the box
-- **Sandboxed scripting** — scripts run in isolated Web Workers with a full SDK (`u.db`, `u.chan`, `u.mail`, `u.events`, `u.sys`, …); a bad script cannot crash the server
-- **Zero external dependencies** — Deno KV for persistence — no Postgres, Redis, or Mongo to install or configure
-- **REST API** — every built-in system exposes clean JSON endpoints; plugins add their own versioned routes automatically
-- **WebSocket auth** — connect via `ws://host:4203?token=<jwt>&client=web` for JWT pre-auth — no `connect name password` prompt needed for web clients
-- **Telnet compatible** — classic Telnet sidecar proxies to the hub so legacy clients and bots still work
-- **Tiered permissions** — flag-based access control: `player` → `builder` → `wizard` → `admin` → `superuser`
-- **MXP support** — MXP negotiation and `%mxp[cmd|text]` substitutions for rich Telnet clients
-- **GameClock** — pluggable in-game calendar and time system
-- **TinyMUX 2.x softcode engine** — full evaluator with ~250 functions (math, string, list, logic, object, registers, output); softcode attributes flagged with `/softcode`; action commands `@switch`, `@dolist`, `@if`, `@while`, `@break`, `@trigger`, `@wait`
-- **$-pattern / ^-pattern dispatch** — `$<glob>:<action>` attributes fire on command match; `^<pattern>:<action>` attributes fire as monitors; `%0`–`%9` capture groups supported
-- **Zone system** — `@zone` assigns objects to a zone master; zones share `$`-pattern commands across all member objects without duplicating attributes
-- **Channel admin** — `@chancreate`, `@chandestroy`, `@chanset` for in-game channel management (admin/wizard only)
-- **Hot reload** — `@reload` hot-reloads commands, config, scripts, and plugins without restarting the server
-- **Rate limiting** — WebSocket rate limiting (10 cmds/sec per socket) and HTTP rate limiting on auth endpoints
+**Engine**
+
+- **TinyMUX 2.x softcode** — full evaluator with ~250 stdlib functions
+  (math/string/list/logic/object/registers/output), action commands
+  (`@switch`, `@dolist`, `@if`, `@while`, `@break`, `@trigger`, `@wait`),
+  `$`-pattern command attrs and `^`-pattern listener attrs with `%0`–`%9`
+  capture groups, master-room routing, zones (`@zone`).
+- **Sandboxed scripting** — every script runs in an isolated Web Worker
+  with the full `IUrsamuSDK`. A bad script cannot crash the server.
+- **Native command surface** — 102 built-in commands (admin, building,
+  comms, channels, queries, status, auth) registered via `addCmd`.
+- **Zero external deps** — Deno KV is the only datastore. No Postgres,
+  Redis, or Mongo.
+- **Hot reload** — `@reload` swaps commands, config, scripts, and
+  plugins without disconnecting players. `@reboot` and `@update` send
+  `SIGUSR2` to the supervised parent for no-disconnect restarts; the
+  Telnet sidecar persists and JWT clients auto-reauth.
+
+**Plugin system (v2.6.0)**
+
+- Manifest-driven installs with **semver-aware dependency resolution**
+  (`deps[].version` supports ranges like `^1.2.0` or `>=1.0.0 <2.0.0`).
+- **Fail-fast atomic installs** — a single failure anywhere in the
+  manifest (unsafe name/URL, clone failure, version mismatch, conflict
+  between requesters) aborts the run and rolls back every directory and
+  registry mutation. Previously installed plugins are untouched.
+- Typed error hierarchy: `PluginInstallError` base plus
+  `PluginDepNameError`, `PluginDepUrlError`, `PluginCloneError`,
+  `PluginRenameError`, `PluginVersionError`, `PluginSemverError`,
+  `PluginConflictError`.
+- 10 official plugins ship pre-wired; community plugins drop into
+  `plugins.manifest.json`.
+
+**Formatting pipeline (v2.3.x – v2.4.x)**
+
+- 8 format slots: `NAMEFORMAT`, `DESCFORMAT`, `CONFORMAT`, `EXITFORMAT`,
+  `WHOFORMAT`, `WHOROWFORMAT`, `PSFORMAT`, `PSROWFORMAT`, plus arbitrary
+  plugin-defined `UPPERCASE` slot names.
+- `registerFormatHandler` for TS handlers; **`registerFormatTemplate`**
+  for raw MUSH-softcode templates (v2.4.0).
+- `resolveFormat` / `resolveGlobalFormat` exposed on `u.util` for both
+  TS and softcode contexts.
+
+**Locks (v2.2.0+)**
+
+- Boolean expressions with `&&`, `||`, `!`, parentheses (legacy `&`/`|`
+  still parsed).
+- **`registerLockFunc`** for custom lockfuncs alongside built-ins
+  (`flag`, `attr`, `type`, `is`, `holds`, `perm`). Fail-closed parsing,
+  4096-char / 256-token caps.
+
+**Supervised game scaffold (v2.4.0+)**
+
+- `daemon.sh` / `stop.sh` / `restart.sh` / `status.sh` driven by
+  `src/cli/start.ts`. SIGUSR2 restart path keeps connections live.
+- Fresh `JWT_SECRET` written to `.env` on scaffold; loaded via
+  `@std/dotenv`.
+
+**Transport & auth**
+
+- WebSocket JWT pre-auth (`?token=<jwt>&client=web`), per-socket rate
+  limit (10 cmds/sec).
+- Telnet sidecar with byte-level IAC stripping (NAWS/option bytes no
+  longer leak into commands).
+- HTTP rate limit on `/auth/*` endpoints.
+- MXP negotiation and `%mxp[cmd|text]` substitutions.
+
+**Game systems**
+
+- GameClock — pluggable in-game calendar with `timeMultiplier`.
+- Channels — `@chancreate` / `@chandestroy` / `@chanset`, history,
+  aliases, auto-join.
+- Pluggable stat systems via `registerStatSystem`.
+- UI manifest (`/api/v1/ui-manifest`) for web-client component
+  registration.
 
 ---
 
@@ -99,65 +152,58 @@ deno task start
 
 ```
 src/
-├── @types/          # TypeScript interfaces (IDBObj, IUrsamuSDK, IPlugin, …)
-├── cli/             # CLI tools — create, config, ursamu (JSR entry points)
-├── commands/        # Core built-in commands
-├── middleware/       # HTTP middleware — auth, CORS, rate limiting
-├── plugins/         # Official plugins (auto-installed) + plugins.manifest.json
-├── routes/          # HTTP API routers — auth, objects, scenes, config
+├── @types/          TypeScript interfaces (IDBObj, IUrsamuSDK, IPlugin, …)
+├── cli/             CLI entry points (create, plugin, update, scripts, …)
+├── commands/        102 built-in addCmd registrations
+├── middleware/      HTTP middleware (auth, CORS, rate limiting)
+├── plugins/         Official plugins + plugins.manifest.json
+├── routes/          REST routers (auth, dbobj, scenes, players, config)
 ├── services/
-│   ├── broadcast/   # send() / broadcast() to sockets
-│   ├── commands/    # cmdParser — input parsing & dispatch
-│   ├── Config/      # Config loading & caching
-│   ├── Database/    # Deno KV wrapper (DBO, dbojs)
-│   ├── DBObjs/      # Game object CRUD (createObj, hydrate, Obj)
-│   ├── GameClock/   # In-game calendar / time
-│   ├── Hooks/       # Game lifecycle hooks (GameHooks)
-│   ├── Intents/     # Intent resolution & interceptors (AOP)
-│   ├── jwt/         # JWT signing & verification
-│   ├── parser/      # MUSH color code & substitution parser
-│   ├── Queue/       # Async task queue
-│   ├── Sandbox/     # Web Worker script execution (isolated)
-│   ├── SDK/         # UrsamuSDK factory — builds `u` for scripts
-│   ├── Script/      # Script lifecycle
-│   ├── Softcode/    # Native MUSHcode support
-│   ├── StatSystem/  # Pluggable stat systems
-│   ├── telnet/      # Telnet sidecar
-│   └── WebSocket/   # WebSocket hub (rooms, rate limiting)
-├── utils/           # target resolution, flag helpers, script loading
-├── app.ts           # HTTP/WS request dispatcher (handleRequest)
-├── main.ts          # Engine init (mu function)
-└── telnet.ts        # Telnet sidecar entry point
+│   ├── broadcast/   send() / room broadcast
+│   ├── commands/    cmdParser — parse and dispatch
+│   ├── Config/      Config loader + cache
+│   ├── Database/    Deno KV wrapper (DBO, dbojs, events)
+│   ├── DBObjs/      Object CRUD (createObj, hydrate, Obj)
+│   ├── GameClock/   In-game calendar
+│   ├── Hooks/       gameHooks (player:login, say, move, …)
+│   ├── Intents/     Interceptors (AOP)
+│   ├── jwt/         Token sign/verify
+│   ├── parser/      MUSH color + substitution parser
+│   ├── Queue/       Async task queue
+│   ├── Sandbox/     Web Worker script execution
+│   ├── SDK/         IUrsamuSDK factory
+│   ├── Softcode/    TinyMUX 2.x evaluator + stdlib
+│   ├── StatSystem/  Pluggable stat systems
+│   ├── telnet/      Telnet sidecar
+│   └── WebSocket/   WS hub (rooms, rate limit)
+├── utils/           target resolution, flags, format handlers
+├── app.ts           HTTP/WS dispatcher
+├── main.ts          Engine init (mu)
+└── telnet.ts        Telnet sidecar entry
 ```
 
 ### Request lifecycle
 
 ```
 Player input
-    │
-    ▼
-WebSocket hub (rate limit check)
-    │
-    ▼
-cmdParser middleware stack
-    ├── 1. Interceptors (AOP — room/object scripts)
-    ├── 2. SCRIPT_NODE bypass (object-attached scripts)
-    ├── 3. Registered addCmd() commands (plugin commands)
-    ├── 4. System scripts (system/scripts/*.ts via Sandbox)
-    └── 5. Exit matching / channel alias dispatch
-
-Sandbox (Web Worker)
-    ├── Script receives `u` (IUrsamuSDK)
-    ├── u.send(), u.db.*, u.chan.*, u.emit(), …
-    └── Result posted back → broadcast
+  → WebSocket hub (rate limit)
+  → cmdParser middleware stack:
+      1. Interceptors (object/room scripts)
+      2. SCRIPT_NODE bypass (attached scripts)
+      3. addCmd() registrations (plugin + native)
+      4. registerScript overrides (local → plugin → engine)
+      5. Exit matching / channel alias dispatch
+  → Sandbox Worker (for scripts) receives `u` (IUrsamuSDK)
+  → Result posted back, broadcast to room/socket
 ```
 
 ### Persistence
 
-All data is stored in **Deno KV** (embedded, zero-config). Each plugin gets a namespaced `DBO<T>` instance that prevents key collisions.
+Everything lives in Deno KV. Each plugin gets a namespaced `DBO<T>`
+instance keyed by `<plugin>.<collection>`.
 
 ```ts
-const notes = new DBO<Note>("server.notes");
+const notes = new DBO<Note>("myplugin.notes");
 await notes.create({ title: "Hello", body: "World" });
 const all = await notes.query({});
 ```
@@ -166,7 +212,8 @@ const all = await notes.query({});
 
 ## Configuration
 
-Copy `config.sample.json` to `config/config.json` and edit:
+A scaffolded project writes `config/config.json` and `.env` for you.
+For source checkouts, copy `config.sample.json`:
 
 ```json
 {
@@ -182,7 +229,8 @@ Copy `config.sample.json` to `config/config.json` and edit:
     "name": "My Game",
     "description": "A UrsaMU-powered MUSH.",
     "version": "0.0.1",
-    "playerStart": "1"
+    "playerStart": "1",
+    "timeMultiplier": 1
   }
 }
 ```
@@ -191,64 +239,60 @@ Copy `config.sample.json` to `config/config.json` and edit:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JWT_SECRET` | Recommended | random | Long random string for signing JWTs. If not set, a new secret is generated each restart, logging out all players. |
-| `URSAMU_HTTP_PORT` | No | `4203` | Override the HTTP/WS hub port. |
-| `URSAMU_TELNET_PORT` | No | `4201` | Override the Telnet sidecar port. |
+| `JWT_SECRET` | Recommended | random per restart | HMAC secret for JWT signing. Scaffolded projects write a fresh secret to `.env`. |
+| `URSAMU_HTTP_PORT` | No | `4203` | Override HTTP/WS hub port. |
+| `URSAMU_TELNET_PORT` | No | `4201` | Override Telnet sidecar port. |
 
-Create a `.env` file in the project root (it is loaded automatically via `@std/dotenv`):
-
-```bash
-JWT_SECRET=replace-with-a-long-random-string
-```
+`.env` is auto-loaded via `@std/dotenv` from `src/main.ts`.
 
 ---
 
-## Available Scripts
+## Tasks
 
-Run any script with `deno task <name>`.
+Run with `deno task <name>`.
 
 | Task | Description |
 |------|-------------|
-| `start` | **Recommended.** Runs first-run setup, then spawns game server + Telnet sidecar. |
-| `dev` | Development mode via `scripts/run.sh` (foreground, live logs). |
-| `server` | Run game server only (no Telnet sidecar). |
+| `start` | First-run setup, then spawn game server + Telnet sidecar (supervised). |
+| `dev` | Development mode with live logs. |
+| `server` | Run game server only. |
 | `telnet` | Run Telnet sidecar only. |
 | `daemon` | Start both processes in background (managed restart loop). |
-| `stop` | Stop background daemon. |
-| `restart` | Restart background daemon. |
-| `status` | Show daemon status and PIDs. |
+| `stop` / `restart` / `status` | Daemon control. |
 | `logs` | Tail `logs/main.log` and `logs/telnet.log`. |
-| `test` | Run the full test suite. |
-| `test:coverage` | Run tests with LCOV coverage report. |
+| `test` | Run the full test suite (1141+ tests). |
+| `test:coverage` | Run tests with LCOV coverage. |
 | `config` | Interactive configuration tool. |
 | `create` | Scaffold a new game project or plugin. |
-| `cli` | Open the interactive CLI menu. |
-| `install-cli` | Install `ursamu` as a global CLI command. |
-| `docker:build` | Build the Docker image. |
-| `docker:up` | Start via Docker Compose (detached). |
-| `docker:down` | Stop Docker Compose stack. |
-| `docker:logs` | Tail Docker Compose logs. |
+| `cli` | Interactive CLI menu. |
+| `install-cli` | Install `ursamu` as a global command. |
+| `docker:build` / `:up` / `:down` / `:logs` | Docker Compose lifecycle. |
+
+CLI subcommands (`deno run -A jsr:@ursamu/ursamu/cli <subcommand>`):
+`create` / `init`, `plugin list|install|update|remove|search|info`,
+`update [<branch>]`, `scripts list`, `help`.
 
 ---
 
-## Official Plugins
+## Plugins
 
-All plugins are declared in `src/plugins/plugins.manifest.json` and auto-installed on first startup via `ensurePlugins` — no manual steps required.
+All plugins are declared in `src/plugins/plugins.manifest.json` and
+installed on first startup via `ensurePlugins` — no manual steps.
 
 | Plugin | Min Engine | Description |
 |--------|-----------|-------------|
-| [**channel**](https://github.com/UrsaMU/channel-plugin) | `>=1.9.27` | Channel system — alias dispatch, auto-join, `@chancreate`/`@chandestroy`, message history |
-| [**rhost-vision**](https://github.com/chogan1981/ursamu-rhost-vision) | `>=1.8.0` | Rhost-style display — `look`, `who`, `score`, `+finger`, `+where`, `+staff` |
-| [**discord**](https://github.com/UrsaMU/discord-plugin) | `>=1.9.0` | Webhook-based Discord bridge — channel bridging, presence, chargen events |
-| [**jobs**](https://github.com/UrsaMU/jobs-plugin) | `>=1.9.0` | Anomaly-style jobs/requests — player requests, staff commands, REST API |
-| [**events**](https://github.com/UrsaMU/events-plugin) | `>=1.9.2` | In-game event calendar with RSVP tracking and REST API |
-| [**bbs**](https://github.com/UrsaMU/bbs-plugin) | `>=1.9.0` | Myrddin-style bulletin boards — threading, IC/OOC tags, sticky posts, Discord hooks |
-| [**wiki**](https://github.com/UrsaMU/wiki-plugin) | `>=1.9.0` | Markdown wiki — pages, search, history, backlinks |
-| [**mail**](https://github.com/UrsaMU/mail-plugin) | `>=1.9.3` | In-game mail — drafts, reply/forward, folders, attachments, quota, REST API |
-| [**builder**](https://github.com/UrsaMU/builder-plugin) | `>=1.9.5` | World-building commands — `@dig`, `@open`, `@link`, `@describe`, `@examine`, REST API |
-| [**help**](https://github.com/UrsaMU/help-plugin) | `>=1.9.0` | API-first help system — file/DB/command providers, `+help/set`, per-plugin help dirs |
+| [channel](https://github.com/UrsaMU/channel-plugin) | `>=1.9.27` | Channel system — aliases, auto-join, history. |
+| [rhost-vision](https://github.com/chogan1981/ursamu-rhost-vision) | `>=1.8.0` | Rhost-style `look`, `who`, `score`, `+finger`, `+where`, `+staff`. |
+| [discord](https://github.com/UrsaMU/discord-plugin) | `>=1.9.0` | Webhook Discord bridge with reconnect/backoff. |
+| [jobs](https://github.com/UrsaMU/jobs-plugin) | `>=1.9.0` | Job/request tracking + REST API. |
+| [events](https://github.com/UrsaMU/events-plugin) | `>=1.9.2` | In-game event calendar with RSVP + REST API. |
+| [bbs](https://github.com/UrsaMU/bbs-plugin) | `>=1.9.0` | Bulletin boards — threading, IC/OOC tags, sticky posts. |
+| [wiki](https://github.com/UrsaMU/wiki-plugin) | `>=1.9.0` | Markdown wiki — pages, search, history, backlinks. |
+| [mail](https://github.com/UrsaMU/mail-plugin) | `>=1.9.3` | In-game mail — drafts, folders, quota, REST API. |
+| [builder](https://github.com/UrsaMU/builder-plugin) | `>=1.9.5` | World-building (`@dig`, `@open`, `@link`, `@describe`, …). |
+| [help](https://github.com/UrsaMU/help-plugin) | `>=1.9.0` | API-first help — file/DB/command providers. |
 
-To add a community plugin, append it to `plugins.manifest.json`:
+### Adding a community plugin
 
 ```json
 {
@@ -256,7 +300,7 @@ To add a community plugin, append it to `plugins.manifest.json`:
   "url": "https://github.com/example/my-plugin",
   "ref": "v1.0.0",
   "description": "What this plugin does.",
-  "ursamu": ">=1.9.0",
+  "ursamu": ">=2.6.0",
   "deps": [
     { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" },
     { "name": "channel", "url": "https://github.com/UrsaMU/channel-plugin" }
@@ -264,66 +308,76 @@ To add a community plugin, append it to `plugins.manifest.json`:
 }
 ```
 
-Each `deps[]` entry may include an optional `version` semver range (e.g.
-`"^1.2.0"`, `">=1.0.0 <2.0.0"`). When present, the installer reads the
-dependency's own `ursamu.plugin.json` `version` and verifies it satisfies
-the range. Entries without `version` install unconditionally — backwards
-compatible with existing manifests.
+Each `deps[]` entry may include an optional `version` semver range
+(e.g. `^1.2.0`, `>=1.0.0 <2.0.0`). When present, the installer reads
+the dependency's own `ursamu.plugin.json` `version` and verifies the
+range. Entries without `version` install unconditionally — older
+manifests keep working.
 
-**Atomic installs.** `ensurePlugins` is fail-fast across the whole manifest:
-if any plugin or transitive dep fails to clone, has an unsafe name or URL,
-declares a version that violates a requested range, or has conflicting
-ranges from multiple requesters, the entire install run aborts and rolls
-back. Nothing from the failed run is left on disk or in
-`src/plugins/.registry.json` — your previously installed plugins are
-untouched.
+**Atomic installs (v2.6.0).** `ensurePlugins` is fail-fast across the
+entire manifest. If any plugin or transitive dep fails to clone, has an
+unsafe name or URL, declares a version that violates a requested range,
+or has conflicting ranges from multiple requesters, the entire run
+aborts and rolls back. Nothing from the failed run is left on disk or
+in `src/plugins/.registry.json`.
 
 ---
 
 ## Plugin Development
 
-Scaffold a new plugin inside any project:
+Scaffold a plugin inside any project:
 
 ```bash
 deno run -A jsr:@ursamu/ursamu/cli create plugin my-feature
 ```
 
-This generates four files:
+Generated layout:
 
 ```
 src/plugins/my-feature/
-├── index.ts      # IPlugin lifecycle — init() and remove()
-├── commands.ts   # addCmd() registrations
-├── router.ts     # registerPluginRoute() REST endpoints
-└── db.ts         # DBO<T> namespaced storage
+├── index.ts      IPlugin lifecycle — init() and remove()
+├── commands.ts   addCmd() registrations
+├── router.ts     registerPluginRoute() REST endpoints
+└── db.ts         DBO<T> namespaced storage
 ```
 
-A minimal plugin:
+Minimal plugin:
 
 ```ts
 import type { IPlugin } from "jsr:@ursamu/ursamu";
-import { addCmd } from "jsr:@ursamu/ursamu";
+import { addCmd, gameHooks } from "jsr:@ursamu/ursamu";
+
+const onLogin = (e: { id: string }) => { /* … */ };
 
 export default {
   name: "my-feature",
+  version: "1.0.0",
+  description: "Example plugin.",
 
-  async init() {
+  init() {
     addCmd({
       name: "greet",
       pattern: /^greet\s+(.+)/i,
       category: "Social",
-      help: "greet <name>\nSay hello to someone.",
+      help: "greet <name>  — Wave at someone.",
       exec: async (u) => {
-        const name = u.cmd.args[0];
+        const name = u.util.stripSubs(u.cmd.args[0] ?? "").trim();
         u.send(`You wave at ${name}.`);
-        u.emit(`${u.me.name} waves at ${name}.`);
+        u.broadcast(`${u.util.displayName(u.me, u.me)} waves at ${name}.`);
       },
     });
+    gameHooks.on("player:login", onLogin);
+    return true;
+  },
+
+  remove() {
+    gameHooks.off("player:login", onLogin);
   },
 } satisfies IPlugin;
 ```
 
-See [docs/plugins/](docs/plugins/) for the full guide including REST routes, DB access, hooks, and publishing.
+See [docs/plugins/](docs/plugins/) for the full guide including REST
+routes, DB access, hooks, format handlers, lockfuncs, and publishing.
 
 ---
 
@@ -333,38 +387,65 @@ The engine exposes a versioned REST API at `/api/v1/`.
 
 | Endpoint | Auth | Description |
 |----------|------|-------------|
-| `POST /api/v1/auth/login` | public | Authenticate and receive a JWT |
-| `POST /api/v1/auth/reset` | public | Request a password reset |
-| `GET /api/v1/me` | token | Current player info |
-| `GET /api/v1/players/online` | token | List of connected players |
-| `GET /api/v1/channels` | token | List channels |
-| `GET /api/v1/channels/:name/history` | token | Channel message history |
-| `GET /api/v1/dbobj/:id` | token | Fetch a game object |
-| `GET /api/v1/scenes` | token | List scenes |
-| `GET /api/v1/scenes/:id/export` | token | Export scene as `?format=markdown\|json` |
-| `GET /api/v1/ui-manifest` | token | Registered web UI components |
-| `GET /api/v1/help` | public | Help topics index |
-| `GET /api/v1/help/:topic` | public | Fetch a help topic |
+| `POST /api/v1/auth/login` | public | Authenticate, receive a JWT. |
+| `POST /api/v1/auth/connect` | public | Create + connect (scaffold). |
+| `POST /api/v1/auth/logout` | token | Invalidate session. |
+| `POST /api/v1/auth/reset-password` | public | Request a reset email. |
+| `POST /api/v1/auth/reset/:token` | public | Submit new password. |
+| `GET /api/v1/me` | token | Current player. |
+| `GET /api/v1/players/online` | token | Connected players. |
+| `GET /api/v1/channels` | token | List channels. |
+| `GET /api/v1/channels/:id/history` | token | Channel history. |
+| `GET /api/v1/dbos` | token | List DBO collections. |
+| `GET\|PUT\|DELETE /api/v1/dbobj/:id` | token | Object CRUD. |
+| `POST\|GET\|PUT\|DELETE /api/v1/dbobj/:id/attrs[/:name]` | token | Attribute CRUD. |
+| `GET\|POST /api/v1/scenes` | token | List / create scenes. |
+| `GET\|PUT\|DELETE /api/v1/scenes/:id` | token | Scene CRUD. |
+| `POST\|PUT\|DELETE /api/v1/scenes/:id/pose[/:poseId]` | token | Pose CRUD. |
+| `GET /api/v1/scenes/:id/export?format=markdown\|json` | token | Export scene. |
+| `GET /api/v1/scenes/locations` | token | Locations with scenes. |
+| `GET /api/v1/config` | public | Public config. |
+| `GET /api/v1/ui-manifest` | token | Registered UI components. |
 
-Full reference: [docs/api/rest.md](docs/api/rest.md)
+Plugin routes attach via `registerPluginRoute`. Full reference:
+[docs/api/rest.md](docs/api/rest.md).
+
+---
+
+## Stdlib (v2.5.1+)
+
+Math/spatial/noise/physics primitives are re-exported from `mod.ts`
+for direct use in TypeScript plugins — no `npm:simplex-noise` or
+`npm:alea` needed.
+
+```ts
+import {
+  Rng, Noise,
+  lerp, smoothstep, clamp, remap,
+  dist2d, dist3d, angle2d, bearing,
+  vreflect, pointInAabb, rayAabb,
+  fbm2, ridged2, perlin2, simplex2, worley2,
+} from "jsr:@ursamu/ursamu";
+
+const rng = new Rng(12345);             // per-instance seedable mulberry32
+const noise = new Noise(rng.next());    // per-instance Perlin/Simplex/Worley
+const h = fbm2(noise, x, y, 6, 2.0, 0.5);
+```
+
+Full surface listed in [docs/api/core.md](docs/api/core.md).
 
 ---
 
 ## Docker
 
 ```bash
-# Build and start
 deno task docker:build
 deno task docker:up
-
-# View logs
 deno task docker:logs
-
-# Stop
 deno task docker:down
 ```
 
-The Compose stack mounts three volumes so data persists across container restarts:
+The Compose stack mounts three volumes:
 
 ```yaml
 volumes:
@@ -373,42 +454,34 @@ volumes:
   - ./logs:/app/logs      # Server logs
 ```
 
-Set your JWT secret in a `.env` file before starting:
-
-```bash
-JWT_SECRET=replace-with-a-long-random-string
-```
+Set `JWT_SECRET` in `.env` before starting.
 
 ---
 
 ## Production Deployment
 
-### Daemon mode (recommended for VPS)
+### Supervised daemon (recommended)
 
 ```bash
-# Start both game server and Telnet sidecar as background processes
-bash scripts/daemon.sh
-
-# Check status
-deno task status
-
-# Tail logs
-deno task logs
-
-# Stop
-deno task stop
+deno task daemon     # start
+deno task status     # check
+deno task logs       # tail
+deno task restart    # SIGUSR2 — no-disconnect restart
+deno task stop       # stop
 ```
 
-The daemon runs inside a managed restart loop. On `@reboot` or `@update` (in-game commands), the server exits with code `75` and the loop restarts it automatically. On `@shutdown`, it exits with `0` and the loop stops cleanly.
+The supervisor restarts the main process on exit code `75` (used by
+`@reboot` and `@update`); exit `0` (`@shutdown`) stops cleanly. The
+Telnet sidecar persists across `restart`/`@reboot`; JWT clients
+auto-reauth.
 
-### Nginx reverse proxy (TLS termination)
+### Nginx (TLS termination)
 
 ```nginx
 server {
     listen 443 ssl;
     server_name yourdomain.com;
 
-    # WebSocket upgrade
     location / {
         proxy_pass http://127.0.0.1:4203;
         proxy_http_version 1.1;
@@ -419,15 +492,15 @@ server {
 }
 ```
 
-Point Telnet clients at port `4201` directly (no proxy needed for Telnet).
+Point Telnet clients directly at port `4201`.
 
-### Updating from in-game
-
-Admins and wizards can update the running server without touching the terminal:
+### In-game updates
 
 ```
-@update          -- git pull origin main, then restart
-@update main     -- pull a specific branch
+@update          pull origin main, SIGUSR2 restart
+@update main     pull specific branch
+@reboot          SIGUSR2 restart (no git pull)
+@shutdown        clean stop
 ```
 
 ---
@@ -435,27 +508,20 @@ Admins and wizards can update the running server without touching the terminal:
 ## Testing
 
 ```bash
-# Run all tests
 deno task test
-
-# With coverage
 deno task test:coverage
 ```
 
-The test suite covers authentication, command parsing, scripting (system scripts run in-process via `wrapScript()`), plugin lifecycle, WebSocket rate limiting, scene export, and more.
+Pre-commit checklist (mirrors CI):
 
+```bash
+deno check --unstable-kv mod.ts
+deno lint
+deno test tests/ --allow-all --unstable-kv --no-check
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
 ```
-tests/
-├── auth.test.ts
-├── gameclock.test.ts
-├── plugin_deps.test.ts
-├── scripts_attrs.test.ts
-├── scripts_comms.test.ts
-├── scripts_identity.test.ts
-├── scripts_world.test.ts
-├── websocket_e2e.test.ts
-└── … (58 total)
-```
+
+1141+ tests, 0 failures; 348 files lint-clean.
 
 ---
 
@@ -483,24 +549,21 @@ tests/
 
 ## Contributing
 
-Pull requests are welcome. For major changes please open an issue first to discuss your ideas.
+Pull requests are welcome. For major changes please open an issue first
+to discuss your plan.
 
 ```bash
-# Fork and clone
 git clone https://github.com/YOUR-USERNAME/ursamu.git
 cd ursamu
-
-# Run tests before and after your changes
 deno task test
-
-# Scaffold a new plugin to test plugin APIs
 deno task create plugin my-test-feature
 ```
 
-See [docs/development/contributing.md](docs/development/contributing.md) for coding conventions and the PR process.
+See [docs/development/contributing.md](docs/development/contributing.md)
+for coding conventions and PR process.
 
 ---
 
 ## License
 
-UrsaMU is licensed under the **MIT License** — see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,25 @@
-# UrsaMU Documentation
+# UrsaMU Documentation (v2.6.0)
 
-Welcome to the UrsaMU documentation. All documentation is written in Markdown
-and can be viewed directly here on GitHub.
+Welcome to the UrsaMU documentation. All pages are written in Markdown and
+rendered by the Lume static-site generator — they also read cleanly directly
+on GitHub.
 
-## 🧭 Navigation
+## Navigation
 
-- [**Home (index.md)**](./index.md) - Main documentation index.
-- [**Guides**](./guides/) - User and installation guides.
-- [**API Reference**](./api/) - Developer API documentation.
-- [**Configuration**](./configuration/) - Server configuration details.
-- [**Plugins**](./plugins/) - Plugin developer resources.
+- [Home](./index.md) — landing page, features, quick install
+- [About](./about.md) — what UrsaMU is and how it compares to other MU* servers
+- [MUSH Compatibility](./mush_compatibility.md) — TinyMUX 2.x parity matrix
+- [Guides](./guides/) — installation, player, and admin guides
+- [API Reference](./api/) — core, database, hooks, commands, formats
+- [Configuration](./configuration/) — `config.json` shape and `JWT_SECRET`
+- [Plugins](./plugins/) — plugin authoring and the v2.6.0 manifest format
+- [Development](./development/) — pre-commit gauntlet, testing, contributing
+- [LLM Reference](./llms.md) — machine-optimized API summary
 
-## 📄 How to read these docs
+## Building the Site Locally
 
-Simply click on the links above or browse the directories to read the
-documentation files. GitHub will automatically render them for you.
+```bash
+deno task docs
+```
+
+This serves the site at `http://localhost:3000` with hot reload.

--- a/docs/about.md
+++ b/docs/about.md
@@ -163,7 +163,7 @@ The WebSocket hub enforces **10 commands per second** per connection. Excess com
 | Web framework | Hono / Oak |
 | Database | dbojs (embedded, file-backed) |
 | Scripting | Web Workers (sandboxed ESM) |
-| Testing | `deno test` — 1141 tests, 0 failures |
+| Testing | `deno test` — 1141+ tests, 0 failures |
 | Docs | Lume (static site generator) |
 | CI | GitHub Actions |
 
@@ -183,11 +183,13 @@ The WebSocket hub enforces **10 commands per second** per connection. Excess com
 
 ## Project Status
 
-UrsaMU is at **v2.0.0**.
+UrsaMU is at **v2.6.0** — production-ready since v2.0.0.
 
-- **Test suite**: 1141 passing, 0 failing
-- **Core systems**: complete (commands, sandbox, WebSocket, Discord, scenes, channels, softcode engine, zone system, security hardening)
-- **Status**: actively maintained, published on JSR
+- **Test suite**: 1141+ passing, 0 failing across 348 lint-clean files
+- **Core systems**: complete — 102 native commands, full TinyMUX 2.x softcode (250+ functions), sandbox, WebSocket, Telnet sidecar, Discord bridge, scenes, channels, zone system, format-handler pipeline, security hardening
+- **Plugin system**: atomic fail-fast installs with semver constraints and rollback (v2.6.0); typed `IPlugin` lifecycle and `gameHooks` declaration merging
+- **Stdlib (v2.5.1+)**: Noise, PRNG, physics, spatial, interpolation, vector primitives re-exported from `mod.ts`
+- **Status**: actively maintained, published on JSR as `@ursamu/ursamu`
 
 The project is open-source under the MIT License. Contributions are welcome!
 ---

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,650 +1,87 @@
 ---
 layout: layout.vto
 title: Core API Reference
-description: ICmd, IUrsamuSDK, IPlugin, IDBObj — the complete type reference for UrsaMU plugin and script authors.
+description: Complete type and function reference for UrsaMU plugin and script authors — exports of jsr:@ursamu/ursamu as of v2.6.0.
 ---
 
 # Core API Reference
 
-This page documents the types and functions available to plugin and script authors.
-All of these are exported from `jsr:@ursamu/ursamu`.
+Everything documented here is exported from `jsr:@ursamu/ursamu`. Last
+verified against `mod.ts` for v2.6.0.
+
+## Contents
+
+- [Imports](#imports)
+- [Engine entry points](#engine-entry-points) — `mu`, `startTelnetServer`, `createObj`, `checkAndCreateSuperuser`
+- [Commands](#commands) — `addCmd`, `cmds`, `registerScript`, `registerCmdMiddleware`
+- [Plugin SDK (IUrsamuSDK)](#plugin-sdk-iursamusdk) — the `u` object
+- [Database](#database) — `DBO`, `dbojs`
+- [Locks & permissions](#locks--permissions) — `registerLockFunc`, `evaluateLock`, `validateLock`
+- [Format handlers](#format-handlers) — `registerFormatHandler`, `registerFormatTemplate`, `resolveFormat`, `resolveGlobalFormat`, `header`/`divider`/`footer`
+- [Softcode extension](#softcode-extension) — `registerSoftcodeFunc`, `registerSoftcodeSub`, `softcodeService`
+- [Hooks & events](#hooks--events) — `gameHooks`, `GameHookMap`
+- [REST & UI](#rest--ui) — `registerPluginRoute`, `registerUIComponent`
+- [Stat systems](#stat-systems) — `registerStatSystem`
+- [WebSocket](#websocket) — `wsService`, `joinSocketToRoom`, `send`
+- [Engine context](#engine-context) — `buildContext`, `GameContext`
+- [Plugin config](#plugin-config) — `PluginConfigManager`
+- [Stdlib (TS)](#stdlib-ts) — Noise, Rng, physics, spatial, interpolation, vectors
+- [Types](#types)
+- [Internal: plugin install errors](#internal-plugin-install-errors)
+
 ---
 
 ## Imports
 
 ```typescript
-// Functions and classes
-import { addCmd, registerPluginRoute, mu, createObj, DBO, dbojs } from "jsr:@ursamu/ursamu";
+import {
+  mu, startTelnetServer, createObj, checkAndCreateSuperuser,
+  addCmd, cmds, registerScript, registerCmdMiddleware,
+  DBO, dbojs, send, joinSocketToRoom, wsService,
+  gameHooks,
+  registerLockFunc, evaluateLock, validateLock,
+  registerFormatHandler, registerFormatTemplate, unregisterFormatHandler,
+  resolveFormat, resolveFormatOr, resolveGlobalFormat, resolveGlobalFormatOr,
+  header, divider, footer,
+  registerSoftcodeFunc, registerSoftcodeSub, softcodeService,
+  registerPluginRoute, registerUIComponent, unregisterUIComponent, getRegisteredUIComponents,
+  registerStatSystem, getStatSystem, getDefaultStatSystem, getStatSystemNames,
+  buildContext, PluginConfigManager,
+} from "jsr:@ursamu/ursamu";
 
-// Types (import type — zero runtime cost)
-import type { ICmd, IPlugin, IDBObj, IUrsamuSDK } from "jsr:@ursamu/ursamu";
+import type {
+  IUrsamuSDK, IDBObj, IDBOBJ, ICmd, IPlugin, IPluginDependency,
+  IContext, IMiddlewareFunction, IStatSystem, IUIComponent,
+  GameHookMap, SessionEvent, SayEvent, PoseEvent, PageEvent, MoveEvent,
+  ChannelMessageEvent, ObjectCreatedEvent, ObjectDestroyedEvent, ObjectModifiedEvent,
+  SceneCreatedEvent, ScenePoseEvent, SceneSetEvent, SceneTitleEvent, SceneClearEvent,
+  MailReceivedEvent, FormatHandler, FormatSlot, GameContext, UserSocket,
+  LockFunc, SoftcodeFn, SoftcodeSubHandler, SoftcodeContext,
+} from "jsr:@ursamu/ursamu";
 ```
+
 ---
 
-## IDBObj
-
-Every object in the game database — players, rooms, exits, things — is an
-`IDBObj`.
-
-```typescript
-interface IDBObj {
-  id: string;                    // Numeric DB ID, e.g. "1", "42"
-  name?: string;                 // Display name (top-level shortcut to state.name)
-  flags: Set<string>;            // Flag set, e.g. Set { "player", "connected" }
-  location?: string;             // ID of containing room or object
-  state: Record<string, unknown>; // All stored data — desc, stats, attrs, etc.
-  contents: IDBObj[];            // Objects contained by this object
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `id` | Numeric string, e.g. `"1"`. Use this when calling DB methods or `u.teleport()`. |
-| `flags` | Use `flags.has("wizard")`, not array methods. |
-| `state` | Arbitrary key-value store. Cast values on read: `obj.state.gold as number`. |
-| `contents` | Populated at query time — may be empty even if the object has contents depending on context. |
----
-
-## ICmd
-
-Passed to `addCmd()` to register a command.
-
-```typescript
-interface ICmd {
-  name:     string;
-  pattern:  string | RegExp;
-  lock?:    string;
-  exec:     (u: IUrsamuSDK) => void | Promise<void>;
-  help?:    string;
-  hidden?:  boolean;
-  category?: string;
-}
-```
-
-| Field | Description |
-|-------|-------------|
-| `name` | Human-readable name; appears in `help` listings unless `hidden` is true. |
-| `pattern` | RegExp (or string converted to RegExp) matched against raw player input. Capture groups map to `u.cmd.args[0]`, `u.cmd.args[1]`, … |
-| `lock` | Lock expression evaluated before `exec`. If the check fails the command silently does nothing. See the [Lock Expressions guide](../guides/lock-expressions.md). |
-| `exec` | Async-safe — you can `await` inside freely. |
-| `help` | Shown when a player runs `help <name>`. |
-| `hidden` | Hides the command from `help` and `@commands` listings. |
-| `category` | Groups related commands together in listings. |
-
-### Example
-
-```typescript
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "+greet",
-  pattern: /^\+greet\s+(.+)/i,
-  lock: "connected",
-  exec: (u: IUrsamuSDK) => {
-    u.send(`Hello, ${u.cmd.args[0]}!`);
-  },
-  help: "+greet <name>\nSays hello.",
-});
-```
----
-
-## IUrsamuSDK
-
-The `u` object injected into every command's `exec()` function and into
-sandbox scripts. It provides everything the command needs — actor info, DB
-access, messaging, and utility helpers.
-
-```typescript
-interface IUrsamuSDK {
-  state:    Record<string, unknown>;   // Shared state bag for the command run
-  socketId?: string;                   // WebSocket ID of the connected player
-  me:       IDBObj;                    // The actor who triggered the command
-  here:     IDBObj & { broadcast(msg: string): void };  // Actor's current room
-  target?:  IDBObj & { broadcast(msg: string): void };  // Optional pre-resolved target
-  cmd:      { name: string; args: string[]; switches?: string[]; original?: string };
-  // ... namespaces below
-}
-```
----
-
-## u.me / u.here
-
-```typescript
-u.me.id          // "42"
-u.me.name        // "Alice"
-u.me.location    // room ID
-u.me.flags       // Set<string>
-u.me.state       // all stored player data
-u.me.contents    // inventory
-
-u.here.id        // room ID
-u.here.name      // room name
-u.here.state     // room data (desc, exits, etc.)
-u.here.contents  // everyone and everything in the room
-u.here.broadcast("Message to everyone in the room.");
-```
-
-Check flags:
-
-```typescript
-u.me.flags.has("superuser")   // first player ever created
-u.me.flags.has("admin")       // or "wizard" — equivalent
-u.me.flags.has("builder")
-u.me.flags.has("player")
-u.me.flags.has("connected")   // currently online
-```
----
-
-## u.db
-
-Database operations. All methods are async.
-
-### `u.db.search(query)`
-
-```typescript
-const results: IDBObj[] = await u.db.search(query);
-```
-
-`query` can be:
-- A string — searched against name, ID, and flags
-- An object — field filter, e.g. `{ flags: ["room"] }`
-
-```typescript
-// Find all rooms
-const rooms = await u.db.search({ flags: ["room"] });
-
-// Find by name fragment
-const matches = await u.db.search("Town Square");
-```
-
-### `u.db.create(template)`
-
-```typescript
-const obj: IDBObj = await u.db.create({
-  name: "Magic Sword",
-  flags: new Set(["thing"]),
-  location: u.me.id,
-  state: { desc: "A gleaming sword.", damage: 5 },
-  contents: [],
-});
-```
-
-### `u.db.modify(id, op, data)`
-
-Updates fields on an object. The `op` argument **must** be one of `"$set"`, `"$unset"`, or `"$inc"` — any other value is rejected.
-
-```typescript
-// Merge one field (preferred — precise, no full-object rewrite)
-await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
-
-// Replace full state (always spread to preserve other fields)
-await u.db.modify(u.me.id, "$set", { data: { ...u.me.state, gold: 100 } });
-
-// Increment a number field
-await u.db.modify(u.me.id, "$inc", { "data.deaths": 1 });
-
-// Remove a field
-await u.db.modify(u.me.id, "$unset", { "data.tempFlag": "" });
-
-// Update name or location (these are top-level fields)
-await u.db.modify(obj.id, "$set", { name: "New Name" });
-await u.db.modify(obj.id, "$set", { location: destinationId });
-```
-
-### `u.db.destroy(id)`
-
-```typescript
-await u.db.destroy(obj.id);
-```
----
-
-## u.util
-
-Utility helpers.
-
-### `u.util.target(actor, query, global?)`
-
-Resolves a name or `#id` reference to an `IDBObj`. Searches the actor's
-inventory then the current room. Pass `global: true` to search the whole DB.
-
-```typescript
-const obj = await u.util.target(u.me, u.cmd.args[0]);
-if (!obj) return u.send("I don't see that here.");
-```
-
-### `u.util.displayName(obj, actor)`
-
-Returns the display name of `obj` as seen by `actor`, applying moniker
-substitutions if set.
-
-```typescript
-u.send(`You see ${u.util.displayName(target, u.me)}.`);
-```
-
-### `u.util.stripSubs(str)`
-
-Strips MUSH color codes (`%cX`, `%n`, `%r`, `%t`, `%b`) and raw ANSI escapes.
-Useful for measuring the true display length of a string.
-
-```typescript
-const plain = u.util.stripSubs("%chBold text%cn");
-// → "Bold text"
-```
-
-### `u.util.center(str, length, filler?)`
-
-Centers `str` within `length` characters, optionally padding with `filler`.
-
-```typescript
-u.send(u.util.center("TITLE", 78, "-"));
-// → "--------------------------------TITLE---------------------------------"
-```
-
-### `u.util.ljust(str, length, filler?)` / `u.util.rjust(str, length, filler?)`
-
-Left-pads or right-pads a string.
-
-```typescript
-u.send(u.util.ljust("Name", 20) + u.util.rjust("100", 10));
-```
-
-### `u.util.sprintf(format, ...args)`
-
-Printf-style formatting.
-
-```typescript
-u.send(u.util.sprintf("%-20s %5d gp", player.name, gold));
-```
----
-
-## u.cmd
-
-Populated by the command parser before `exec` is called.
-
-```typescript
-u.cmd.name       // "look"
-u.cmd.args       // string[] — capture groups from the pattern RegExp
-u.cmd.switches   // string[] — e.g. ["quiet"] from "@set/quiet ..."
-u.cmd.original   // The raw input string the player typed
-```
----
-
-## u.auth
-
-Authentication helpers for scripts that need to verify or change passwords.
-
-```typescript
-// Verify a password
-const ok: boolean = await u.auth.verify(u.me.name!, "mypassword");
-
-// Hash a password (bcrypt)
-const hashed: string = await u.auth.hash("newpassword");
-
-// Change a player's password (use carefully — no confirmation prompt)
-await u.auth.setPassword(u.me.id, "newpassword");
-
-// Log in a player (rarely needed in scripts)
-await u.auth.login(u.me.id);
-```
----
-
-## u.sys
-
-Server administration methods. Most are locked behind the `wizard` or
-`superuser` flag in system scripts.
-
-```typescript
-// Set a config value (only keys whitelisted in the engine are accepted)
-await u.sys.setConfig("server.name", "My Game");
-
-// Disconnect a player by socket ID
-await u.sys.disconnect(socketId);
-
-// Server uptime in milliseconds
-const ms: number = await u.sys.uptime();
-
-// Reboot or shut down (DANGEROUS — confirms nothing)
-await u.sys.reboot();
-await u.sys.shutdown();
-
-// In-game calendar
-const t: IGameTime = await u.sys.gameTime();
-// t.year, t.month (1-12), t.day (1-28), t.hour (0-23), t.minute (0-59)
-
-await u.sys.setGameTime({ year: 1340, month: 6, day: 15, hour: 8, minute: 0 });
-```
----
-
-## u.chan
-
-Channel management. Players can join/leave channels and admins can create and
-configure them.
-
-```typescript
-// Join a channel (alias is the local shorthand, e.g. "pub")
-await u.chan.join("Public", "pub");
-
-// Leave by alias
-await u.chan.leave("pub");
-
-// List all channels the actor is a member of
-const channels = await u.chan.list();
-
-// Admin — create a channel
-await u.chan.create("Staff", { header: "%ch[STAFF]%cn", hidden: true });
-
-// Admin — destroy a channel
-await u.chan.destroy("Staff");
-
-// Admin — update channel settings
-await u.chan.set("Public", { header: "%ch[PUB]%cn", masking: false });
-
-// Get recent channel messages
-const history = await u.chan.history("public");        // last 20 messages (default)
-const history = await u.chan.history("public", 50);    // last 50 messages
-// → [{ id: string, playerName: string, message: string, timestamp: number }, ...]
-```
----
-
-## u.bb
-
-Bulletin board access.
-
-```typescript
-// List all boards
-const boards = await u.bb.listBoards();
-// → [{ id, name, description, order, postCount, newCount }, ...]
-
-// List posts on a board
-const posts = await u.bb.listPosts(boardId);
-// → [{ id, num, subject, authorName, date, edited? }, ...]
-
-// Read a post (by board + post number)
-const post = await u.bb.readPost(boardId, postNum);
-// → { id, subject, body, authorName, date, edited? } | null
-
-// Post a message
-await u.bb.post(boardId, "Subject line", "Body text.");
-
-// Edit a post you authored
-await u.bb.editPost(boardId, postNum, "New body text.");
-
-// Delete a post (owner or admin)
-await u.bb.deletePost(boardId, postNum);
-
-// Count unread posts
-const total: number = await u.bb.totalNewCount();
-```
----
-
-## u.events
-
-Emit custom events and register handlers by attribute name.
-
-```typescript
-// Emit an event (other scripts can listen)
-await u.events.emit("game:levelup", { playerId: u.me.id, level: 5 });
-
-// Register a listener (stores a script key to call when the event fires)
-const handlerId = await u.events.on("game:levelup", "scripts/levelup-handler");
-```
----
-
-## u.attr
-
-Reads soft-coded `&ATTR` values stored on objects.
-
-```typescript
-// Returns the string value, or null if not set
-const bio: string | null = await u.attr.get(u.me.id, "FINGER-INFO");
-const desc = await u.attr.get(objectId, "SHORT-DESC");
-
-// Attribute names are case-insensitive
-const val = await u.attr.get(objectId, "onenter");   // same as "ONENTER"
-```
----
-
-## u.mail *(sandbox scripts only)*
-
-Mail system access. Available in `system/scripts/` sandbox context.
-For native `addCmd` handlers, import `mail` from the database service directly.
-
-```typescript
-// Send a message
-await u.mail.send({
-  from:    `#${u.me.id}`,           // dbref format: "#42"
-  to:      [`#${recipientId}`],     // array of dbrefs
-  cc:      [`#${ccId}`],            // optional
-  subject: "Guild meeting",
-  message: "Tonight at 8pm.",
-  read:    false,
-  date:    Date.now(),
-});
-
-// Notify recipient in-game
-u.send(`%chMAIL:%cn You have new mail from ${u.util.displayName(u.me, u.me)}.`, recipientId);
-
-// Read inbox
-const inbox = await u.mail.read({ to: { $in: [`#${u.me.id}`] } });
-inbox.sort((a, b) => b.date - a.date);
-
-// Delete
-await u.mail.delete(messageId);
-
-// Update (e.g. mark as read)
-await u.mail.modify({ id: messageId }, "$set", { read: true });
-```
-
-**IMail shape:**
-```typescript
-{
-  id?:      string;
-  from:     string;     // "#42"
-  to:       string[];   // ["#7", "#8"]
-  cc?:      string[];
-  bcc?:     string[];
-  subject:  string;
-  message:  string;
-  read:     boolean;
-  date:     number;     // Date.now() timestamp
-}
-```
----
-
-## u.eval
-
-Evaluates a stored `&ATTR` as a script and returns its output as a string.
-
-```typescript
-// Evaluate &FORMULA on object #42
-const result = await u.eval("#42", "FORMULA", ["arg1", "arg2"]);
-u.send(`Result: ${result}`);
-
-// Evaluate an attribute on the actor
-const score = await u.eval(u.me.id, "SCORE-FORMULA");
-```
----
-
-## u.forceAs
-
-Executes a command as another object. Requires wizard or admin privilege — enforce
-this in your script; the SDK does not check automatically.
-
-```typescript
-if (!u.me.flags.has("wizard") && !u.me.flags.has("admin") && !u.me.flags.has("superuser")) {
-  u.send("Permission denied.");
-  return;
-}
-
-await u.forceAs(npcId, "say Welcome, traveler!");
-await u.forceAs(roomId, "look");
-```
----
-
-## Top-level methods
-
-These are direct properties on `u`, not namespaced.
-
-### `u.send(message, target?, options?)`
-
-Sends `message` to the actor, or to `target` (DB ID) if provided.
-
-```typescript
-u.send("You say, \"Hello!\"");
-u.send("Whispered message.", otherPlayerId);
-```
-
-### `u.broadcast(message, options?)`
-
-Sends `message` to everyone in the actor's current room.
-
-```typescript
-u.broadcast(`${u.me.name} waves.`);
-```
-
-### `u.setFlags(target, flags)`
-
-Sets or clears flags on a target. Prefix with `!` to remove.
-
-```typescript
-await u.setFlags(u.me.id, "builder");      // add "builder"
-await u.setFlags(u.me.id, "!builder");     // remove "builder"
-await u.setFlags(obj.id, "dark");
-```
-
-### `u.checkLock(target, lock)`
-
-Evaluates a lock expression against a target. Returns `true` if the lock passes.
-
-```typescript
-const canEnter = await u.checkLock(u.me, "builder|wizard");
-```
-
-See the [Lock Expressions guide](../guides/lock-expressions.md) for syntax.
-
-### `u.teleport(target, destination)`
-
-Moves `target` (DB ID) to `destination` (DB ID).
-
-```typescript
-await u.teleport(u.me.id, "1");  // send actor to room #1
-```
-
-### `u.force(command)`
-
-Executes `command` as if the actor typed it.
-
-```typescript
-u.force("look");
-```
-
-### `u.execute(command)`
-
-Executes `command` as the server (no actor context).
-
-```typescript
-u.execute("@pemit #3=Server message.");
-```
-
-### `u.trigger(target, attr, args?)`
-
-Triggers an attribute script on `target`.
-
-```typescript
-await u.trigger(room.id, "onEnter", [u.me.id]);
-```
-
-### `u.canEdit(actor, target)`
-
-Returns `true` if `actor` has permission to edit `target`.
-
-```typescript
-const ok = await u.canEdit(u.me, target);
-if (!ok) return u.send("Permission denied.");
-```
----
-
-## IPlugin
-
-The interface your plugin's exported object must satisfy.
-
-```typescript
-interface IPlugin {
-  name:         string;
-  version:      string;
-  description?: string;
-  init?:        () => boolean | Promise<boolean>;
-  remove?:      () => void   | Promise<void>;
-}
-```
-
-```typescript
-import type { IPlugin } from "jsr:@ursamu/ursamu";
-import "./commands.ts";
-
-export const plugin: IPlugin = {
-  name:        "my-plugin",
-  version:     "1.0.0",
-  description: "Does cool things.",
-  init: async () => {
-    // Startup logic — seed data, connect to external services, etc.
-    return true;   // return false to abort loading
-  },
-};
-```
----
-
-## Exported functions
-
-These are the top-level exports you import from `jsr:@ursamu/ursamu`.
-
-### `addCmd(...cmds: ICmd[])`
-
-Registers one or more commands. Safe to call at module level.
-
-```typescript
-import { addCmd } from "jsr:@ursamu/ursamu";
-
-addCmd(
-  { name: "cmd1", pattern: /^cmd1$/i, exec: (u) => u.send("one") },
-  { name: "cmd2", pattern: /^cmd2$/i, exec: (u) => u.send("two") },
-);
-```
-
-### `registerPluginRoute(prefix, handler)`
-
-Registers a custom HTTP route handled by your plugin.
-
-```typescript
-import { registerPluginRoute } from "jsr:@ursamu/ursamu";
-
-registerPluginRoute("/api/v1/my-plugin", async (req, userId) => {
-  return Response.json({ ok: true, userId });
-});
-```
-
-`handler` signature: `(req: Request, userId: string | null) => Promise<Response>`
+## Engine entry points
 
 ### `mu(config?)`
 
-Starts the UrsaMU engine. Called once in your game's `src/main.ts`. Returns
-a Deno `Deno.HttpServer` instance.
+Boots the engine. Call once from `src/main.ts`.
 
 ```typescript
 import { mu } from "jsr:@ursamu/ursamu";
 await mu();
 ```
 
+### `startTelnetServer(port?)`
+
+Spawn a standalone Telnet listener that talks to the same hub.
+
 ### `createObj(template)`
 
-Creates a new object directly in the DB. Useful in startup scripts or
-migrations that run outside a command handler (where `u.db.create()` isn't
-available).
+Create a DB object outside of a command handler (migrations, seeders).
 
 ```typescript
-import { createObj } from "jsr:@ursamu/ursamu";
-
 const room = await createObj({
   name: "The Void",
   flags: new Set(["room"]),
@@ -653,57 +90,274 @@ const room = await createObj({
 });
 ```
 
-### `DBO`
+### `checkAndCreateSuperuser()`
 
-The raw Deno KV database wrapper. Use `dbojs` for most game-data access — `DBO`
-is for low-level or plugin-specific storage.
+Idempotent — ensures `#1` exists with the `superuser` flag.
+
+---
+
+## Commands
+
+### `addCmd(...cmds)`
+
+Registers one or more `ICmd` objects. Safe at module load.
+
+```typescript
+addCmd({
+  name: "+greet",
+  pattern: /^\+greet\s+(.+)/i,
+  lock: "connected",
+  category: "Social",
+  help: "+greet <name> — Say hello.",
+  exec: (u) => u.send(`Hello, ${u.cmd.args[0]}!`),
+});
+```
+
+`ICmd` shape:
+
+```typescript
+interface ICmd {
+  name: string;
+  pattern: string | RegExp;
+  lock?: string;
+  category?: string;
+  help?: string;
+  hidden?: boolean;
+  exec: (u: IUrsamuSDK) => void | Promise<void>;
+}
+```
+
+Capture groups in `pattern` populate `u.cmd.args[0]`, `[1]`, etc.
+
+### `cmds`
+
+The registered command map. Use to introspect or override an existing
+command:
+
+```typescript
+import { cmds } from "jsr:@ursamu/ursamu";
+const existing = cmds.get("look");
+```
+
+### `registerScript(name, content)`
+
+Register a softcode/system script. Lookup order: local file override →
+plugin registry → engine bundled.
+
+```typescript
+registerScript("custom-look", "say You ran the custom look script.");
+```
+
+### `registerCmdMiddleware(fn)`
+
+Insert middleware into the command pipeline. Runs before `exec`. Return
+`false` to abort dispatch.
+
+```typescript
+registerCmdMiddleware(async (u) => {
+  if (u.me.flags.has("frozen")) { u.send("You're frozen."); return false; }
+});
+```
+
+---
+
+## Plugin SDK (`IUrsamuSDK`)
+
+The `u` object passed to every `addCmd` `exec` and every sandbox script.
+
+```typescript
+interface IUrsamuSDK {
+  state: Record<string, unknown>;
+  socketId?: string;
+  me: IDBObj;
+  here: IDBObj & { broadcast(msg: string): void };
+  target?: IDBObj & { broadcast(msg: string): void };
+  cmd: { name: string; original?: string; args: string[]; switches?: string[] };
+
+  send(message: string, target?: string): void;
+  broadcast(message: string): void;
+  execute(command: string): Promise<void>;
+  force(command: string): Promise<void>;
+  forceAs(targetId: string, command: string): Promise<void>;
+  canEdit(actor: IDBObj, target: IDBObj): Promise<boolean>;
+  checkLock(target: IDBObj, lock: string): Promise<boolean>;
+  setFlags(targetId: string, flags: string): Promise<void>;
+  trigger(targetId: string, attr: string, args?: string[]): Promise<void>;
+  eval(targetId: string, attr: string, args?: string[]): Promise<string>;
+  evalString(source: string): Promise<string>;
+  intercept?: (input: string) => Promise<boolean>;
+
+  db:    { search, create, modify, destroy };
+  util:  { target, displayName, stripSubs, center, ljust, rjust, sprintf,
+           template, parseDesc, resolveFormat, resolveFormatOr,
+           resolveGlobalFormat, resolveGlobalFormatOr };
+  auth:  { verify, login, hash, setPassword };
+  sys:   { setConfig, disconnect, reboot, shutdown, uptime, update,
+           gameTime, setGameTime };
+  chan:  { join, leave, list, create, destroy, set, history };
+  attr:  { get, set, clear };
+  events:{ emit, on };
+  ui:    { panel, render, layout };
+}
+```
+
+### `u.db`
+
+All async. `op` must be `"$set"`, `"$inc"`, `"$unset"`, or `"$push"`.
+
+```typescript
+const list = await u.db.search({ flags: ["room"] });
+const sword = await u.db.create({ name: "Sword", flags: new Set(["thing"]),
+  location: u.me.id, state: {}, contents: [] });
+await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
+await u.db.modify(u.me.id, "$inc", { "data.deaths": 1 });
+await u.db.modify(u.me.id, "$unset", { "data.tempFlag": "" });
+await u.db.modify(u.here.id, "$push", { "data.log": "Alice arrived." });
+await u.db.destroy(sword.id);
+```
+
+### `u.util`
+
+```typescript
+const obj = await u.util.target(u.me, u.cmd.args[0], true);
+const name = u.util.displayName(target, u.me);
+const plain = u.util.stripSubs("%chBold%cn");
+u.send(u.util.center("TITLE", 78, "="));
+u.send(u.util.ljust("Name", 20) + u.util.rjust("100", 10));
+u.send(u.util.sprintf("%-20s %5d gp", player.name!, gold));
+const text = await u.util.resolveFormat(u.me, "NAMEFORMAT", defaultName);
+```
+
+### `u.auth` / `u.sys` / `u.chan` / `u.attr` / `u.events`
+
+```typescript
+await u.auth.verify(u.me.name!, "pw");
+await u.auth.setPassword(u.me.id, "newpw");
+
+await u.sys.setConfig("server.name", "My Game");
+const t = await u.sys.gameTime();
+
+await u.chan.join("Public", "pub");
+await u.chan.create("Staff", { header: "%ch[STAFF]%cn", hidden: true });
+
+const bio = await u.attr.get(u.me.id, "FINGER-INFO");
+await u.attr.set(u.me.id, "BIO", "Tall and lanky.");
+
+await u.events.emit("game:levelup", { id: u.me.id, lvl: 5 });
+```
+
+### `u.eval` / `u.evalString` / `u.trigger`
+
+```typescript
+const score = await u.eval(u.me.id, "SCORE-FORMULA");
+const rendered = await u.evalString("[name(me)] is here.");
+await u.trigger(u.here.id, "ONENTER", [u.me.id]);
+```
+
+### `u.force` / `u.forceAs` / `u.execute`
+
+```typescript
+await u.force("look");
+await u.forceAs(npcId, "say Welcome.");
+await u.execute("@pemit #3=Server message.");
+```
+
+`u.forceAs` is privileged — guard with `u.me.flags.has("wizard")` etc.
+
+---
+
+## Database
+
+### `DBO<T>`
+
+Generic Deno KV collection. Use for plugin-scoped storage. Always prefix
+the namespace with your plugin name.
 
 ```typescript
 import { DBO } from "jsr:@ursamu/ursamu";
 
-const db = new DBO<{ score: number }>("server.highscores");
-await db.create({ score: 100 });
-const all = await db.all();
+const scores = new DBO<{ player: string; score: number }>("myplugin.scores");
+await scores.create({ player: "Alice", score: 100 });
+const all = await scores.all();
+const top = await scores.queryOne({ player: "Alice" });
+await scores.modify({ player: "Alice" }, "$inc", { score: 1 });
+await scores.modify({ player: "Alice" }, "$push", { history: Date.now() });
 ```
+
+Ops: `$set`, `$inc`, `$unset`, `$push` (atomic CAS append).
 
 ### `dbojs`
 
-The game-object database accessor. Lets you query `IDBObj` records directly.
+The shared game-object collection (`IDBOBJ`).
 
 ```typescript
 import { dbojs } from "jsr:@ursamu/ursamu";
 
-const players = await dbojs.queryAll((o) => o.flags.has("player"));
-const room    = await dbojs.queryOne((o) => o.id === "1");
+const players = await dbojs.find({ flags: { $in: ["player"] } });
+const room = await dbojs.queryOne({ id: "1" });
 ```
+
+---
+
+## Locks & permissions
+
+Lock strings combine **lockfuncs** with the operators `&&`, `||`, `!`, and
+`()`. Legacy `&` / `|` still work. Max length 4096 chars / 256 tokens.
+
+Built-in lockfuncs:
+
+| Func | Example | Passes when |
+|------|---------|-------------|
+| `flag(name)` | `flag(wizard)` | enactor has the flag |
+| `attr(name)` | `attr(tribe)` | enactor.state has own property `name` |
+| `attr(name, val)` | `attr(tribe, glasswalker)` | `state[name] === val` |
+| `type(name)` | `type(player)` | enactor has the type flag |
+| `is(#id)` | `is(#5)` | `enactor.id === "5"` |
+| `holds(#id)` | `holds(#12)` | enactor.contents includes `#12` |
+| `perm(level)` | `perm(admin)` | passes privilege ladder check |
+
+### `registerLockFunc(name, fn)`
+
+Register a custom lockfunc. Built-in names are protected.
+
+```typescript
+import { registerLockFunc } from "jsr:@ursamu/ursamu";
+
+registerLockFunc("tribe", (enactor, _target, args) =>
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// lock: "tribe(glasswalker) || perm(admin)"
+```
+
+### `evaluateLock(lock, enactor, target?)`
+
+Returns `Promise<boolean>`. Fail-closed on unknown funcs or parse errors.
+
+### `validateLock(lock)`
+
+Throws on syntax error. Use to validate user-supplied lock strings.
 
 ---
 
 ## Format handlers
 
-Pluggable display formatters for engine and plugin output. Used by `look`,
-`who`, `+ps`, `+mail`, and anywhere that resolves a `*FORMAT` slot. Resolution
-priority is fixed: per-object softcode attribute → registered TS handler →
-registered MUSH-softcode template → built-in default.
+Pluggable display formatters for engine and plugin output. Resolution
+priority: per-object softcode attribute → registered TS handler →
+registered MUSH template → built-in default.
 
-```typescript
-import {
-  registerFormatHandler,
-  registerFormatTemplate,
-  unregisterFormatHandler,
-} from "jsr:@ursamu/ursamu";
-import type { FormatHandler, FormatSlot } from "jsr:@ursamu/ursamu";
+`FormatSlot` is an **open union** (v2.3.4+). The eight engine-known slots
+get IDE autocomplete:
+
+```
+NAMEFORMAT  DESCFORMAT  CONFORMAT   EXITFORMAT
+WHOFORMAT   WHOROWFORMAT  PSFORMAT  PSROWFORMAT
 ```
 
-### `registerFormatHandler(slot, fn)`
+Plugins may register any `UPPERCASE` slot (e.g. `"MAILFORMAT"`,
+`"BBROWFORMAT"`) without casts.
 
-Install a TypeScript handler for a `FormatSlot`. Slot is an open `UPPERCASE`
-string union — the eight engine-known literals (`NAMEFORMAT`, `DESCFORMAT`,
-`CONFORMAT`, `EXITFORMAT`, `WHOFORMAT`, `WHOROWFORMAT`, `PSFORMAT`,
-`PSROWFORMAT`) get IDE autocomplete; plugin-defined slots like `"MAILFORMAT"`
-are accepted without casts. Return a string to render, or `null` to fall
-through to the next handler / built-in default. The first non-null handler
-wins.
+### `registerFormatHandler(slot, fn)`
 
 ```typescript
 registerFormatHandler("NAMEFORMAT", (u, target, defaultName) => {
@@ -712,41 +366,383 @@ registerFormatHandler("NAMEFORMAT", (u, target, defaultName) => {
 });
 ```
 
-### `registerFormatTemplate(slot, mushSource)`
+Return `null` to fall through. First non-null handler wins. Returns the
+registered function so `unregisterFormatHandler` can remove it.
 
-Shortcut for plugins that want to install a MUSH-softcode template as a
-handler. The engine runs `mushSource` whenever the slot resolves; `%0` is
-bound to the default rendering and the resolver's target is the executor —
-so `name(%0)`, `get(%0/<attr>)`, and friends work directly. Returns the
-underlying handler so callers can pass it to `unregisterFormatHandler` from
-plugin `remove()`.
+### `registerFormatTemplate(slot, mushSource)` *(v2.4.0)*
+
+Install a MUSH-softcode template. `%0` binds to the default rendering.
 
 ```typescript
-const handler = registerFormatTemplate(
+const fn = registerFormatTemplate(
   "NAMEFORMAT",
   "[center(strcat(%cy[ ,%0, ]%cn),78,=)]",
 );
-// later, in plugin remove():
-unregisterFormatHandler("NAMEFORMAT", handler);
+// remove() ...
+unregisterFormatHandler("NAMEFORMAT", fn);
 ```
 
 ### `unregisterFormatHandler(slot, fn)`
 
-Remove a previously registered handler. Same reference identity that
-`registerFormatHandler` / `registerFormatTemplate` returned at registration.
+Remove a handler by reference identity.
 
-### Type: `FormatHandler`
+### `resolveFormat(target, slot, defaultArg)`
+
+Two-step lookup for target-bound formats: softcode attr on `target` →
+registered handler. Returns `string | null`.
+
+### `resolveFormatOr(target, slot, defaultArg, fallback)`
+
+As above, but always returns a string.
+
+### `resolveGlobalFormat(enactor, slot, defaultArg)` *(v2.3.3)*
+
+Two-tier lookup for global-list formats (WHO, @ps, +mail, +bb): `#0` →
+enactor. Returns `string | null`.
+
+### `resolveGlobalFormatOr(enactor, slot, defaultArg, fallback)`
+
+Always returns a string.
+
+### `header(title, width?)` / `divider(width?)` / `footer(width?)`
+
+Native TS layout helpers for block-style section rules. Distinct from the
+softcode helpers of the same name.
+
+```typescript
+u.send(header("Stats", 78));
+u.send(divider(78));
+u.send(footer(78));
+```
+
+### Types
 
 ```typescript
 type FormatHandler = (
-  u:          IUrsamuSDK,
-  target:     IDBObj,
+  u: IUrsamuSDK,
+  target: IDBObj,
   defaultArg: string,
 ) => Promise<string | null> | string | null;
+
+type FormatSlot = "NAMEFORMAT" | "DESCFORMAT" | "CONFORMAT" | "EXITFORMAT"
+  | "WHOFORMAT" | "WHOROWFORMAT" | "PSFORMAT" | "PSROWFORMAT"
+  | (string & {});
 ```
 
-### Type: `FormatSlot`
+---
 
-Open `UPPERCASE` string union — see `registerFormatHandler` above. Use one
-of the engine literals for autocomplete or any custom slot your plugin
-defines.
+## Softcode extension
+
+### `registerSoftcodeFunc(name, fn)`
+
+Register a custom stdlib function callable from softcode as `name(args)`.
+
+```typescript
+import { registerSoftcodeFunc } from "jsr:@ursamu/ursamu";
+
+registerSoftcodeFunc("double", (_ctx, args) =>
+  String(Number(args[0]) * 2)
+);
+```
+
+### `registerSoftcodeSub(char, handler)`
+
+Register a custom `%X` substitution.
+
+```typescript
+registerSoftcodeSub("$", (ctx) => `[$${ctx.enactor.id}]`);
+```
+
+### `softcodeService`
+
+The evaluator instance. Exposed for plugin integration tests.
+
+```typescript
+import { softcodeService } from "jsr:@ursamu/ursamu";
+const out = await softcodeService.eval({ enactor, executor, source: "[add(2,3)]" });
+```
+
+---
+
+## Hooks & events
+
+```typescript
+import { gameHooks } from "jsr:@ursamu/ursamu";
+import type { SessionEvent, SayEvent } from "jsr:@ursamu/ursamu";
+
+const onLogin = (e: SessionEvent) => console.log(`${e.player.name} logged in`);
+gameHooks.on("player:login", onLogin);
+
+// In plugin remove() — same function reference required:
+gameHooks.off("player:login", onLogin);
+```
+
+`GameHookMap` event names:
+
+```
+player:login      player:logout
+say               pose             page             move
+channel:message
+object:created    object:destroyed object:modified
+scene:created     scene:pose       scene:set
+scene:title       scene:clear
+mail:received
+```
+
+Each has a typed payload (`SessionEvent`, `SayEvent`, `PoseEvent`,
+`PageEvent`, `MoveEvent`, `ChannelMessageEvent`, `ObjectCreatedEvent`,
+`ObjectDestroyedEvent`, `ObjectModifiedEvent`, `SceneCreatedEvent`,
+`ScenePoseEvent`, `SceneSetEvent`, `SceneTitleEvent`, `SceneClearEvent`,
+`MailReceivedEvent`).
+
+---
+
+## REST & UI
+
+### `registerPluginRoute(prefix, handler)`
+
+Attach a REST handler. Always return 401 before doing work when `userId`
+is null on a protected route.
+
+```typescript
+registerPluginRoute("/api/v1/my-plugin", async (req, userId) => {
+  if (!userId) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  return Response.json({ ok: true, userId });
+});
+```
+
+Handler signature: `(req: Request, userId: string | null) => Promise<Response>`.
+
+### `registerUIComponent(component)` / `unregisterUIComponent(id)` / `getRegisteredUIComponents()`
+
+Expose a UI element via `GET /api/v1/ui-manifest`.
+
+```typescript
+import type { IUIComponent } from "jsr:@ursamu/ursamu";
+
+const comp: IUIComponent = {
+  id: "myplugin.panel",
+  type: "panel",
+  title: "My Panel",
+  url: "/plugins/myplugin/panel.html",
+  requires: { flag: "builder" },
+};
+registerUIComponent(comp);
+```
+
+---
+
+## Stat systems
+
+Plugins can register a pluggable stat/skill system, queryable by name.
+
+```typescript
+import { registerStatSystem, getDefaultStatSystem } from "jsr:@ursamu/ursamu";
+import type { IStatSystem } from "jsr:@ursamu/ursamu";
+
+const system: IStatSystem = { name: "wod5", /* ...impl */ };
+registerStatSystem(system, { default: true });
+
+const def = getDefaultStatSystem();
+```
+
+Also: `getStatSystem(name)`, `getStatSystemNames(): string[]`.
+
+---
+
+## WebSocket
+
+### `wsService`
+
+Direct access to the WebSocket hub. Used by channel/notification plugins.
+
+### `joinSocketToRoom(socketId, room)`
+
+Subscribe a connected socket to a broadcast room.
+
+### `send(message, target?, options?)`
+
+Module-level broadcast — sends to a socket ID, room ID, or DB object ID.
+Same semantics as `u.send` but importable from anywhere.
+
+```typescript
+import { send } from "jsr:@ursamu/ursamu";
+send("Server reboot in 5 minutes.", "#all");
+```
+
+`UserSocket` is the typed socket metadata exported for plugin authors.
+
+---
+
+## Engine context
+
+`GameContext` is the substrate every command runs on (actor, location,
+helpers). Most plugin code uses `IUrsamuSDK` instead — `GameContext` is
+exposed for low-level integrations.
+
+```typescript
+import { buildContext } from "jsr:@ursamu/ursamu";
+const ctx = await buildContext({ socketId, actorId });
+```
+
+---
+
+## Plugin config
+
+`PluginConfigManager` reads per-plugin scoped values from `config.json`.
+
+```typescript
+import { PluginConfigManager } from "jsr:@ursamu/ursamu";
+
+const cfg = new PluginConfigManager("myplugin");
+const apiKey = cfg.get<string>("apiKey");
+await cfg.set("lastRun", Date.now());
+```
+
+---
+
+## Stdlib (TS)
+
+All functions are pure and deterministic. v2.5.1 promoted these from
+softcode-only to TS-importable. v2.5.2 added per-instance `Noise`.
+
+### Noise
+
+```typescript
+import {
+  seedNoise, perlin1, perlin2, perlin3,
+  simplex2, worley2, fbm2, ridged2, noiseGrid,
+  Noise, createNoise, buildPerm,
+} from "jsr:@ursamu/ursamu";
+
+seedNoise(42);
+const v = perlin2(0.5, 1.7);
+
+const n = createNoise(123);
+const v2 = n.perlin2(0.5, 1.7);
+```
+
+| Function | Purpose |
+|----------|---------|
+| `seedNoise(seed)` | Reseed the singleton noise stream |
+| `perlin1/2/3` | Classic Perlin noise (1D/2D/3D), range ~[-1, 1] |
+| `simplex2` | 2D simplex noise |
+| `worley2` | 2D Worley/cellular noise, returns distance to nearest feature |
+| `fbm2` | Fractional Brownian Motion (octave-summed Perlin) |
+| `ridged2` | Ridged multifractal noise |
+| `noiseGrid(w,h,fn)` | Sample a function over a grid → `number[][]` |
+| `buildPerm(seed)` | Build a permutation table for a custom noise impl |
+| `Noise` class | Per-instance independent noise stream |
+| `createNoise(seed)` | Construct a `Noise` |
+
+### PRNG (`Rng`)
+
+```typescript
+import { Rng, createRng } from "jsr:@ursamu/ursamu";
+
+const r = createRng(123);
+r.next();        // [0, 1)
+r.int(1, 6);     // dice roll
+r.pick(["a", "b", "c"]);
+```
+
+Per-instance mulberry32 — independent of the softcode RNG.
+
+### Physics
+
+```typescript
+import { vreflect, pointInAabb, rayAabb } from "jsr:@ursamu/ursamu";
+import type { Vec3 } from "jsr:@ursamu/ursamu";
+
+const reflected = vreflect([1, 0, 0], [0, 1, 0]);
+const inside = pointInAabb([5, 5, 5], [0, 0, 0], [10, 10, 10]);
+const hit = rayAabb(origin, dir, min, max);
+```
+
+### Spatial scalars
+
+```typescript
+import {
+  dist2d, dist3d, distSq2d, distSq3d,
+  manhattan, chebyshev, angle2d, bearing,
+} from "jsr:@ursamu/ursamu";
+
+dist2d(0, 0, 3, 4);     // 5
+manhattan(0, 0, 3, 4);  // 7
+bearing(0, 0, 1, 1);    // radians
+```
+
+### Interpolation
+
+```typescript
+import { lerp, inverseLerp, remap, smoothstep, smootherstep, clamp }
+  from "jsr:@ursamu/ursamu";
+
+lerp(0, 100, 0.5);          // 50
+inverseLerp(0, 100, 75);    // 0.75
+remap(0, 100, 0, 1, 50);    // 0.5
+smoothstep(0, 1, 0.5);      // 0.5 (Hermite curve)
+clamp(150, 0, 100);         // 100
+```
+
+### Vector ops
+
+```typescript
+import { vsize, vsizeSq, vdistance, vdistanceSq, vlerp, vclamp }
+  from "jsr:@ursamu/ursamu";
+import type { Vec } from "jsr:@ursamu/ursamu";
+
+const a: Vec = [3, 4];
+vsize(a);              // 5
+vdistance([0, 0], a);  // 5
+vlerp([0, 0], a, 0.5); // [1.5, 2]
+```
+
+---
+
+## Types
+
+| Type | Purpose |
+|------|---------|
+| `IUrsamuSDK` | The `u` object — full surface |
+| `IDBObj` | Hydrated game object (Set flags, populated contents) |
+| `IDBOBJ` | Raw DB record shape |
+| `ICmd` | Command registration |
+| `IPlugin` | Plugin module export |
+| `IPluginDependency` | Entry in `ursamu.plugin.json` deps |
+| `IContext` | Low-level command context (legacy) |
+| `IMiddlewareFunction` | `(u: IUrsamuSDK) => boolean \| Promise<boolean>` |
+| `IStatSystem` | Pluggable stat system |
+| `IUIComponent` | UI manifest entry |
+| `GameHookMap` | Event-name → payload mapping |
+| `FormatHandler` | TS format-handler signature |
+| `FormatSlot` | Open uppercase-string union |
+| `GameContext` | Engine substrate |
+| `UserSocket` | WebSocket metadata |
+| `LockFunc` | Custom lockfunc signature |
+| `SoftcodeFn` | Custom stdlib function signature |
+| `SoftcodeSubHandler` | Custom `%X` handler signature |
+| `SoftcodeContext` | Evaluator context |
+
+---
+
+## Internal: plugin install errors
+
+The v2.6.0 plugin installer throws typed errors on failure. They live in
+`src/utils/pluginErrors.ts` and are **not currently exported from
+`mod.ts`** — they are used internally by the `ursamu plugin install`
+flow. Listed here for diagnostic visibility.
+
+```
+PluginInstallError              base class
+├─ PluginDepNameError           invalid/missing name in deps entry
+├─ PluginDepUrlError            invalid/missing url
+├─ PluginCloneError             git clone failed
+├─ PluginRenameError            move into plugins/ failed
+├─ PluginVersionError           installed plugin missing version manifest
+├─ PluginSemverError            installed version doesn't satisfy dep range
+└─ PluginConflictError          two deps disagree on resolved version
+```
+
+On any throw the installer's `InstallTxn` rolls back every directory and
+registry mutation made during the run.

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -1,37 +1,65 @@
 ---
 layout: layout.vto
 title: REST API Reference
-description: Complete reference for all UrsaMU HTTP endpoints — auth, players, channels, objects, scenes, mail, building, wiki, help, and health.
+description: Complete reference for UrsaMU's built-in HTTP endpoints — auth, players, channels, DB objects, scenes, config, and UI manifest.
 ---
 
 # REST API Reference
 
-The UrsaMU REST API runs on the same port as the WebSocket hub (default `4203`).
+The UrsaMU HTTP API runs on the same port as the WebSocket hub (default
+`4203`). This document covers only the **engine-built-in** endpoints —
+plugins (mail, jobs, bbs, help, wiki, builder, events) register their own
+routes via `registerPluginRoute()` and document them in their own repos.
+
+Verified against `src/routes/` and `src/app.ts` for v2.6.0.
+
+## Contents
+
+- [Auth model](#auth-model)
+- [Error responses](#error-responses)
+- [WebSocket connection](#websocket-connection)
+- [Auth router](#auth-router) — `/api/v1/auth/*`
+- [Players & channels](#players--channels) — `/api/v1/me`, `/api/v1/players/*`, `/api/v1/channels/*`
+- [DB Objects](#db-objects) — `/api/v1/dbos`, `/api/v1/dbobj/:id`
+- [Scenes](#scenes) — `/api/v1/scenes/*`
+- [Config & text](#config--text) — `/api/v1/config`, `/api/v1/connect`, `/api/v1/welcome`
+- [UI manifest](#ui-manifest) — `/api/v1/ui-manifest`
+- [Avatars](#avatars) — `/avatars/:id`
+- [Health](#health) — `/health`
+- [Plugin endpoints](#plugin-endpoints)
 
 ---
 
-## Authentication
+## Auth model
 
-All endpoints require a `Bearer` JWT in the `Authorization` header unless marked **None**.
+All protected endpoints require a JWT in the `Authorization` header:
 
-Obtain a token via `POST /api/v1/auth/login`. Tokens are signed with `JWT_SECRET` — set this in production.
-
-```bash
+```
 Authorization: Bearer <token>
 ```
 
-### Error responses
+Obtain a token via `POST /api/v1/auth` or `POST /api/v1/auth/register`.
+Tokens are signed with `JWT_SECRET` (set in `.env`). If `JWT_SECRET` is
+unset in production the engine exits at boot. In dev a random per-process
+secret is used and tokens are invalidated on every restart.
+
+A global API rate limit applies per IP (`apiRateLimits` map in
+`src/app.ts`). Auth endpoints have an additional per-IP brute-force
+guard.
+
+## Error responses
 
 | Status | Meaning |
 |--------|---------|
-| `400` | Bad request — missing or invalid body fields |
-| `401` | Missing or invalid token |
-| `403` | Valid token, insufficient permissions (flag check failed) |
-| `404` | Resource not found |
-| `429` | Rate limited |
-| `500` | Internal server error |
+| 400 | Bad request — missing or invalid body |
+| 401 | Missing or invalid token |
+| 403 | Valid token, insufficient permissions |
+| 404 | Resource not found |
+| 405 | Method not allowed |
+| 429 | Rate limited (`Retry-After` header set) |
+| 500 | Internal server error |
 
-All error bodies follow the same shape:
+Error body shape:
 
 ```json
 { "error": "Human-readable message" }
@@ -39,498 +67,317 @@ All error bodies follow the same shape:
 
 ---
 
-## WebSocket Connection
+## WebSocket connection
 
-The WebSocket hub is on the same port as HTTP (`4203`). Two connection modes are supported:
+The hub shares the HTTP port. Two connection modes:
 
 ### JWT pre-auth (web clients)
-
-Attach a token as a query parameter. The player is authenticated immediately — no
-`connect name password` prompt needed.
 
 ```
 ws://localhost:4203?token=<jwt>&client=web
 ```
 
+The player is authenticated immediately. On JWT reauth the engine
+re-applies the `connected` flag and re-joins the player's `#cid` and
+`#location` rooms (v2.4.0 fix).
+
 ### Classic connect (Telnet-style)
 
-Connect without a token. The server sends the connect screen. Authenticate with:
-
-```
-connect <name> <password>
-```
+Connect without a token, then send `connect <name> <password>`.
 
 ### Rate limiting
 
-Each WebSocket connection is limited to **10 commands per second**. Excess commands
-are silently dropped (a warning is logged server-side). This cannot be changed per
-connection — if you need higher throughput, batch commands or use the REST API.
+Each WebSocket is limited to **10 commands/sec**. Excess commands are
+silently dropped (warning logged server-side).
 
 ---
 
-## Auth Endpoints
+## Auth router
+
+Defined in `src/routes/authRouter.ts`. All endpoints accept `POST` only.
+Path is matched by suffix on `/api/v1/auth*`.
+
+### POST /api/v1/auth
+
+Login. Returns a JWT.
+
+Body:
+
+```json
+{ "username": "Alice", "password": "hunter2" }
+```
+
+Response 200:
+
+```json
+{ "token": "<jwt>", "id": "5", "name": "Alice" }
+```
+
+Errors: 401 invalid credentials, 429 rate-limited.
 
 ### POST /api/v1/auth/register
 
-Create a new character account. Returns a JWT.
+Create a new character. Returns a JWT.
 
-```bash
-curl -X POST http://localhost:4203/api/v1/auth/register \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Alice", "password": "hunter2"}'
-```
+Body:
 
 ```json
-{ "token": "<jwt>" }
+{ "username": "Alice", "email": "alice@example.com", "password": "hunter2" }
 ```
 
-### POST /api/v1/auth/login
-
-Authenticate and receive a JWT.
-
-```bash
-curl -X POST http://localhost:4203/api/v1/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Alice", "password": "hunter2"}'
-```
+Response 201:
 
 ```json
-{ "token": "<jwt>" }
+{ "token": "<jwt>", "id": "5", "name": "Alice" }
 ```
 
 ### POST /api/v1/auth/reset-password
 
-Consume a one-time reset token and set a new password.
+Consume a one-time reset token and set a new password. Token comparison
+is constant-time (v2.0.0 hardening). Expired tokens are cleaned up
+opportunistically.
 
-```bash
-curl -X POST http://localhost:4203/api/v1/auth/reset-password \
-  -H "Content-Type: application/json" \
-  -d '{"token": "<one-time-token>", "password": "newpassword"}'
-```
+Body:
 
 ```json
-{ "message": "Password reset successfully." }
+{ "token": "<one-time-token>", "newPassword": "newpw" }
+```
+
+Response 200:
+
+```json
+{ "message": "Password updated successfully." }
 ```
 
 ---
 
-## Players & Channels
+## Players & channels
+
+Routed from `src/app.ts`; handlers in `src/routes/playersRouter.ts`.
 
 ### GET /api/v1/me
 
-Current player profile (requires auth).
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/me
-```
+Current player profile. Requires auth.
 
 ```json
 {
-  "id": "p-1",
+  "id": "5",
   "name": "Alice",
   "flags": ["connected", "player"],
-  "data": { "description": "A mysterious figure.", "avatar": "/avatars/alice.png" }
+  "data": { "description": "...", "avatar": "/avatars/5" }
 }
 ```
 
 ### GET /api/v1/players/online
 
-List connected players. No auth required.
-
-```bash
-curl http://localhost:4203/api/v1/players/online
-```
+List currently connected players. Requires auth.
 
 ```json
 [
-  { "id": "p-1", "name": "Alice", "location": "The Lobby" },
-  { "id": "p-2", "name": "Bob",   "location": "The Library" }
+  { "id": "5", "name": "Alice", "location": "The Lobby" },
+  { "id": "8", "name": "Bob",   "location": "The Library" }
 ]
 ```
 
 ### GET /api/v1/channels
 
-List all channels.
-
-```bash
-curl http://localhost:4203/api/v1/channels
-```
+List all channels. No auth required.
 
 ```json
 [
-  { "name": "Public", "header": "[Public]", "members": 4 },
-  { "name": "Staff",  "header": "[Staff]",  "members": 2 }
+  { "name": "Public", "header": "[Public]", "members": 4 }
 ]
 ```
 
 ### GET /api/v1/channels/:name/history
 
-Recent message history for a channel (requires auth).
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:4203/api/v1/channels/Public/history?limit=20"
-```
+Recent messages. Requires auth. Query param `?limit=N` (default 20, max
+500).
 
 ```json
 [
-  { "sender": "Alice", "message": "Hello everyone!", "timestamp": 1750536000000 },
-  { "sender": "Bob",   "message": "Hey Alice.",       "timestamp": 1750536010000 }
+  { "sender": "Alice", "message": "Hi!", "timestamp": 1750536000000 }
 ]
 ```
 
 ---
 
-## Database Objects
+## DB Objects
+
+`src/routes/dbObjRouter.ts`. All endpoints require auth.
 
 ### GET /api/v1/dbos
 
-List accessible objects. Optional `?flags=` filter.
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:4203/api/v1/dbos?flags=room"
-```
+List accessible objects. Optional `?flags=room` filter.
 
 ### GET /api/v1/dbobj/:id
 
-Fetch a single game object by its DB id.
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/dbobj/p-1
-```
+Fetch a single object.
 
 ```json
 {
-  "id": "p-1",
+  "id": "5",
   "name": "Alice",
-  "location": "room-1",
+  "location": "1",
   "flags": ["connected", "player"],
-  "data": { "description": "…", "state": {} },
+  "data": { "description": "..." },
   "contents": []
 }
 ```
 
 ### PATCH /api/v1/dbobj/:id
 
-Update object data, name, or description (requires ownership or admin).
+Update object data, name, or description. Requires ownership or admin.
 
-```bash
-curl -X PATCH \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"data": {"description": "A tall figure in a green cloak."}}' \
-  http://localhost:4203/api/v1/dbobj/p-1
+Body:
+
+```json
+{ "data": { "description": "A tall figure in a green cloak." } }
 ```
+
+> The engine does not currently expose `PUT` / `DELETE` for `/dbobj/:id`
+> or any `/attrs` sub-routes. Edit attributes via the `&attr` command or
+> a custom plugin route.
 
 ---
 
 ## Scenes
 
+`src/routes/sceneRouter.ts`. All endpoints require auth.
+
 ### GET /api/v1/scenes
 
-List active scenes (requires auth).
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/scenes
-```
-
-```json
-[
-  {
-    "id": "sc-1",
-    "name": "The Heist",
-    "status": "active",
-    "type": "action",
-    "roomId": "room-5",
-    "participants": ["Alice", "Bob"],
-    "createdAt": 1750536000000
-  }
-]
-```
+List active scenes the caller can see.
 
 ### POST /api/v1/scenes
 
-Create a new scene (requires auth).
+Create a scene.
 
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "The Heist", "type": "action", "roomId": "room-5"}' \
-  http://localhost:4203/api/v1/scenes
+Body:
+
+```json
+{ "name": "The Heist", "type": "action", "roomId": "room-5" }
 ```
+
+### GET /api/v1/scenes/locations
+
+List rooms that currently host scenes.
 
 ### GET /api/v1/scenes/:id
 
-Get scene details with pose log and participants.
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/scenes/sc-1
-```
+Fetch a scene with its pose log and participants.
 
 ### PATCH /api/v1/scenes/:id
 
-Update scene metadata (owner or admin).
+Update scene metadata (owner or admin; ownerless scenes are adopted by
+the patcher — v2.0.0 fix).
 
-```bash
-curl -X PATCH \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"status": "closed"}' \
-  http://localhost:4203/api/v1/scenes/sc-1
+### POST /api/v1/scenes/:id/pose
+
+Add a pose, OOC line, or scene-set.
+
+Body:
+
+```json
+{ "msg": "Alice steps through the door.", "type": "pose" }
+```
+
+`type`: `"pose"` (default), `"ooc"`, `"set"`. When type is not `"set"`,
+`msg` is required (400 otherwise).
+
+### PATCH /api/v1/scenes/:id/pose/:poseId
+
+Edit an existing pose. Owner or admin.
+
+### POST /api/v1/scenes/:id/join
+
+Join a scene.
+
+### POST /api/v1/scenes/:id/invite
+
+Invite a player. Owner only.
+
+Body:
+
+```json
+{ "playerId": "8" }
 ```
 
 ### GET /api/v1/scenes/:id/export
 
-Export a scene as Markdown or JSON.
-
-```bash
-# Markdown (for copy-paste into a wiki or Google Doc)
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:4203/api/v1/scenes/sc-1/export?format=markdown"
-
-# JSON (for external tools)
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:4203/api/v1/scenes/sc-1/export?format=json"
-```
-
-### POST /api/v1/scenes/:id/pose
-
-Add a pose, OOC comment, or scene-set to a scene.
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"msg": "Alice steps through the door.", "type": "pose"}' \
-  http://localhost:4203/api/v1/scenes/sc-1/pose
-```
-
-`type` values: `"pose"` (default), `"ooc"`, `"set"` (scene description).
-
-### POST /api/v1/scenes/:id/join
-
-Join a scene (requires auth).
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  http://localhost:4203/api/v1/scenes/sc-1/join
-```
-
-### POST /api/v1/scenes/:id/invite
-
-Invite a player to a scene (owner only).
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"playerId": "p-3"}' \
-  http://localhost:4203/api/v1/scenes/sc-1/invite
-```
+Export as Markdown or JSON. Query: `?format=markdown` (default) or
+`?format=json`.
 
 ---
 
-## Mail
+## Config & text
 
-Provided by the [mail-plugin](https://github.com/UrsaMU/mail-plugin).
-
-### GET /api/v1/mail
-
-Inbox (requires auth).
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/mail
-```
-
-```json
-[
-  {
-    "id": "ml-1",
-    "from": "Bob",
-    "subject": "Meeting tonight",
-    "read": false,
-    "receivedAt": 1750536000000
-  }
-]
-```
-
-### POST /api/v1/mail
-
-Send a new message.
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"to": "Bob", "subject": "Re: Meeting", "body": "I will be there!"}' \
-  http://localhost:4203/api/v1/mail
-```
-
-### GET /api/v1/mail/:id
-
-Read a message (marks as read).
-
-```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:4203/api/v1/mail/ml-1
-```
-
-### DELETE /api/v1/mail/:id
-
-Delete a message.
-
-```bash
-curl -X DELETE \
-  -H "Authorization: Bearer $TOKEN" \
-  http://localhost:4203/api/v1/mail/ml-1
-```
-
----
-
-## Help
-
-Provided by the [help-plugin](https://github.com/UrsaMU/help-plugin).
-
-### GET /api/v1/help
-
-List all help sections and topics. No auth required.
-
-```bash
-curl http://localhost:4203/api/v1/help
-```
-
-```json
-{
-  "sections": {
-    "building": ["dig", "open", "link", "describe", "examine"],
-    "mail":     ["send", "reply", "delete", "folders"],
-    "social":   ["say", "pose", "page"]
-  }
-}
-```
-
-### GET /api/v1/help/:topic
-
-Fetch a single topic. Use `?format=md` for raw Markdown.
-
-```bash
-# Rendered (MUSH color codes stripped)
-curl http://localhost:4203/api/v1/help/dig
-
-# Raw Markdown
-curl "http://localhost:4203/api/v1/help/dig?format=md"
-```
-
-### POST /api/v1/help/:topic
-
-Create or update a help entry (admin).
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"content": "# DIG\n\nCreates a new room.", "section": "building"}' \
-  http://localhost:4203/api/v1/help/dig
-```
-
-### DELETE /api/v1/help/:topic
-
-Delete a help entry (admin). Restores the underlying file entry if one exists.
-
-```bash
-curl -X DELETE \
-  -H "Authorization: Bearer $TOKEN" \
-  http://localhost:4203/api/v1/help/dig
-```
-
----
-
-## Building
-
-Provided by the [builder-plugin](https://github.com/UrsaMU/builder-plugin). Requires `builder+` flag.
-
-### POST /api/v1/building/room
-
-Create a new room.
-
-```bash
-curl -X POST \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "The Library", "description": "Shelves of ancient tomes."}' \
-  http://localhost:4203/api/v1/building/room
-```
-
----
-
-## Wiki
-
-Provided by the [wiki-plugin](https://github.com/UrsaMU/wiki-plugin).
-
-### GET /api/v1/wiki
-
-List all wiki topics. No auth required.
-
-```bash
-curl http://localhost:4203/api/v1/wiki
-```
-
-### GET /api/v1/wiki/:topic
-
-Retrieve a wiki page. No auth required.
-
-```bash
-curl http://localhost:4203/api/v1/wiki/lore/history
-```
-
----
-
-## Config & Text
+`src/routes/config.ts`. No auth required.
 
 ### GET /api/v1/config
 
-Server config (name, version, ports, theme). No auth required.
-
-```bash
-curl http://localhost:4203/api/v1/config
-```
+Server config (name, version, ports, theme).
 
 ```json
 {
-  "game": { "name": "My Game", "version": "0.0.1" },
-  "server": { "http": 4203, "telnet": 4201 }
+  "game":   { "name": "My Game", "version": "0.0.1" },
+  "server": { "http": 4203, "telnet": 4201 },
+  "theme":  { "primary": "#...", "backgroundImage": "..." }
 }
 ```
 
 ### GET /api/v1/connect
 
-Connect-screen text (raw, suitable for display in a login screen).
-
-```bash
-curl http://localhost:4203/api/v1/connect
-```
+Connect-screen text (Markdown). Reads
+`config.game.text.connect` (default `text/default_connect.txt`) with a
+path-traversal guard.
 
 ### GET /api/v1/welcome
 
-Welcome text shown after login.
+Post-login welcome text (from the `texts` DBO, id `welcome`).
 
-```bash
-curl http://localhost:4203/api/v1/welcome
+### GET /api/v1/404
+
+Site 404 page content (from `texts` DBO, id `404`). Falls back to a
+default if no entry exists.
+
+---
+
+## UI manifest
+
+### GET /api/v1/ui-manifest
+
+Returns the list of UI components registered by plugins via
+`registerUIComponent()`. Optionally authenticated — if a JWT is
+presented, results are filtered by the caller's privileges
+(`requires.flag`, etc.).
+
+```json
+[
+  { "element": "myplugin-panel", "title": "My Panel", "url": "..." }
+]
 ```
+
+External script URLs are rejected at registration time (v1.9.3
+hardening).
+
+---
+
+## Avatars
+
+### GET /avatars/:id
+
+Public avatar image. `:id` must match `^[a-zA-Z0-9_-]+$` — dots and
+slashes are rejected. Looks for `data/avatars/<id>.{png,jpg,gif,webp}`.
+Cached for 1 hour.
 
 ---
 
 ## Health
 
-### GET /health
+### GET /health (or GET /)
 
-No auth required. Returns immediately; useful for load balancer health checks.
-
-```bash
-curl http://localhost:4203/health
-```
+Liveness probe. No auth.
 
 ```json
 { "status": "ok", "engine": "UrsaMU" }
@@ -538,14 +385,23 @@ curl http://localhost:4203/health
 
 ---
 
-## Plugin Endpoints
+## Plugin endpoints
 
-Official plugins add versioned routes on install:
+Plugins register routes via `registerPluginRoute(prefix, handler)`. The
+engine matches by `startsWith(prefix)` and forwards the request along
+with the authenticated `userId` (or `null`).
 
-| Plugin | Base path | Full docs |
-|--------|-----------|-----------|
-| **jobs** | `/api/v1/jobs` | [UrsaMU/jobs-plugin](https://github.com/UrsaMU/jobs-plugin) |
-| **events** | `/api/v1/events` | [Events plugin](./events.md) |
-| **bbs** | `/api/v1/bbs` | [UrsaMU/bbs-plugin](https://github.com/UrsaMU/bbs-plugin) |
+Official plugins:
 
-Custom plugins register routes via `registerPluginRoute(path, handler)` — see [Plugin Development](../plugins/index.md).
+| Plugin | Base path | Repo |
+|--------|-----------|------|
+| jobs   | `/api/v1/jobs`   | [UrsaMU/jobs-plugin](https://github.com/UrsaMU/jobs-plugin) |
+| events | `/api/v1/events` | [UrsaMU/events-plugin](https://github.com/UrsaMU/events-plugin) |
+| bbs    | `/api/v1/bbs`    | [UrsaMU/bbs-plugin](https://github.com/UrsaMU/bbs-plugin) |
+| mail   | `/api/v1/mail`   | [UrsaMU/mail-plugin](https://github.com/UrsaMU/mail-plugin) |
+| help   | `/api/v1/help`   | [UrsaMU/help-plugin](https://github.com/UrsaMU/help-plugin) |
+| wiki   | `/api/v1/wiki`   | [UrsaMU/wiki-plugin](https://github.com/UrsaMU/wiki-plugin) |
+| builder| `/api/v1/building` | [UrsaMU/builder-plugin](https://github.com/UrsaMU/builder-plugin) |
+
+Custom plugins register their own routes — see
+[Plugin Development](../plugins/index.md).

--- a/docs/child-games/index.md
+++ b/docs/child-games/index.md
@@ -1,336 +1,131 @@
 ---
 layout: layout.vto
-description: Learn how to create a child game using UrsaMU as a library
+description: Scaffold and run a derived game project on top of UrsaMU
 ---
 
-# Creating Child Games with UrsaMU
+# Child Games
 
-This guide explains how to create a child game using UrsaMU as a library.
+A "child game" is a standalone project that uses `@ursamu/ursamu` as a
+library — your own config, plugins, system-script overrides, and (usually)
+your own deployment.
 
-## Overview
+## Scaffold
 
-A "child game" is a complete MU* game built on top of the UrsaMU engine. Unlike plugins, which extend the functionality of UrsaMU, a child game is a standalone application that uses UrsaMU as a library.
-
-Creating a child game allows you to:
-
-- Create a completely customized MU* experience
-- Define your own game world, theme, and mechanics
-- Distribute your game as a standalone application
-- Maintain your game separately from the UrsaMU core
-
-## Getting Started
-
-### Prerequisites
-
-Before creating a child game, ensure you have:
-
-- [Deno](https://deno.land/) installed (version 1.37.0 or higher)
-- Basic knowledge of TypeScript
-- Understanding of MU* concepts
-
-### Installation
-
-1. Create a new directory for your game:
+The CLI ships with a generator that lays down a complete supervised
+project, including daemon scripts, telnet sidecar, and a `.env` with a
+fresh JWT secret (v2.4.0):
 
 ```bash
-mkdir my-game
+deno run -A jsr:@ursamu/ursamu/cli create my-game
 cd my-game
 ```
 
-2. Initialize a new Deno project:
+The scaffold writes:
+
+- `deno.json` with `start` / `dev` / `test` tasks
+- `config/config.json` (see "Configuration" below)
+- `plugins.manifest.json` — declared plugin dependencies
+- `system/scripts/` — empty, ready for local script overrides
+- `daemon.sh`, `stop.sh`, `restart.sh`, `status.sh` — supervised lifecycle
+- `.env` containing a generated `JWT_SECRET`
+
+A `--local` variant points the import map at a checkout of the engine
+instead of JSR; the tasks, manifest, and scripts are otherwise identical.
+
+## Running the game
 
 ```bash
-deno init
+./daemon.sh    # start under supervisor (background)
+./status.sh    # show pid / uptime / health
+./restart.sh   # SIGUSR2 → no-disconnect main restart; telnet sidecar persists
+./stop.sh      # graceful shutdown
 ```
 
-3. Install UrsaMU as a dependency:
+Or run in the foreground:
 
 ```bash
-# Add UrsaMU as a dependency in your deps.ts file
+deno task start   # initializes config, ensures superuser, spawns server + telnet
+deno task dev     # same, with hot reload
 ```
 
-## Project Structure
-
-A typical child game project structure looks like this:
-
-```
-my-game/
-├── config/                  # Configuration files
-│   ├── config.json          # Main configuration
-│   ├── text/                # Text files
-│   └── plugins/             # Plugin configurations
-├── src/                     # Source code
-│   ├── commands/            # Custom commands
-│   ├── plugins/             # Custom plugins
-│   ├── types/               # TypeScript type definitions
-│   └── main.ts              # Entry point
-├── data/                    # Database files (generated)
-├── deps.ts                  # Dependencies
-├── deno.json                # Deno configuration
-└── README.md                # Documentation
-```
+In-game `@reboot` issues the same SIGUSR2 as `restart.sh`. JWTs are
+re-authenticated automatically; the telnet sidecar stays connected across
+restarts.
 
 ## Configuration
 
-### Basic Configuration
+`config/config.json` controls server ports, KV prefixes, game identity,
+theme, and per-plugin scoped config. The shape:
 
-Create a `config/config.json` file with your game's configuration:
+- `server` — telnet / ws / http ports plus KV prefixes (`db`, `channels`,
+  `mail`, `wiki`, `bboard`, `counters`)
+- `game` — `name`, `description`, `version`, `playerStart`, text paths,
+  `timeMultiplier`
+- `theme` — color tokens, glass values, `backgroundImage`
+- `plugins` — per-plugin scoped config
+
+`.env` is loaded via `dotenv/load` at the top of the entry point. The only
+required variable is `JWT_SECRET`. Rotate it by replacing the value and
+restarting; existing tokens are invalidated.
+
+## Plugins
+
+External plugins are declared in `plugins.manifest.json` and resolved on
+startup by `ensurePlugins`. Each entry:
 
 ```json
 {
-  "server": {
-    "port": 4201,
-    "host": "0.0.0.0"
-  },
-  "game": {
-    "name": "My Game",
-    "motd": "Welcome to My Game!",
-    "debug": false
-  },
-  "database": {
-    "path": "./data"
-  }
+  "name": "@ursamu/help-plugin",
+  "url": "https://github.com/UrsaMU/help-plugin",
+  "ref": "v1.0.0",
+  "version": "^1.0.0"
 }
 ```
 
-### Text Files
+`ref` is optional (git ref / tag / branch); `version` is an optional semver
+range checked against the cloned plugin's manifest. As of v2.6.0 plugin
+installs are fail-fast with atomic rollback — any clone, rename, semver, or
+conflict error throws a typed `PluginInstallError` and leaves the
+filesystem and registry untouched. Deps without a `version:` constraint
+remain legacy-compatible.
 
-UrsaMU uses text files for various game messages. Create a `config/text` directory and add your custom text files:
-
-```
-config/text/
-├── connect.txt       # Connection screen
-├── motd.txt          # Message of the day
-└── welcome.txt       # Welcome message for new players
-```
-
-## Customization
-
-### Creating the Main File
-
-Create a `src/main.ts` file as the entry point for your game:
-
-```typescript
-import { mu } from "ursamu";
-import { config } from "../config/mod.ts";
-
-// Import your custom plugins
-import myPlugin from "./plugins/myPlugin/mod.ts";
-
-// Start the game
-await mu({
-  config,
-  plugins: [
-    myPlugin,
-    // Add more custom plugins here
-  ]
-});
-
-console.log("Game started!");
-```
-
-### Custom Commands
-
-Create custom commands in the `src/commands` directory:
-
-```typescript
-// src/commands/hello.ts
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "hello",
-  pattern: /^hello\s*(.*)/i,
-  lock: "connected",
-  exec: (u: IUrsamuSDK) => {
-    const target = u.cmd.args[0]?.trim() || "World";
-    u.send(`Hello, ${target}!`);
-  }
-});
-```
-
-### Custom Plugins
-
-Create custom plugins in the `src/plugins` directory:
-
-```typescript
-// src/plugins/myPlugin/mod.ts
-import { IPlugin } from "ursamu";
-
-const myPlugin: IPlugin = {
-  name: "my-plugin",
-  version: "1.0.0",
-  description: "A custom plugin for my game",
-  
-  init: async () => {
-    console.log("My plugin initialized!");
-    return true;
-  },
-  
-  remove: async () => {
-    console.log("My plugin removed!");
-  }
-};
-
-export default myPlugin;
-```
-
-## Deployment
-
-### Running Your Game
-
-Run your game with Deno:
+Install or update from the CLI:
 
 ```bash
-deno run --allow-net --allow-read --allow-write --allow-env src/main.ts
+deno run -A jsr:@ursamu/ursamu/cli plugin install <url> [--ref <ref>]
+deno run -A jsr:@ursamu/ursamu/cli plugin update
+deno run -A jsr:@ursamu/ursamu/cli plugin list
 ```
 
-### Creating a Startup Script
+## Local script overrides
 
-Create a `start.sh` script for easier startup:
+The engine has no bundled `system/scripts/` — all native commands are
+`addCmd` registrations in `src/commands/`. Child games may still place
+sandbox scripts under their own `system/scripts/<name>.ts` to:
+
+- Override a plugin-supplied or registered script (local file wins).
+- Add new in-sandbox commands without writing a plugin.
+
+Scripts run in a Web Worker — no `Deno.*`, no `fetch`, no `import` other
+than ESM-style `export default async (u) => { ... }`. See `CLAUDE.md`
+("Softcode / system scripts") for the sandbox contract.
+
+## Existing child games
+
+The following projects use UrsaMU as their engine and can be read as
+working references. Treat the layout as the canonical pattern; treat
+project-specific mechanics as their own.
+
+- `legends` — the in-repo reference game (gitignored under `games/`)
+- `salem-rentals`
+- `urban-shadows`
+
+## Updating the engine
 
 ```bash
-#!/bin/bash
-deno run --allow-net --allow-read --allow-write --allow-env src/main.ts
+deno run -A jsr:@ursamu/ursamu/cli update         # latest stable
+deno run -A jsr:@ursamu/ursamu/cli update main    # specific branch
 ```
 
-Make it executable:
-
-```bash
-chmod +x start.sh
-```
-
-### Docker Deployment
-
-Create a `Dockerfile` for containerized deployment:
-
-```dockerfile
-FROM denoland/deno:1.37.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN deno cache src/main.ts
-
-EXPOSE 4201
-
-CMD ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "--allow-env", "src/main.ts"]
-```
-
-Build and run the Docker container:
-
-```bash
-docker build -t my-game .
-docker run -p 4201:4201 my-game
-```
-
-## Examples
-
-### Basic Child Game
-
-Here's a complete example of a basic child game:
-
-```typescript
-// src/main.ts
-import { mu } from "jsr:@ursamu/ursamu";
-import welcomePlugin from "./plugins/welcome/mod.ts";
-
-// Define configuration
-const config = {
-  server: {
-    telnet: 4201,
-    ws: 4202,
-    http: 4203,
-  },
-  game: {
-    name: "My First MU",
-    motd: "Welcome to My First MU!"
-  }
-};
-
-// Start the game
-await mu(config, [welcomePlugin]);
-
-console.log(`${config.game.name} is running`);
-
-// src/plugins/welcome/mod.ts
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IPlugin, IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-const welcomePlugin: IPlugin = {
-  name: "welcome",
-  version: "1.0.0",
-  description: "A welcome plugin for new players",
-
-  init: async () => {
-    // Register a welcome command
-    addCmd({
-      name: "welcome",
-      pattern: /^welcome\s*(.*)/i,
-      lock: "connected",
-      exec: (u: IUrsamuSDK) => {
-        const target = u.cmd.args[0]?.trim() || "friend";
-        u.send(`Welcome to our game, ${target}!`);
-      }
-    });
-
-    return true;
-  },
-
-  remove: async () => {
-    // Cleanup code here
-  }
-};
-
-export default welcomePlugin;
-```
-
-### Advanced Child Game
-
-For a more advanced example, see the [UrsaMU Examples repository](https://github.com/UrsaMU/examples) which contains complete child game examples with various features.
-
-### Customizing the Database
-
-You can customize how your game uses the database:
-
-```typescript
-// src/main.ts
-import { mu } from "../deps.ts";
-
-await mu({
-  config: {
-    // ... other config options
-    database: {
-      path: "./custom-data",
-      backupInterval: 3600000 // Backup every hour
-    }
-  }
-});
-```
-
-### Creating a Custom Theme
-
-You can create a custom theme by overriding the default text files and adding custom CSS for the web interface:
-
-```typescript
-// src/plugins/theme/mod.ts
-import { IPlugin } from "../../../deps.ts";
-
-const themePlugin: IPlugin = {
-  name: "custom-theme",
-  version: "1.0.0",
-  description: "Custom theme for my game",
-  
-  init: async () => {
-    // Register custom CSS
-    // Set up custom colors
-    // Override default text files
-    return true;
-  }
-};
-
-export default themePlugin;
-```
-
-By following this guide, you can create a fully customized MU* game using UrsaMU as a foundation, while maintaining the flexibility to extend and modify it to suit your specific needs. 
+The updater rewrites the import map and re-runs `ensurePlugins`. Restart
+the game after an update.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,304 +1,165 @@
 ---
 layout: layout.vto
 title: Configuration
-description: Learn how to configure UrsaMU for your needs
+description: Configure UrsaMU — server ports, KV prefixes, game settings, theme, plugins, and the JWT_SECRET environment variable.
 ---
 
 # Configuring UrsaMU
 
-This guide explains how to configure UrsaMU for your specific needs.
+This page documents the v2.6.0 configuration surface — `config/config.json` and
+the environment variables consumed at startup.
 
-## Overview
+## Files
 
-UrsaMU uses a flexible configuration system that allows you to customize various
-aspects of the game. The configuration is stored in JSON files and can be
-accessed programmatically through the configuration API.
+- `config/config.json` — runtime configuration, validated at boot
+- `.env` — secrets (notably `JWT_SECRET`), loaded by `src/main.ts` via `dotenv/load`
 
-## Configuration Files
+`ursamu create` scaffolds both with sensible defaults and a fresh `JWT_SECRET`.
 
-The main configuration file is typically located at `config/config.json`. This
-file contains settings for the server, game, database, and other components.
+## Top-Level Shape
 
-Here's an example of a basic configuration file:
+```json
+{
+  "server": { /* transport + KV prefixes */ },
+  "game":   { /* world metadata */ },
+  "theme":  { /* web client styling */ },
+  "plugins": { /* per-plugin scoped config */ }
+}
+```
+
+## `server`
+
+Transport ports and Deno-KV collection prefixes.
 
 ```json
 {
   "server": {
     "telnet": 4201,
-    "ws": 4202,
-    "http": 4203,
-    "db": "data/ursamu.db",
+    "ws":     4202,
+    "http":   4203,
+    "db":       "data/ursamu.db",
     "counters": "counters",
-    "chans": "chans",
-    "mail": "mail",
-    "bboard": "bboard"
-  },
+    "chans":    "chans",
+    "mail":     "mail",
+    "wiki":     "wiki",
+    "bboard":   "bboard"
+  }
+}
+```
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `telnet` | number | `4201` | Telnet sidecar port |
+| `ws` | number | `4202` | Legacy standalone WebSocket port (the hub also accepts WS upgrades on `http`) |
+| `http` | number | `4203` | Hub HTTP + REST + WebSocket port |
+| `db` | string | `data/ursamu.db` | Deno KV database path |
+| `counters` | string | `counters` | KV prefix for ID counters |
+| `chans` | string | `chans` | KV prefix for channels |
+| `mail` | string | `mail` | KV prefix for player mail |
+| `wiki` | string | `wiki` | KV prefix for wiki pages |
+| `bboard` | string | `bboard` | KV prefix for bulletin boards |
+
+## `game`
+
+```json
+{
   "game": {
-    "name": "UrsaMU",
-    "description": "A Modern MUSH-Like engine written in Typescript.",
-    "version": "0.0.1",
+    "name":            "My UrsaMU Game",
+    "description":     "A collaborative-fiction MUSH.",
+    "version":         "1.0.0",
+    "playerStart":     "1",
+    "timeMultiplier":  1,
     "text": {
-      "connect": "text/default_connect.txt"
-    },
-    "playerStart": "1"
-  }
-}
-```
-
-## Server Configuration
-
-The `server` section of the configuration file contains settings related to the
-server:
-
-```json
-{
-  "server": {
-    "telnet": 4201,
-    "ws": 4202,
-    "http": 4203,
-    "db": "data/ursamu.db",
-    "counters": "counters",
-    "chans": "chans",
-    "mail": "mail",
-    "bboard": "bboard"
-  }
-}
-```
-
-### Server Options
-
-- `telnet` (number): The port for the telnet server (default: 4201)
-- `ws` (number): The port for the WebSocket server (default: 4202)
-- `http` (number): The port for the HTTP server (default: 4203)
-- `db` (string): Path to the database file (default: "data/ursamu.db")
-- `counters` (string): DB prefix for counters (default: "counters")
-- `chans` (string): DB prefix for channels (default: "chans")
-- `mail` (string): DB prefix for mail (default: "mail")
-- `bboard` (string): DB prefix for bulletin boards (default: "bboard")
-
-## Game Configuration
-
-The `game` section contains settings related to the game itself:
-
-```json
-{
-  "game": {
-    "name": "My UrsaMU Game",
-    "motd": "Welcome to My UrsaMU Game!",
-    "debug": false,
-    "startingRoom": "1",
-    "startingMoney": 100,
-    "maxPlayers": 100,
-    "idleTimeout": 3600
-  }
-}
-```
-
-### Game Options
-
-- `name` (string): The name of the game (default: "UrsaMU")
-- `motd` (string): Message of the day (default: "Welcome to UrsaMU!")
-- `debug` (boolean): Whether to enable debug mode (default: false)
-- `startingRoom` (string): The ID of the starting room for new players (default:
-  "1")
-- `startingMoney` (number): The amount of money new players start with
-  (default: 0)
-- `maxPlayers` (number): The maximum number of players allowed (default: 0,
-  unlimited)
-- `idleTimeout` (number): The number of seconds before a player is considered
-  idle (default: 3600)
-
-## Plugin Configuration
-
-Plugins can have their own configuration sections in the main configuration
-file:
-
-```json
-{
-  "plugins": {
-    "my-plugin": {
-      "enabled": true,
-      "option1": "value1",
-      "option2": 42
+      "connect": "text/default_connect.txt",
+      "welcome": "text/welcome.txt",
+      "404":     "text/404.txt"
     }
   }
 }
 ```
 
-### Accessing Plugin Configuration
+| Key | Type | Purpose |
+|-----|------|---------|
+| `name` | string | Game name (shown in `who`, REST `/api/v1/config`) |
+| `description` | string | Free-form description |
+| `version` | string | Reported via `@version` |
+| `playerStart` | string | DBref of the starting room for new characters |
+| `timeMultiplier` | number | In-game-clock multiplier (`u.sys.gameTime()`) |
+| `text.connect` | path | Pre-auth banner |
+| `text.welcome` | path | Post-create welcome |
+| `text.404` | path | Static-route fallback |
 
-Plugins can access their configuration using the `getConfig` function:
+## `theme`
 
-```typescript
-import { getConfig } from "../../services/Config/mod.ts";
+Theme tokens read by the bundled web client and `/api/v1/config`:
 
-// Get a plugin configuration value with a default fallback
-const option1 = getConfig("plugins.my-plugin.option1", "default");
-const option2 = getConfig("plugins.my-plugin.option2", 0);
+```json
+{
+  "theme": {
+    "primary":    "#7f5af0",
+    "secondary":  "#2cb67d",
+    "accent":     "#ff8906",
+    "background": "#16161a",
+    "surface":    "#242629",
+    "text":       "#fffffe",
+    "muted":      "#94a1b2",
+    "glass":      0.6,
+    "backgroundImage": "https://example.com/bg.jpg"
+  }
+}
 ```
 
-## Text Files
+## `plugins`
 
-UrsaMU uses text files for various game messages. These files are typically
-located in the `config/text` directory:
+Per-plugin scoped config. Plugins read their slice via
+`PluginConfigManager` or `getConfig("plugins.<name>.<key>", default)`.
 
-- `connect.txt`: The connection screen shown to players when they connect
-- `motd.txt`: The message of the day shown to players when they connect
-- `welcome.txt`: The welcome message shown to new players
-- `help.txt`: The help text shown to players when they type "help"
-
-### Example Text File
-
-Here's an example of a `connect.txt` file:
-
-```
-%ch%cy==================================%cn
-%ch%cw           My UrsaMU Game        %cn
-%ch%cy==================================%cn
-
-Welcome to My UrsaMU Game!
-
-Type 'connect <name> <password>' to connect.
-Type 'create <name> <password>' to create a new character.
-Type 'quit' to disconnect.
-
-%ch%cy==================================%cn
+```json
+{
+  "plugins": {
+    "discord": { "enabled": true, "token": "...", "channelId": "..." },
+    "my-game": { "startingGold": 100 }
+  }
+}
 ```
 
-### Color Codes
+Plugin manifests (`ursamu.plugin.json`) declare their dependencies — see
+[Plugin development](../plugins/) for the manifest format and atomic-install
+behavior introduced in v2.6.0.
 
-Text files can use color codes to add color to the text:
+## Environment Variables
 
-- `%cn`: Reset to default color
-- `%ch`: Highlight (bold)
-- `%cr`: Red
-- `%cg`: Green
-- `%cy`: Yellow
-- `%cb`: Blue
-- `%cm`: Magenta
-- `%cc`: Cyan
-- `%cw`: White
+| Name | Required | Purpose |
+|------|----------|---------|
+| `JWT_SECRET` | Yes | HMAC secret for JWT signing. Loaded from `.env` by `src/main.ts`. If unset, JWT issuance fails — start scripts generate one automatically. |
 
-## Advanced Configuration
+`.env` is generated by `ursamu create` and excluded from git by the scaffold's
+`.gitignore`. Rotate by replacing the secret and restarting the hub; existing
+sessions will be invalidated.
 
-### Configuration API
-
-UrsaMU provides a configuration API for accessing and modifying configuration
-values programmatically:
+## Runtime Configuration API
 
 ```typescript
 import { getConfig, setConfig } from "../../services/Config/mod.ts";
 
-// Get a configuration value
-const port = getConfig("server.port", 4201);
-
-// Set a configuration value
-await setConfig("server.port", 4202);
+const port = getConfig<number>("server.http", 4203);
+await setConfig("game.name", "New Name");
 ```
 
-### Environment Variables
+`u.sys.setConfig(key, value)` is the sandbox equivalent — restricted to
+admin/wizard at the command layer.
 
-UrsaMU supports environment variables for configuration. Environment variables
-take precedence over values in the configuration file.
+## Text Files
 
-Environment variables should be prefixed with `URSAMU_` and use underscores
-instead of dots:
+The paths in `game.text.*` resolve relative to the game project root. Files
+support the full MUSH color-code set (`%ch`, `%cn`, `%cr`, `%cg`, `%cb`, `%cy`,
+`%cw`, `%cc`, `%cm`, plus `%xRRGGBB` truecolor and `%r`/`%t`/`%b`).
 
+```text
+%ch%cy==================================%cn
+%ch%cw           Welcome                 %cn
+%ch%cy==================================%cn
+
+Type 'connect <name> <password>' to log in.
+Type 'create <name> <password>' to make a new character.
 ```
-URSAMU_SERVER_PORT=4202
-URSAMU_GAME_NAME="My UrsaMU Game"
-URSAMU_DATABASE_PATH="./custom-data"
-```
-
-### Configuration Hierarchy
-
-UrsaMU uses the following hierarchy for configuration values (from highest to
-lowest precedence):
-
-1. Environment variables
-2. Values set programmatically via `setConfig`
-3. Values in the configuration file
-4. Default values
-
-### Custom Configuration Files
-
-You can specify a custom configuration file when starting UrsaMU:
-
-```typescript
-import { mu } from "ursamu";
-import { config } from "./my-custom-config.ts";
-
-await mu({ config });
-```
-
-### Dynamic Configuration
-
-Some configuration values can be changed at runtime:
-
-```typescript
-import { setConfig } from "../../services/Config/mod.ts";
-
-// Change the game name at runtime
-await setConfig("game.name", "New Game Name");
-```
-
-### Configuration Validation
-
-UrsaMU validates configuration values to ensure they are of the correct type and
-within acceptable ranges. If a configuration value is invalid, UrsaMU will log a
-warning and use the default value instead.
-
-### Example: Complete Configuration
-
-Here's an example of a complete configuration file with all available options:
-
-```json
-{
-  "server": {
-    "port": 4201,
-    "host": "0.0.0.0",
-    "webSocket": true,
-    "telnet": true,
-    "web": true,
-    "webPort": 4202,
-    "ssl": {
-      "enabled": false,
-      "key": "path/to/key.pem",
-      "cert": "path/to/cert.pem"
-    }
-  },
-  "game": {
-    "name": "My UrsaMU Game",
-    "motd": "Welcome to My UrsaMU Game!",
-    "debug": false,
-    "startingRoom": "1",
-    "startingMoney": 100,
-    "maxPlayers": 100,
-    "idleTimeout": 3600,
-    "registerEnabled": true,
-    "guestEnabled": true,
-    "guestPrefix": "Guest"
-  },
-  "database": {
-    "path": "./data",
-    "backupInterval": 3600000,
-    "maxBackups": 5
-  },
-  "plugins": {
-    "my-plugin": {
-      "enabled": true,
-      "option1": "value1",
-      "option2": 42
-    }
-  },
-  "logging": {
-    "level": "info",
-    "file": "logs/ursamu.log",
-    "maxSize": 10485760,
-    "maxFiles": 5
-  }
-}
-```
-
-By following this guide, you can configure UrsaMU to suit your specific needs
-and create a customized MU* experience.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,133 +1,120 @@
 ---
 layout: layout.vto
-description: Learn how to contribute to the UrsaMU project
+description: How to contribute to UrsaMU — branching, PRs, commits, and the pre-commit gauntlet.
 ---
 
 # Contributing to UrsaMU
 
-Thank you for your interest in contributing to UrsaMU! This guide will help you get started with contributing to the project.
+Thanks for your interest in contributing to UrsaMU. This page captures the
+ground rules for v2.6.0.
 
-## Code of Conduct
+## Prerequisites
 
-UrsaMU has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](./code-of-conduct.md) so that you can understand what actions will and will not be tolerated.
-
-## Getting Started
-
-### Prerequisites
-
-Before you begin, ensure you have the following installed:
-
-- [Deno](https://deno.land/) (version 1.37.0 or higher)
+- [Deno](https://deno.land/) 1.45+ (for `--unstable-kv`)
 - [Git](https://git-scm.com/)
-- A code editor (we recommend [VS Code](https://code.visualstudio.com/) with the Deno extension)
+- An editor with the Deno extension (VS Code recommended)
 
-### Setting Up Your Development Environment
-
-1. Fork the [UrsaMU repository](https://github.com/lcanady/ursamu) on GitHub
-2. Clone your fork to your local machine:
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/ursamu.git
-   cd ursamu
-   ```
-3. Add the original repository as a remote:
-   ```bash
-   git remote add upstream https://github.com/lcanady/ursamu.git
-   ```
-4. Install dependencies:
-   ```bash
-   deno task setup
-   ```
-
-## Development Process
-
-### Branching Strategy
-
-- `main` - The main development branch
-- `release/*` - Release branches
-- `feature/*` - Feature branches
-- `bugfix/*` - Bug fix branches
-
-Always create a new branch for your changes:
+## Initial Setup
 
 ```bash
-git checkout -b feature/your-feature-name
+git clone https://github.com/lcanady/ursamu.git
+cd ursamu
+deno task test   # confirm clean baseline
 ```
 
-### Development Workflow
+If you plan to send PRs, fork on GitHub and add your fork as `origin`,
+keeping `upstream` pointed at `lcanady/ursamu`.
 
-1. Make sure your branch is up to date with the latest changes:
-   ```bash
-   git fetch upstream
-   git rebase upstream/main
-   ```
-2. Make your changes
-3. Run tests to ensure your changes don't break anything:
-   ```bash
-   deno task test
-   ```
-4. Commit your changes with a descriptive commit message:
-   ```bash
-   git commit -m "Add feature: your feature description"
-   ```
-5. Push your changes to your fork:
-   ```bash
-   git push origin feature/your-feature-name
-   ```
+## Branching
+
+Always work on a topic branch off `main`:
+
+```bash
+git fetch upstream
+git checkout -b feature/short-description upstream/main
+```
+
+There is no long-lived `develop` branch — `main` is the release line.
+
+## Pre-Commit Gauntlet
+
+Run these four steps in order before every commit. They mirror CI:
+
+```bash
+deno check --unstable-kv mod.ts
+deno lint
+deno test tests/ --allow-all --unstable-kv --no-check
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
+```
+
+A commit isn't ready until all four pass.
+
+## Docs Stay in Sync
+
+If you touch a public API, command, config key, script, scaffold output, or
+plugin surface — update `README.md` and the relevant page under `docs/` in the
+same commit. Stale docs ship as broken docs.
+
+## Commits
+
+- Write descriptive, present-tense subject lines: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`.
+- One logical change per commit.
+- **No AI/Claude attribution.** Do not add `Co-Authored-By: Claude …`, do not
+  reference AI tools in commit messages, PR descriptions, or code comments.
+- Never amend a commit that failed a pre-commit hook — fix and create a new
+  commit instead.
 
 ## Pull Requests
 
-When you're ready to submit your changes, create a pull request:
+1. Push your branch to your fork.
+2. Open a PR against `lcanady/ursamu:main`.
+3. Keep PRs scoped — one feature or fix per PR.
+4. Fill in the description: what changed, why, and how it was tested.
+5. Make sure CI is green.
 
-1. Go to your fork on GitHub
-2. Select your branch
-3. Click "Pull Request"
-4. Fill out the pull request template with details about your changes
-5. Submit the pull request
+PRs are **squash-merged**. After merge, maintainers tag the release:
 
-### Pull Request Guidelines
+```bash
+git tag v<version>
+git push --tags
+```
 
-- Keep pull requests focused on a single feature or bug fix
-- Make sure all tests pass
-- Update documentation as needed
-- Follow the coding standards
-- Be responsive to feedback and questions
+No AI attribution in PR titles or bodies either.
 
 ## Coding Standards
 
-UrsaMU follows a set of coding standards to maintain consistency across the codebase:
+- TypeScript only. Follow the
+  [Deno style guide](https://docs.deno.com/runtime/contributing/style_guide/).
+- Early return over nested conditionals.
+- No function longer than ~50 lines; no file longer than ~200 lines — decompose.
+- `catch (e: unknown)` — never bare `catch`.
+- Library-first: if the SDK does it, use the SDK.
+- No comments unless the *why* is non-obvious (hidden invariant, bug workaround).
 
-- Use TypeScript for all code
-- Follow the [Deno Style Guide](https://deno.land/manual/contributing/style_guide)
-- Use meaningful variable and function names
-- Write comments for complex logic
-- Include JSDoc comments for public APIs
-- Write tests for new features and bug fixes
+## Testing
 
-## Documentation
+- All new commands need tests in `tests/`.
+- See [Testing](./testing.md) for `mockPlayer` / `mockU` helpers and DB
+  cleanup conventions.
 
-Documentation is a crucial part of UrsaMU. When contributing, please:
+## Plugin Audit Checklist
 
-- Update the documentation for any changes to APIs or features
-- Use clear, concise language
-- Include examples where appropriate
-- Follow the [documentation guidelines](./documentation-guidelines.md)
+Mental pass before opening a PR that touches plugins or core commands:
 
-### Building Documentation
-
-To build and preview the documentation locally:
-
-```bash
-deno task docs
-```
-
-This will start a local server where you can preview the documentation.
+- `u.util.stripSubs()` on user strings before DB ops or length checks
+- `await u.canEdit(u.me, target)` before modifying any object not owned by `u.me`
+- DB writes use `"$set"` / `"$inc"` / `"$unset"` / `"$push"` — never raw overwrite
+- `u.util.target()` result null-checked
+- Admin-only paths gate on `u.me.flags` explicitly
+- `system/scripts/` files use no Deno APIs, no `fetch`, no non-`u` globals
+- All `%c*` color codes closed with `%cn`
+- `gameHooks.on()` in `init()` paired with `gameHooks.off()` in `remove()` (same named ref)
+- DBO collection names prefixed with `<pluginName>.`
+- REST handlers return 401 before any work when `userId` is null
+- `init()` returns `true`
 
 ## Getting Help
 
-If you need help with contributing to UrsaMU, you can:
-
-- Join the [UrsaMU Discord server](#)
-- Open an issue on GitHub
-- Reach out to the maintainers
-
-Thank you for contributing to UrsaMU! Your efforts help make the project better for everyone. 
+- File an issue on GitHub
+- Join the Discord linked from the project README
+- Reach out to maintainers in the PR thread

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,56 +1,75 @@
 ---
 layout: layout.vto
-description: Contribute to the UrsaMU project and help make it better
+description: Contribute to UrsaMU — pre-commit gauntlet, repo layout, and the contributor workflow for v2.6.0.
 ---
 
 # UrsaMU Development
 
-This section covers how to contribute to the UrsaMU project, whether you're fixing bugs, adding features, or improving documentation.
+This section covers how to contribute to UrsaMU — fixing bugs, adding commands,
+shipping plugins, or improving the docs. UrsaMU is v2.6.0; the test suite is
+1141+ passing across 348 lint-clean files.
 
-## Getting Started
+## Pre-Commit Gauntlet
 
-Everything you need to start contributing to UrsaMU:
+Every commit must pass these four steps in order — they mirror the CI workflow
+in `.github/workflows/ci.yml`:
 
-- [Development Environment](./environment.md) - Set up your development environment
-- [Project Structure](./structure.md) - Understand the UrsaMU codebase
-- [Building from Source](./building.md) - How to build UrsaMU from source
-- [Running Tests](./testing.md) - How to run the UrsaMU test suite
+```bash
+deno check --unstable-kv mod.ts                                       # type check
+deno lint                                                              # lint
+deno test tests/ --allow-all --unstable-kv --no-check                  # unit tests
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check # security
+```
 
-## Development Workflow
+If any step fails, the commit is not ready. CI will reject it.
 
-The UrsaMU development process:
+## Day-to-Day Commands
 
-- [Contributing Guide](./contributing.md) - How to contribute to UrsaMU
-- [Issue Tracking](./issues.md) - How we track issues and feature requests
-- [Pull Requests](./pull-requests.md) - How to submit changes to UrsaMU
-- [Code Review](./code-review.md) - Our code review process
+```bash
+deno task test          # full suite — must stay green
+deno task test:coverage # LCOV at coverage/lcov.info
+deno task start         # run the hub + telnet sidecar
+deno task dev           # dev mode with auto-restart
+deno lint               # must be clean across all 348 files
+```
 
-## Code Standards
+## Repo Layout
 
-Our coding standards and best practices:
+```
+src/
+  @types/            TypeScript interfaces (IDBObj, IUrsamuSDK, ICmd, IPlugin, …)
+  commands/          Native addCmd registrations (Deno context, full APIs)
+  plugins/<name>/    Bundled plugins — index.ts + commands.ts + help/ + README.md
+  routes/            Express REST routers (auth, dbObj, scenes, players, config)
+  services/          Core engine (Database, Sandbox, GameClock, Hooks, JWT, …)
+  utils/             Shared helpers (flags, target, locks, formatHandlers, …)
+system/
+  scripts/           Sandbox scripts — one file per command (no Deno APIs)
+  help/              In-game help text
+tests/               Deno test files — always place new tests here
+docs/                Lume static site
+config/              Runtime configuration (config.json, text/)
+```
 
-- [Coding Style](./style.md) - UrsaMU coding style guidelines
-- [TypeScript Guidelines](./typescript.md) - TypeScript-specific guidelines
-- [Testing Guidelines](./testing-guidelines.md) - How to write tests for UrsaMU
-- [Documentation Guidelines](./documentation-guidelines.md) - How to document your code
+## Where Changes Go
 
-## Documentation
+| Adding | Location |
+|--------|----------|
+| A new core command | `src/commands/<name>.ts`, registered via `addCmd` |
+| A plugin command | `src/plugins/<plugin>/commands.ts`, imported by `index.ts` |
+| A REST endpoint | `src/routes/` (core) or `registerPluginRoute` (plugin) |
+| A sandbox script | `system/scripts/<name>.ts`, ESM `export default` |
+| A new hook event | Extend `GameHookMap` via declaration merging |
+| A custom lockfunc | `registerLockFunc(name, fn)` in plugin `init()` |
+| A format slot | `registerFormatHandler` (TS) or `registerFormatTemplate` (softcode) |
 
-How to contribute to UrsaMU documentation:
+## Sub-Pages
 
-- [Documentation Structure](./docs-structure.md) - How the documentation is organized
-- [Writing Documentation](./writing-docs.md) - How to write clear and helpful documentation
-- [API Documentation](./api-docs.md) - How to document APIs
-- [Building Documentation](./building-docs.md) - How to build and test documentation locally
+- [Testing](./testing.md) — mock SDK, sandbox stubs, DB cleanup, CI integration
+- [Contributing](./contributing.md) — branching, PRs, commit conventions
 
-## Architecture
+## Reference
 
-- [System Architecture](./architecture.md)
-- [Database Schema](./database-schema.md)
-- [Command System](./command-system.md)
-
-## Advanced Topics
-
-- [Performance Optimization](./performance.md)
-- [Security Considerations](./security.md)
-- [Testing](./testing.md) 
+- Authoritative API surface: `src/@types/UrsamuSDK.ts` and
+  [`docs/llms.md`](../llms.md)
+- Project conventions: `CLAUDE.md` at the repo root

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -7,8 +7,10 @@ description: How to run the UrsaMU test suite and write tests for commands, scri
 # Testing
 
 UrsaMU uses [Deno's built-in test runner](https://docs.deno.com/runtime/fundamentals/testing/).
-The test suite has 58 test files covering authentication, command parsing, scripting, plugin
-lifecycle, WebSocket rate limiting, scene export, and more.
+The v2.6.0 suite is **1141+ passing, 0 failing** across 348 lint-clean files —
+covering authentication, command parsing, sandbox scripting, softcode evaluation,
+plugin lifecycle, WebSocket rate limiting, scene export, format handlers,
+plugin install atomicity, and security regression tests.
 ---
 
 ## Running Tests
@@ -290,18 +292,16 @@ Tests must pass before a PR can be merged.
 
 ---
 
-## Known Pre-existing Failures
+## Pre-Commit Gauntlet
 
-A small set of tests have pre-existing failures inherited from earlier versions.
-These are **not introduced by new code** — they reflect commands that were
-partially extracted to plugins. If you see failures in any of these, skip them:
-
-`@set`, `@examine`, `@describe`, `@flags`, `@name`, `@moniker`, `@alias`,
-`@drop`, `@give`, `@trigger`, `@get`, `@chown`, `target()`, `Core Migration: flags`
-
-Run with `--filter` to exclude them while working on unrelated code:
+These four steps mirror CI and must pass before every commit:
 
 ```bash
-deno test --allow-all --unstable-kv --no-check \
-  --filter "^(?!.*(examine|describe|@flags|moniker|alias|chown)).*"
+deno check --unstable-kv mod.ts
+deno lint
+deno test tests/ --allow-all --unstable-kv --no-check
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
 ```
+
+The full suite is green on `main` — there are no expected failures. If a test
+fails on your branch, fix it before submitting a PR.

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -1,428 +1,147 @@
 ---
 layout: layout.vto
-description: Learn how to extend UrsaMU with custom functionality
+description: Extension points exposed by the UrsaMU engine
 ---
 
 # Extending UrsaMU
 
-This guide explains how to extend UrsaMU with custom functionality beyond what plugins provide.
+UrsaMU exposes a small set of named registries through `jsr:@ursamu/ursamu`
+(`mod.ts`). Each one is a stable extension point intended for plugins and
+child-game code. Plugins are still the preferred packaging unit — these
+registries are what plugins use under the hood.
 
-## Overview
-
-UrsaMU is designed to be highly extensible. While plugins are the primary way to add functionality, there are several other extension points that allow you to customize the system at a deeper level.
-
-Extension points include:
-
-- Custom commands
-- Custom flags
-- Custom functions
-- Custom hooks
-- Advanced extensions (middleware, services, etc.)
-
-## Extension Points
-
-### When to Use Extensions vs. Plugins
-
-- **Plugins**: Use plugins for self-contained features that can be enabled or disabled as a unit.
-- **Extensions**: Use extensions when you need to modify core behavior or add functionality that integrates deeply with the system.
-
-Extensions are typically implemented within plugins but can also be added directly in a child game.
-
-## Custom Commands
-
-Commands are the primary way players interact with UrsaMU. You can create custom commands to add new functionality.
-
-### Registering Commands
-
-Use the `addCmd` function to register a new command:
+All examples assume the JSR import path used by external plugins:
 
 ```typescript
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "mycommand",                    // Unique identifier for the command
-  pattern: /^mycommand\s*(.*)/i,        // Regex pattern to match user input
-  lock: "connected",                    // Lock expression required to use the command
-  exec: (u: IUrsamuSDK) => {           // Function to execute when command is triggered
-    const args = u.cmd.args[0]?.trim() ?? "";
-    u.send(`You typed: ${args}`);
-  }
-});
+import { /* ... */ } from "jsr:@ursamu/ursamu";
 ```
 
-### Command Context (IUrsamuSDK)
+## Commands
 
-The `u` object passed to the `exec` function contains:
+`addCmd({ name, pattern, lock, category, help, exec })` registers a command.
+The `exec` handler receives an `IUrsamuSDK` (`u`) with `u.me`, `u.here`,
+`u.cmd`, `u.send`, `u.db`, `u.util`, `u.canEdit`, and the other SDK
+namespaces listed in `docs/api/sdk.md`. See `CLAUDE.md` for the `addCmd`
+skeleton and pattern cheat-sheet (catch-all switch gotcha included).
 
-- `u.me`: The actor who triggered the command (`IDBObj` with `id`, `state`, `flags`, etc.)
-- `u.here`: The room the actor is currently in
-- `u.cmd.args`: Array of regex capture groups from the matched pattern
-- `u.cmd.switches`: Array of switches (e.g. `@command/switch`)
-- `u.send(msg)`: Send output to the actor
-- `u.broadcast(roomId, msg)`: Broadcast a message to a room
-- `u.force(cmd)`: Execute a command as the actor
-- `u.setFlags(target, flags)`: Set flags on an object
-- `u.db`: Database operations (search, create, modify, destroy)
-- `u.util`: Utilities (target, stripSubs, etc.)
+## Format handlers
 
-### Command Patterns
+Format handlers customize how named display slots (NAMEFORMAT, DESCFORMAT,
+CONFORMAT, EXITFORMAT, WHOFORMAT, WHOROWFORMAT, PSFORMAT, PSROWFORMAT, or any
+arbitrary uppercase slot name) render. Two entry points:
 
-Command patterns are regular expressions. Capture groups become `u.cmd.args`:
+- `registerFormatHandler(slot, fn)` — TS function that returns a string.
+- `registerFormatTemplate(slot, mushSource)` — raw MUSH softcode body, parsed
+  and evaluated as if it were a `&NAMEFORMAT` attribute (v2.4.0).
+
+Lookups go through `resolveFormat` / `resolveFormatOr` (per-target) and
+`resolveGlobalFormat` / `resolveGlobalFormatOr` (two-tier `#0` → `u.me`).
+`unregisterFormatHandler(slot)` removes a registration. All four resolvers
+are reachable from softcode via `u.util`. See `docs/api/core.md` for the
+full slot list and priority rules.
+
+## Lock functions
+
+`registerLockFunc(name, fn)` adds a callable lock primitive usable inside
+lock strings (`tribe(glasswaler)`, `attr(mortal) || !tribe(glasswaler)`,
+`connected && perm(builder)`). Built-in names — `flag`, `attr`, `type`,
+`is`, `holds`, `perm` — are protected and cannot be overwritten. Locks are
+fail-closed: unknown function or thrown error evaluates to `false`. Max
+length 4096 chars / 256 tokens. Lock strings support `&&`, `||`, `!`, and
+`()` grouping; legacy `&` / `|` still parse.
+
+## Softcode functions and substitutions
+
+- `registerSoftcodeFunc(name, fn)` adds a stdlib function callable from any
+  evaluated attribute (e.g. `magic(x, y)`).
+- `registerSoftcodeSub(name, fn)` adds a `%`-substitution handler (e.g.
+  `%mxp[...]`).
+
+Both feed the same `softcodeService` evaluator used by `u.eval` /
+`u.evalString` and by `&attr`/`@trigger` dispatch.
+
+## Command middleware
+
+`registerCmdMiddleware(fn)` inserts a middleware function into the command
+pipeline before `exec` runs. Use it for logging, audit, rate-limiting, or
+short-circuit interception. Middleware receives the same context the
+dispatcher builds and can call `next()` to continue or return early to
+abort.
+
+## Scripts
+
+`registerScript(name, content)` registers a sandbox script (legacy block or
+ESM `export default async (u) => { ... }`). Resolution order at dispatch
+time: local `system/scripts/<name>.ts` override → plugin registry → engine
+bundled. Use this when a plugin wants to ship a sandboxed script without
+writing to disk.
+
+## REST routes
+
+`registerPluginRoute(method, path, handler)` attaches an Express handler to
+the main HTTP app. The handler receives the standard Express
+`(req, res, next)` triple. Return 401 before any work when `req.userId` is
+null. Routes are namespaced by convention under `/api/v1/<plugin>/...`.
+
+## UI components
+
+`registerUIComponent(component)` adds an entry to `GET /api/v1/ui-manifest`
+so the bundled web client (and any other client that reads the manifest)
+can discover plugin-provided UI. `unregisterUIComponent(id)` removes it;
+`getRegisteredUIComponents()` lists current entries.
+
+## Stat systems
+
+`registerStatSystem(system)` registers an `IStatSystem` implementation
+(stats, skills, validation, sheet rendering) that chargen plugins and game
+projects can target. `getStatSystem(name)`, `getDefaultStatSystem()`, and
+`getStatSystemNames()` are the read-side helpers.
+
+## Game hooks
+
+`gameHooks` is the engine's `EventEmitter`. Subscribe with
+`gameHooks.on(event, listener)` and pair every listener with a matching
+`gameHooks.off(event, listener)` in `remove()` — using the same named
+reference is non-negotiable (see `CLAUDE.md`). Typed events
+(`GameHookMap`):
+
+- `player:login`, `player:logout`
+- `say`, `pose`, `page`, `move`
+- `channel:message`
+- `object:created`, `object:destroyed`, `object:modified`
+- `scene:created`, `scene:pose`, `scene:set`, `scene:title`, `scene:clear`
+- `mail:received`
+
+## Plugin skeleton
 
 ```typescript
-// /^look\s*(.*)/i — captures the optional target as u.cmd.args[0]
-// /^give\s+(\S+)\s+to\s+(.*)/i — two capture groups: args[0] and args[1]
-// /^quit$/i — exact match, no capture groups
-```
+import "./commands.ts"; // Phase 1: addCmd at module load
+import {
+  gameHooks,
+  registerFormatTemplate,
+  registerLockFunc,
+} from "jsr:@ursamu/ursamu";
+import type { IPlugin, SessionEvent } from "jsr:@ursamu/ursamu";
 
-## Custom Flags
+const onLogin = (e: SessionEvent) => { /* ... */ };
 
-Flags are used to control access to commands and features. You can create custom flags to implement your own permission system.
-
-### Registering Flags
-
-Use the `registerFlag` function to register a new flag:
-
-```typescript
-import { registerFlag } from "../../services/Flags/mod.ts";
-
-registerFlag({
-  name: "myflag",          // Name of the flag
-  description: "My custom flag", // Description of what the flag does
-  default: false           // Default value for new objects
-});
-```
-
-### Checking Flags
-
-Use the `hasFlag` function to check if an object has a flag:
-
-```typescript
-import { hasFlag } from "../../services/Flags/mod.ts";
-
-// Check if player has the "myflag" flag
-if (hasFlag(player, "myflag")) {
-  // Do something
-}
-```
-
-### Setting Flags
-
-Use the `setFlag` function to set a flag on an object:
-
-```typescript
-import { setFlag } from "../../services/Flags/mod.ts";
-
-// Set the "myflag" flag on a player
-await setFlag(player, "myflag", true);
-```
-
-## Custom Functions
-
-Functions are used in expressions and can be called from commands. You can create custom functions to add new capabilities to the expression system.
-
-### Registering Functions
-
-Use the `registerFunction` function to register a new function:
-
-```typescript
-import { registerFunction } from "../../services/Functions/mod.ts";
-
-registerFunction({
-  name: "myfunc",          // Name of the function
-  description: "My custom function", // Description of what the function does
-  args: ["arg1", "?arg2"],  // Arguments (? prefix means optional)
-  exec: (args, ctx) => {    // Function to execute
-    const [arg1, arg2 = "default"] = args;
-    return `${arg1} and ${arg2}`;
-  }
-});
-```
-
-### Using Custom Functions
-
-Once registered, your function can be used in expressions:
-
-```
-> think myfunc(hello, world)
-hello and world
-```
-
-## Custom Hooks
-
-Hooks allow you to run code at specific points in the system's execution. You can create custom hooks to add behavior that runs automatically.
-
-### Registering Hooks
-
-Use the `registerHook` function to register a new hook:
-
-```typescript
-import { registerHook } from "../../services/Hooks/mod.ts";
-
-// Register a hook that runs when a player connects
-registerHook("playerConnect", async (player) => {
-  console.log(`Player ${player.data.name} connected`);
-  
-  // You can modify the player or perform other actions
-  player.data.lastLogin = new Date().toISOString();
-  await dbojs.update(player);
-});
-```
-
-### Available Hook Points
-
-UrsaMU provides several hook points:
-
-- `playerConnect`: Triggered when a player connects
-- `playerDisconnect`: Triggered when a player disconnects
-- `playerCreate`: Triggered when a player is created
-- `commandBefore`: Triggered before a command is executed
-- `commandAfter`: Triggered after a command is executed
-- `objectCreate`: Triggered when an object is created
-- `objectDestroy`: Triggered when an object is destroyed
-
-### Creating Custom Hook Points
-
-You can create your own hook points for plugins to use:
-
-```typescript
-import { registerHookPoint, triggerHook } from "../../services/Hooks/mod.ts";
-
-// Register a new hook point
-registerHookPoint("myCustomHook");
-
-// Trigger the hook somewhere in your code
-await triggerHook("myCustomHook", { data: "some data" });
-```
-
-## Advanced Extensions
-
-### Custom Middleware
-
-You can create custom middleware to process commands before they're executed:
-
-```typescript
-import { registerMiddleware } from "../../services/Commands/mod.ts";
-
-// Register middleware that logs all commands
-registerMiddleware(async (ctx, next) => {
-  console.log(`Player ${ctx.player.data.name} executed: ${ctx.cmd} ${ctx.args}`);
-  
-  // Call the next middleware in the chain
-  await next();
-  
-  console.log("Command execution completed");
-});
-```
-
-### Custom Services
-
-You can create custom services to provide functionality to other parts of the system:
-
-```typescript
-// src/services/MyService/mod.ts
-class MyService {
-  private data: Map<string, any> = new Map();
-  
-  constructor() {
-    console.log("MyService initialized");
-  }
-  
-  set(key: string, value: any): void {
-    this.data.set(key, value);
-  }
-  
-  get(key: string): any {
-    return this.data.get(key);
-  }
-}
-
-// Create a singleton instance
-export const myService = new MyService();
-```
-
-### Custom Database Models
-
-You can create custom database models to store specialized data:
-
-```typescript
-import { dbojs } from "../../services/Database/index.ts";
-
-// Define a type for your model
-interface MyModel {
-  id: string;
-  name: string;
-  data: Record<string, any>;
-}
-
-// Create functions to work with your model
-async function createMyModel(data: Omit<MyModel, "id">): Promise<MyModel> {
-  const model = await dbojs.create({
-    flags: "mymodel",
-    data: {
-      name: data.name,
-      ...data.data
-    }
-  });
-  
-  return {
-    id: model.id,
-    name: data.name,
-    data: data.data
-  };
-}
-
-async function getMyModels(): Promise<MyModel[]> {
-  const models = await dbojs.query({ flags: /mymodel/i });
-  
-  return models.map(model => ({
-    id: model.id,
-    name: model.data.name,
-    data: { ...model.data }
-  }));
-}
-```
-
-### Custom Web Routes
-
-If you're using the web interface, you can add custom routes:
-
-```typescript
-import { app } from "../../app.ts";
-
-// Add a custom API endpoint
-app.router.get("/api/custom", (ctx) => {
-  ctx.response.body = { message: "Custom API endpoint" };
-});
-
-// Add a custom page
-app.router.get("/custom", async (ctx) => {
-  ctx.response.body = await app.render("custom.html", {
-    title: "Custom Page",
-    data: { /* your data */ }
-  });
-});
-```
-
-### Example: Complete Extension
-
-Here's an example of a plugin that uses multiple extension points:
-
-```typescript
-import { IPlugin, addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-import { registerFlag } from "../../services/Flags/mod.ts";
-import { registerFunction } from "../../services/Functions/mod.ts";
-import { registerHook } from "../../services/Hooks/mod.ts";
-import { dbojs } from "../../services/Database/index.ts";
-
-const myExtensionPlugin: IPlugin = {
-  name: "my-extension",
+export const plugin: IPlugin = {
+  name: "myplugin",
   version: "1.0.0",
-  description: "A plugin that demonstrates various extension points",
-  
-  init: async () => {
-    // Register a custom flag
-    registerFlag({
-      name: "vip",
-      description: "VIP player with special privileges",
-      default: false
-    });
-    
-    // Register a custom function
-    registerFunction({
-      name: "isvip",
-      description: "Check if a player is a VIP",
-      args: ["player"],
-      exec: async (args, ctx) => {
-        const [playerName] = args;
-        
-        // Find the player
-        const players = await dbojs.query({
-          "data.name": new RegExp(`^${playerName}$`, "i"),
-          flags: /player/i
-        });
-        
-        if (players.length === 0) {
-          return "0";
-        }
-        
-        // Check if the player has the VIP flag
-        return players[0].flags.includes("vip") ? "1" : "0";
-      }
-    });
-    
-    // Register a custom command
-    addCmd({
-      name: "vip",
-      pattern: /^vip\s+(\S+)\s+(.*)/i,
-      lock: "wizard",
-      exec: async (u: IUrsamuSDK) => {
-        const action = u.cmd.args[0]?.trim() ?? "";
-        const target = u.cmd.args[1]?.trim() ?? "";
-
-        if (!action || !target) {
-          return u.send("Usage: vip add/remove <player>");
-        }
-
-        // Find the target player
-        const players = await dbojs.query({
-          "data.name": new RegExp(`^${target}$`, "i"),
-          flags: /player/i
-        });
-
-        if (players.length === 0) {
-          return u.send(`Player '${target}' not found.`);
-        }
-
-        const player = players[0];
-        const playerName = String(player.data?.name ?? player.id);
-
-        if (action === "add") {
-          if (!player.flags.includes("vip")) {
-            await u.setFlags(player.id, "+vip");
-            u.send(`Added VIP status to ${playerName}.`);
-          } else {
-            u.send(`${playerName} is already a VIP.`);
-          }
-        } else if (action === "remove") {
-          if (player.flags.includes("vip")) {
-            await u.setFlags(player.id, "-vip");
-            u.send(`Removed VIP status from ${playerName}.`);
-          } else {
-            u.send(`${playerName} is not a VIP.`);
-          }
-        } else {
-          u.send("Usage: vip add/remove <player>");
-        }
-      }
-    });
-    
-    // Register a hook
-    registerHook("playerConnect", async (player) => {
-      // Check if the player is a VIP
-      if (player.flags.includes("vip")) {
-        // Broadcast a message to all connected players
-        const connectedPlayers = await dbojs.query({
-          flags: /connected/i
-        });
-        
-        for (const p of connectedPlayers) {
-          p.send(`VIP player ${player.data.name} has connected!`);
-        }
-      }
-    });
-    
+  description: "One sentence.",
+  init: () => {
+    gameHooks.on("player:login", onLogin);
+    registerLockFunc("tribe", (en, _t, args) =>
+      String(en.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+    );
+    registerFormatTemplate("NAMEFORMAT", "[name(%0)] <<%1>>");
     return true;
   },
-  
-  remove: async () => {
-    // Cleanup code here
-  }
+  remove: () => {
+    gameHooks.off("player:login", onLogin);
+  },
 };
-
-export default myExtensionPlugin;
 ```
 
-By using these extension points, you can deeply customize UrsaMU to create a unique game experience tailored to your needs. 
+See `docs/api/core.md` for full signatures and `docs/api/sdk.md` for the
+`IUrsamuSDK` surface.

--- a/docs/guides/admin-guide.md
+++ b/docs/guides/admin-guide.md
@@ -21,20 +21,20 @@ Run the server for the first time:
 deno task start
 ```
 
-When the database is empty, the startup script pauses and prompts you:
+When the database is empty, the engine prints:
 
 ```
-No players found in the database.
-Welcome! Let's set up your superuser account.
+Fresh database detected — no players exist yet.
 
-Enter email address: you@example.com
-Enter username: Admin
-Enter password: ••••••••
+Connect via telnet and run:
+  create <name> <password>
 
-Superuser 'Admin' created successfully!
+The first player created is automatically given superuser access.
 ```
 
-After setup completes, the Hub and Telnet sidecar start automatically.
+Connect with a Telnet client (`telnet localhost 4201`) and create your
+account. The first player created on a fresh database is automatically
+granted the `superuser` flag.
 
 ### Permission levels
 
@@ -58,10 +58,8 @@ From inside the game, grant admin rights with:
 The `superuser` flag cannot be granted via `@set` — it can only be created
 through the first-run interactive prompt.
 
-> **Non-interactive environments**: If you run `deno task start` without a TTY,
-> the prompt is skipped. Run `deno task server` directly in an interactive
-> terminal to complete first-run setup, then switch back to `deno task start`
-> for normal operation.
+The `superuser` flag itself cannot be granted via `@set` from inside the
+game — it can only be created via this first-run flow.
 ---
 
 ## User Management
@@ -254,13 +252,20 @@ From in-game (admin or wizard required):
 @update      -- Pull latest code from git and restart (see below)
 ```
 
-From the terminal, use `Ctrl+C` to stop a running process, then restart with:
+From the terminal:
 
 ```bash
-deno task start     # Hub only (no watch)
-deno task dev       # Hub + Telnet with file watching (development)
-deno task daemon    # Background service with restart loop (production)
+deno task start           # Start Hub + Telnet sidecar (foreground)
+deno task dev             # Same, with file watching (development)
+bash scripts/daemon.sh    # Supervised background process (production)
+bash scripts/restart.sh   # No-disconnect restart of the supervised main
+bash scripts/stop.sh      # Graceful stop (disconnects everyone)
 ```
+
+The supervised scaffold is created automatically by `ursamu create`. See
+[Production Deployment](./deployment.md#supervised-daemon-mode) for the
+signal model (SIGUSR2 = no-disconnect restart; Telnet sidecar persists
+across `@reboot` and JWT auto-reauth).
 
 ### Hot-Reload (`@reload`)
 
@@ -494,13 +499,13 @@ curl -H "Authorization: Bearer <token>" \
 
 All endpoints are served on the Hub's HTTP port (default `4203`). Most require
 a `Bearer` JWT token in the `Authorization` header, obtained from
-`POST /api/v1/auth/login`.
+`POST /api/v1/auth`.
 
 ### Authentication
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/api/v1/auth/login` | Returns `{ token }` |
+| `POST` | `/api/v1/auth` | Returns `{ token }` |
 | `POST` | `/api/v1/auth/register` | Create a new character |
 | `POST` | `/api/v1/auth/reset-password` | Consume a reset token and set a new password |
 | `GET` | `/api/v1/me` | Current user profile |
@@ -647,7 +652,7 @@ warning is printed. This means all sessions are invalidated on restart.
 
 ### Brute-Force Login Protection
 
-The login endpoint (`POST /api/v1/auth/login`) enforces a per-IP rate limit of
+The login endpoint (`POST /api/v1/auth`) enforces a per-IP rate limit of
 **10 failed attempts per minute**. After that threshold is reached the server
 returns `429 Too Many Requests` and logs the event to `logs/security.log`.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -101,6 +101,25 @@ deno run -A jsr:@ursamu/ursamu/cli plugin info <name>
 ```
 
 Displays metadata, installed version, and available update.
+
+### Search
+
+```bash
+deno run -A jsr:@ursamu/ursamu/cli plugin search <query>
+```
+
+Search the public plugin registry for plugins matching `<query>`.
+
+### Plugin install behavior (v2.6.0)
+
+The plugin installer is **fail-fast with whole-manifest atomic rollback**.
+If any plugin (or transitive `deps[]` entry) fails to clone, has an unsafe
+name or URL, violates a `version` semver range, or conflicts with another
+dep's range, the entire install run aborts. Disk and the plugin registry
+are left exactly as they were before the run — your previously installed
+plugins are not touched. See
+[Admin Guide → Plugin Install Behavior](./admin-guide.md#plugin-install-behavior)
+for the full list of error classes.
 ---
 
 ## update
@@ -115,6 +134,17 @@ Preview changes without writing:
 
 ```bash
 deno run -A jsr:@ursamu/ursamu/cli update --dry-run
+```
+---
+
+## scripts
+
+List the names and aliases of every script the engine and its plugins
+register at startup. Useful for discovering what's already registered before
+you write an override.
+
+```bash
+deno run -A jsr:@ursamu/ursamu/cli scripts list
 ```
 ---
 

--- a/docs/guides/commands.md
+++ b/docs/guides/commands.md
@@ -36,6 +36,8 @@ All built-in commands available in UrsaMU. Commands marked **admin+** require th
 | `@name <object>=<name>` | Rename an object |
 | `whisper <player>=<msg>` | Private in-room message; others see attribution only |
 | `quit` | Disconnect from the server |
+| `@version` | Show the engine version |
+| `@poll` | Show the current poll, if any |
 | `help [<topic>]` | Display help text (provided by [help-plugin](https://github.com/UrsaMU/help-plugin)) |
 ---
 

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -274,6 +274,83 @@ registerPluginRoute("/api/v1/leaderboard", async (_req, _userId) => {
 ```
 ---
 
+## Format Handlers
+
+The format-handler pipeline lets you replace the rendering of any "labelled
+display slot" — the name shown at the top of `look`, the contents list, the
+exit line, the WHO row, the @ps row, and more — without rewriting the command.
+
+### The eight engine-known slots
+
+| Slot | Used by |
+|------|---------|
+| `NAMEFORMAT` | Header line of `look` / `examine` |
+| `DESCFORMAT` | Description block of `look` |
+| `CONFORMAT` | The "Contents:" list in `look` |
+| `EXITFORMAT` | The "Exits:" list in `look` |
+| `WHOFORMAT` | Outer wrapper of the `who` command |
+| `WHOROWFORMAT` | One row of `who` |
+| `PSFORMAT` | Outer wrapper of `@ps` |
+| `PSROWFORMAT` | One row of `@ps` |
+
+Plugins can also register handlers for any uppercase slot name they invent
+(e.g. `MAILFORMAT`, `BBROWFORMAT`) and resolve them from their own commands.
+
+### Resolution priority
+
+For any slot, the engine resolves in this order:
+
+1. A stored `&SLOTNAME` softcode attribute on the target object (or, for
+   global-list slots, on `#0`).
+2. The most recently registered plugin format handler for that slot.
+3. `null` (caller falls back to its default rendering).
+
+This means builders can override a single object's display with `&NAMEFORMAT`
+in-game **without** the plugin needing to know they exist.
+
+### Register a TypeScript handler
+
+```typescript
+import { registerFormatHandler } from "jsr:@ursamu/ursamu";
+
+registerFormatHandler("NAMEFORMAT", (target, viewer) => {
+  const star = target.flags.has("admin") ? "%ch%cy*%cn " : "";
+  return `${star}%ch${target.state.name}%cn`;
+});
+```
+
+The handler receives the target, the viewer, and optional slot-specific
+extras (for row-format slots, the row data). Return `null` to fall through
+to the default.
+
+### Register a MUSH-softcode template (v2.4.0)
+
+If your handler is just a softcode string, use `registerFormatTemplate` —
+the shortcut compiles the source once and wraps it in a TS handler for you.
+
+```typescript
+import { registerFormatTemplate } from "jsr:@ursamu/ursamu";
+
+registerFormatTemplate(
+  "EXITFORMAT",
+  "[ansi(hy,<)] [name(%0)] [ansi(hy,>)]"
+);
+```
+
+### Unregister
+
+```typescript
+import { unregisterFormatHandler } from "jsr:@ursamu/ursamu";
+unregisterFormatHandler("NAMEFORMAT");
+```
+
+### Resolving from a script
+
+Scripts use `u.util.resolveFormat[Or]` and `u.util.resolveGlobalFormat[Or]`
+to render through the pipeline. See the
+[SDK Cookbook](./sdk-cookbook.md#resolveformat--resolveformator).
+---
+
 ## External Integrations
 
 ### Fetching data in a command

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -32,7 +32,10 @@ source ~/.bashrc
 ## Environment Variables
 
 Set these before starting the server. The simplest approach is a `.env` file in
-your game project root (UrsaMU loads it via `@std/dotenv` at startup):
+your game project root — UrsaMU loads it via `dotenv/load` at the top of
+`src/main.ts`, so anything defined there is visible to the engine before any
+config is read. Scaffolded projects (`ursamu create`) write a fresh
+`JWT_SECRET` into `.env` automatically.
 
 ```bash
 # .env  — DO NOT commit this file
@@ -95,40 +98,40 @@ The first player created receives the `superuser` flag automatically.
 After that, switch to daemon mode for normal operation.
 ---
 
-## Daemon Mode
+## Supervised Daemon Mode
 
-UrsaMU includes built-in daemon scripts that start both processes in the
-background, write logs to `logs/`, and track PIDs.
+Game projects scaffolded with `ursamu create` ship four shell wrappers in
+`scripts/` that run the server as a supervised background process. They use
+the engine's signal-driven restart loop so `@reboot` and config reloads do
+**not** disconnect Telnet sidecar clients.
 
 ```bash
-# Start in background
-deno task daemon
-
-# Check status
-deno task status
-
-# Follow live logs
-deno task logs
-
-# Stop
-deno task stop
-
-# Stop and restart
-deno task restart
+bash scripts/daemon.sh    # Start the supervisor in the background
+bash scripts/status.sh    # Show pid + uptime
+bash scripts/restart.sh   # No-disconnect restart of the main process
+bash scripts/stop.sh      # Graceful stop (disconnects everyone)
 ```
 
-**What `deno task daemon` does:**
+What happens:
 
-1. Starts `src/telnet.ts` in the background → logs to `logs/telnet.log`
-2. Starts `src/main.ts` in the background → logs to `logs/main.log`
-3. Writes PIDs to `.ursamu.pid`
+1. `daemon.sh` spawns `deno task start` under a supervisor loop. The
+   supervisor PID is written to `.ursamu.pid`; the running `deno` child PID
+   is written to `.ursamu-deno.pid`.
+2. The supervisor watches the deno exit code:
+   - `75` → restart (default after `@reboot`, `@update`, crash)
+   - `0` → clean stop (`@shutdown`)
+   - other → unexpected crash; the supervisor stops and logs
+3. `restart.sh` sends **SIGUSR2** to the main process. The engine catches
+   it, finishes in-flight handlers, and restarts the main loop **without
+   disconnecting the Telnet sidecar**. Clients keep their JWT and auto-
+   reauthenticate on the new main.
+4. `stop.sh` sends SIGTERM and waits for clean shutdown.
 
-The PIDs file is cleaned up automatically on `deno task stop`.
+The same restart semantics back the in-game `@reboot` and `@update` commands.
 
-> **Development vs production:** Use `deno task start` during development — it
-> enables file watching so both servers restart on code changes. Use
-> `deno task daemon` in production where you want the servers to stay up
-> without reloading on filesystem events.
+> **Development vs production:** Use `deno task dev` during development — it
+> enables file watching so the main server restarts on code changes. Use
+> `bash scripts/daemon.sh` in production.
 ---
 
 ## systemd
@@ -320,7 +323,7 @@ UrsaMU writes three log files to `logs/`:
 Follow live:
 
 ```bash
-deno task logs          # tails main.log and telnet.log
+tail -f logs/main.log logs/telnet.log
 tail -f logs/security.log
 ```
 
@@ -360,8 +363,8 @@ deno run -A jsr:@ursamu/ursamu/cli update
 After updating, restart the servers:
 
 ```bash
-deno task restart           # if using daemon mode
-sudo systemctl restart ursamu-main ursamu-telnet  # if using systemd
+bash scripts/restart.sh                              # if using the daemon scaffold
+sudo systemctl restart ursamu-main ursamu-telnet     # if using systemd
 ```
 
 Check the [changelog](https://github.com/ursamu/ursamu/releases) before

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -34,9 +34,21 @@ docker compose up -d
 docker compose logs -f
 ```
 
-On first startup the server will initialize the database and be ready to accept
-connections immediately (no interactive setup in Docker mode — create a superuser
-from the Telnet prompt or the REST API after the container starts).
+On first startup the server initializes the database and prints a one-time
+message inviting you to create the first player via Telnet:
+
+```
+Fresh database detected — no players exist yet.
+
+Connect via telnet and run:
+  create <name> <password>
+
+The first player created is automatically given superuser access.
+```
+
+Connect with `telnet localhost 4201` and run `create <name> <password>` —
+that first account is granted the `superuser` flag automatically. After
+that, all subsequent `create` calls produce regular players.
 
 ---
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,126 +6,55 @@ description: User guides and tutorials for UrsaMU
 
 # UrsaMU Guides
 
-This section contains comprehensive guides and tutorials to help you get started
-with UrsaMU, whether you're installing it for the first time, learning how to
-use it as a player, or administering your own server.
+User guides and tutorials for UrsaMU v2.6.0 — installation, day-to-day play,
+admin operations, plugin development, and softcoding.
 
-## Installation Guide
+## Getting Started
 
-Learn how to install and set up UrsaMU on your system:
+- [**Installation**](./installation.md) — Prerequisites, install methods,
+  first-run setup, and connecting.
+- [**User Guide**](./user-guide.md) — Connecting and playing as a player.
+- [**CLI Reference**](./cli.md) — `ursamu create`, `plugin`, `update`, `scripts`.
 
-- [Prerequisites](./installation.md#prerequisites)
-- [Installation Methods](./installation.md#installation-methods)
-- [Configuration](./installation.md#configuration)
-- [Running the Server](./installation.md#running-the-server)
+## Operating a Server
 
-## User Guide
+- [**Admin Guide**](./admin-guide.md) — Permissions, user management,
+  configuration, `@reload`, plugin install behavior, security.
+- [**Production Deployment**](./deployment.md) — `.env` and `JWT_SECRET`,
+  `scripts/daemon.sh`, systemd, nginx + TLS, log rotation, updates.
+- [**Docker**](./docker.md) — Containerized deployment with `docker compose`.
+- [**Password Reset**](./password-reset.md) — Admin tokens, player flow,
+  REST API.
+- [**Debugging**](./debugging.md) — Common runtime errors and how to fix them.
 
-Learn how to use UrsaMU as a player:
+## Customizing the Game
 
-- [Getting Started](./user-guide.md#getting-started)
-- [Basic Commands](./user-guide.md#basic-commands)
-- [Character Creation](./user-guide.md#character-creation)
-- [Communication](./user-guide.md#communication)
+- [**Customization**](./customization.md) — Color codes, custom commands,
+  attributes, plugins, REST routes, format handlers, external integrations.
+- [**Lock Expressions**](./lock-expressions.md) — Lockfunc syntax, boolean
+  operators, custom lockfuncs via `registerLockFunc`.
+- [**Command Reference**](./commands.md) — All built-in commands.
+- [**Help Authoring**](./help-authoring.md) — Writing help files, directory
+  structure, conventions.
 
-## Admin Guide
+## Writing Code
 
-Learn how to administer an UrsaMU server:
+- [**Scripting**](./scripting.md) — Sandbox model, the `u` SDK, ESM vs legacy
+  blocks, aliases and switches.
+- [**Build Your First Script**](./first-script.md) — Step-by-step walkthrough.
+- [**SDK Cookbook**](./sdk-cookbook.md) — Every `u.*` namespace with examples.
+- [**Soft-Coding**](./softcoding.md) — Storing scripts in attributes, parent
+  inheritance, `@trigger` / `u.trigger` / `u.eval`.
+- [**Recipes**](./recipes.md) — Copy-paste patterns for common tasks.
+- [**Game Clock**](./gameclock.md) — `u.sys.gameTime` and the in-game calendar.
 
-- [User Management](./admin-guide.md#user-management)
-- [Server Configuration](./admin-guide.md#server-configuration)
-- [Backup and Restore](./admin-guide.md#backup-and-restore)
-- [Troubleshooting](./admin-guide.md#troubleshooting)
+## Game Systems
 
-## Scripting Guide
-
-Write TypeScript/JS scripts that run in the sandboxed SDK:
-
-- [How scripting works](./scripting.md#how-scripting-works)
-- [The SDK (`u`)](./scripting.md#the-sdk-u)
-- [Writing a script](./scripting.md#writing-a-script)
-- [Testing scripts](./scripting.md#testing-scripts)
+- [**Scenes**](./scenes.md) — Collaborative RP logs: create, pose, export.
+- [**Wiki**](./wiki.md) — File-based Markdown wiki with frontmatter and REST.
 
 ## MUSH Compatibility
 
-Coming from PennMUSH, TinyMUSH, or MUX2? See what works today and what's planned:
-
-- [What works today](../mush_compatibility/#what-works-today)
-- [What's different](../mush_compatibility/#whats-different-from-traditional-mush)
-- [Planned enhancements](../mush_compatibility/#planned-enhancements)
-- [Connecting with MU* clients](../mush_compatibility/#connecting-with-a-traditional-mu-client)
-
-## Docker
-
-Run UrsaMU in a container:
-
-- [Quick start](./docker.md#quick-start)
-- [docker-compose.yaml reference](./docker.md#docker-composeyaml)
-- [Environment & volumes](./docker.md#environment-variables)
-- [Behind a reverse proxy](./docker.md#behind-a-reverse-proxy)
-- [Troubleshooting](./docker.md#troubleshooting)
-
-## Production Deployment
-
-Get UrsaMU running reliably in production:
-
-- [Environment variables](./deployment.md#environment-variables)
-- [Daemon mode](./deployment.md#daemon-mode)
-- [systemd service](./deployment.md#systemd)
-- [Nginx + TLS](./deployment.md#nginx-and-tls)
-- [Firewall & log rotation](./deployment.md#firewall)
-
-## Scenes
-
-Create, write in, and export collaborative roleplay logs:
-
-- [Creating a scene](./scenes.md#creating-a-scene)
-- [Writing poses](./scenes.md#writing-poses)
-- [Private scenes & invitations](./scenes.md#private-scenes)
-- [Exporting a scene](./scenes.md#exporting-a-scene)
-- [Full API reference](./scenes.md#api-reference)
-
-## Wiki
-
-Build and manage your game wiki with file-based Markdown:
-
-- [Directory structure](./wiki.md#directory-structure)
-- [Frontmatter](./wiki.md#frontmatter)
-- [In-game commands](./wiki.md#in-game-commands)
-- [REST API](./wiki.md#rest-api)
-- [Hooks](./wiki.md#hooks)
-
-## Writing Help Files
-
-Create and organize in-game help files for your players:
-
-- [Directory structure](./help-authoring.md#directory-structure)
-- [File naming conventions](./help-authoring.md#file-naming)
-- [Markdown support & tables](./help-authoring.md#markdown-support)
-- [How players access help](./help-authoring.md#how-players-access-help)
-
-## Password Reset
-
-How admins generate reset tokens and players consume them:
-
-- [Admin steps](./password-reset.md#admin-steps)
-- [Player steps & API](./password-reset.md#player-steps)
-- [Error responses](./password-reset.md#error-responses)
-
-## Lock Expressions
-
-Control access to commands, exits, and objects with lock expressions:
-
-- [Flag checks](./lock-expressions.md#flag-checks)
-- [Boolean operators](./lock-expressions.md#boolean-operators)
-- [Attribute checks](./lock-expressions.md#attribute-checks)
-- [Using locks in scripts](./lock-expressions.md#using-locks-in-scripts)
-
-## Customization
-
-Learn how to customize your UrsaMU server:
-
-- [Themes](./customization.md#themes)
-- [Commands](./customization.md#commands)
-- [Game Mechanics](./customization.md#game-mechanics)
-- [Integration](./customization.md#integration)
+Coming from PennMUSH, TinyMUSH, or MUX2? See
+[mush compatibility](../mush_compatibility.md) for what works today, what
+differs, and how to connect with traditional MU* clients.

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -13,8 +13,8 @@ on your system.
 
 Before installing UrsaMU, ensure you have the following:
 
-- [**Deno**](https://deno.land/) version 1.32.0 or higher
-- Git (for cloning the repository)
+- [**Deno**](https://deno.land/) v1.40 or higher
+- Git (for cloning the repository and plugin installs)
 
 ## Installation Methods
 
@@ -105,15 +105,19 @@ This will:
 
 ### Development Mode
 
-For development with individual servers:
+For development with auto-restart on file changes:
 
 ```bash
-# Main server only with watch mode
-deno task server
-
-# Telnet server only with watch mode
-deno task telnet
+deno task dev
 ```
+
+### Production / Supervised Daemon
+
+Game projects scaffolded with `ursamu create` include `scripts/daemon.sh`,
+`scripts/restart.sh`, `scripts/status.sh`, and `scripts/stop.sh`. These run
+the server as a supervised background process with signal-driven
+no-disconnect restarts. See [Production Deployment](./deployment.md#supervised-daemon-mode)
+for details.
 
 ## Connecting
 
@@ -154,34 +158,30 @@ socket.send(JSON.stringify({ msg: "look", data: {} }));
 
 ## First Admin
 
-UrsaMU handles first-run setup automatically. On the very first `deno task start`
-when the database is empty, the server pauses and prompts you interactively:
+When the database is empty, UrsaMU prints:
 
 ```
-No players found in the database.
-Welcome! Let's set up your superuser account.
+Fresh database detected — no players exist yet.
 
-Enter email address: admin@example.com
-Enter username: Admin
-Enter password: ••••••••
+Connect via telnet and run:
+  create <name> <password>
+
+The first player created is automatically given superuser access.
 ```
 
-This creates your account with the **superuser** flag (level 10 — the highest
-permission level). Once done, the Hub and Telnet sidecar start automatically.
+Connect with a Telnet client (`telnet localhost 4201`) and create your first
+account. That first player receives the **superuser** flag (level 10 — the
+highest permission level) automatically.
 
 After that, use `@set <player>=admin` in-game to grant admin rights to other
-trusted staff. The `superuser` flag itself can only be created at the database
-level via this first-run flow — it cannot be granted from inside the game.
-
-> **Tip**: If you run `deno task start` non-interactively (e.g. inside a script
-> without a TTY), the prompt is skipped and you'll see a message suggesting you
-> run `deno task server` directly to complete setup.
+trusted staff. The `superuser` flag itself can only be created via this
+first-run flow — it cannot be granted from inside the game.
 
 ## Next Steps
 
 Now that you have UrsaMU installed and running, you might want to:
 
-- [**User Guide**](./user-guide) - Learn how to use UrsaMU as a player
+- [**User Guide**](./user-guide.md) - Learn how to use UrsaMU as a player
 - [**Configuration**](../configuration/) - Explore detailed configuration
   options
 - [**Plugin Development**](../plugins/index.md) - Learn how to create plugins to

--- a/docs/guides/lock-expressions.md
+++ b/docs/guides/lock-expressions.md
@@ -1,7 +1,7 @@
 ---
 layout: layout.vto
 title: Lock Expressions
-description: Reference guide for UrsaMU's lock expression syntax — controlling access to commands, objects, and exits.
+description: Reference guide for UrsaMU's lock expression syntax — built-in lockfuncs, boolean operators, indirect locks, and custom lockfunc registration.
 ---
 
 # Lock Expressions
@@ -9,146 +9,146 @@ description: Reference guide for UrsaMU's lock expression syntax — controlling
 Lock expressions control access to commands, exits, and objects. They appear in
 three places:
 
-- The `lock` field of a command definition: `lock: "connected & builder+"`
-- The in-game `@lock` command: `@lock north=admin`
+- The `lock` field of a command definition: `lock: "connected && perm(builder)"`
+- The in-game `@lock` command: `@lock north=flag(admin)`
 - The SDK `u.checkLock()` method in scripts
 
-An empty or absent lock always passes — the object or command is accessible to
-everyone, including unauthenticated connections.
+An empty or absent lock always passes. Locks are **fail-closed**: an unknown
+lockfunc or a runtime error in a lockfunc evaluates to `false`. Maximum lock
+string length is 4096 characters / 256 tokens.
 ---
 
-## Flag Checks
-
-The simplest lock is a single flag name. It passes if the actor has that flag
-set on their object.
+## Quick Examples
 
 ```
-"connected"        -- actor must be logged in
-"player"           -- actor must be a player
-"builder"          -- actor must have the builder flag
-"admin"            -- actor must have the admin flag
-"wizard"           -- actor must have the wizard flag
-"superuser"        -- actor must have the superuser flag
+"connected"                           -- any logged-in actor
+"flag(admin)"                         -- has the admin flag
+"connected && perm(builder)"          -- logged in AND builder level or higher
+"flag(admin) || flag(wizard)"         -- admin OR wizard
+"!flag(dark)"                         -- does NOT have the dark flag
+"connected && (flag(admin) || flag(builder))"
+"attr(tribe, glasswalker)"            -- state.tribe === "glasswalker"
+"is(#5)"                              -- actor is object #5
+"holds(#12)"                          -- actor's inventory includes #12
 ```
+---
 
-### Level-based checks (`flag+`)
+## Built-in Lockfuncs
 
-Append `+` to a flag name to mean *that level or any higher level*. Because
-flags have numeric levels, `builder+` passes for builders, storytellers, admins,
-wizards, and superusers alike.
+Lockfuncs are functions called against the enactor. They take zero or more
+arguments and return a boolean.
 
-| Expression | Passes for |
-|------------|-----------|
-| `player` | `player` only |
-| `player+` | `player`, `builder`, `storyteller`, `admin`, `wizard`, `superuser` |
-| `builder` | `builder` only |
-| `builder+` | `builder`, `storyteller`, `admin`, `wizard`, `superuser` |
-| `admin+` | `admin`, `wizard`, `superuser` |
+| Lockfunc | Example | Passes when |
+|----------|---------|-------------|
+| `flag(name)` | `flag(wizard)` | enactor has the named flag |
+| `attr(name)` | `attr(tribe)` | enactor.state has own-property `name` |
+| `attr(name, value)` | `attr(class, warrior)` | `state[name] === value` (case-insensitive key) |
+| `type(name)` | `type(player)` | enactor has the type flag (player/room/thing/exit) |
+| `is(#id)` | `is(#5)` | enactor's dbref is `#5` |
+| `holds(#id)` | `holds(#12)` | enactor's inventory includes `#12` |
+| `perm(level)` | `perm(admin)` | enactor passes the privilege check for `level` |
 
-> **Note:** `connected` has no numeric level — use it without `+`.
+The legacy plain-flag form is still supported: `"admin"` is equivalent to
+`flag(admin)`, and a trailing `+` (`builder+`) is equivalent to
+`perm(builder)`.
+
+### `perm()` levels
+
+`perm()` is the recommended way to check minimum permission level because it
+walks the flag ladder. Higher levels satisfy lower-level checks.
+
+| Level | Passes for |
+|-------|-----------|
+| `perm(player)` | player, builder, storyteller, admin, wizard, superuser |
+| `perm(builder)` | builder, storyteller, admin, wizard, superuser |
+| `perm(admin)` | admin, wizard, superuser |
+| `perm(wizard)` | wizard, superuser |
+| `perm(superuser)` | superuser only |
+
+### Special tokens
+
+| Token | Meaning |
+|-------|---------|
+| `connected` | enactor is logged in (has the `connected` flag) |
 ---
 
 ## Boolean Operators
 
-Lock expressions support full boolean algebra. Operators evaluate with the
-following precedence (highest first):
+Lock expressions support full boolean algebra. Precedence (highest first):
 
 1. `!` — NOT (prefix)
-2. `&` — AND
-3. `|` — OR
+2. `&&` — AND
+3. `||` — OR
 4. `( )` — Grouping (overrides precedence)
 
 ```
-"!superuser"                     -- actor does NOT have superuser
-"connected & admin+"             -- connected AND admin or higher
-"admin | wizard"                 -- admin OR wizard
-"connected & (admin | builder)"  -- connected AND (admin or builder)
-"!player"                        -- actor is not a player (e.g. a guest or object)
+"!flag(superuser)"
+"connected && perm(admin)"
+"flag(admin) || flag(wizard)"
+"connected && (flag(admin) || flag(builder))"
 ```
 
-### Combining connected with a flag
+### Legacy `&` / `|`
 
-A common pattern: require login *and* a minimum permission level.
-
-```
-"connected & admin+"   -- most staff commands
-"connected & builder+" -- building commands
-"connected"            -- any logged-in player
-```
----
-
-## DB Reference Checks
-
-Use `#id` to restrict access to a specific database object.
-
-```
-"#1"              -- passes only if the actor IS object #1
-"connected & #5"  -- connected AND the actor is object #5
-```
-
-This is useful for owner-only exits or objects that only a specific character
-should be able to use.
----
-
-## Attribute Checks
-
-Check a value stored in an actor's `state` (attributes). The syntax is
-`attribute:value`.
-
-```
-"sex:Male"          -- actor's 'sex' attribute equals "Male" (case-insensitive key)
-"class:Warrior"     -- actor's 'class' attribute equals "Warrior"
-```
-
-Numeric attributes support comparison operators:
-
-```
-"level:>5"     -- actor's 'level' is greater than 5
-"level:>=10"   -- actor's 'level' is 10 or more
-"gold:<100"    -- actor's 'gold' is less than 100
-"gold:<=50"    -- actor's 'gold' is 50 or less
-```
-
-Attribute names are case-insensitive. Values are compared as strings unless a
-comparison operator is present, in which case they're parsed as numbers.
+The single-character operators `&` (AND) and `|` (OR) from earlier UrsaMU
+releases still work as aliases for `&&` / `||`. New code should prefer the
+two-character forms — they are unambiguous around lockfunc names that contain
+underscores or dashes.
 ---
 
 ## Indirect Locks
 
 Prefix `@` to delegate the lock check to the lock stored on another object.
-This lets you centralise a lock definition and point many commands at it.
 
 ```
-"@#10"     -- evaluate the lock on object #10
+"@#10"     -- evaluate the lock stored on object #10
 "@vault"   -- evaluate the lock on the object named "vault"
 ```
 
-Indirect locks are recursion-protected (maximum depth 10) to prevent cycles.
+Indirect locks are recursion-protected (maximum depth 10).
 ---
 
-## Script Checks
+## Registering a Custom Lockfunc
 
-Embed inline script code between `[` and `]`. The lock passes if the code
-returns a truthy value.
+Plugins can register their own lockfuncs via `registerLockFunc`. Built-in
+names (`flag`, `attr`, `type`, `is`, `holds`, `perm`) are protected and cannot
+be overwritten.
+
+```typescript
+import { registerLockFunc } from "jsr:@ursamu/ursamu";
+
+registerLockFunc("tribe", (enactor, _target, args) =>
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+```
+
+Once registered, the function is available everywhere locks are evaluated:
 
 ```
-"[u.me.state.karma > 50]"
-"[await u.db.get(u.me.id) !== undefined]"
+lock: "tribe(glasswalker)"
+lock: "perm(admin) || tribe(glasswalker)"
+lock: "connected && !tribe(banished)"
 ```
 
-Script locks have access to the `u` SDK object in scope. Use sparingly — they
-run synchronously inside the lock check and should be fast.
+**Signature:**
+
+```typescript
+registerLockFunc(
+  name: string,
+  fn: (enactor: IDBObj, target: IDBObj | null, args: string[]) => boolean
+): void;
+```
+
+Locks fail closed — return `false` on missing data or invalid input, and the
+engine itself catches thrown errors.
 ---
 
 ## Using Locks in Scripts
 
-The SDK exposes `u.checkLock()` to evaluate a lock expression from inside a
-script:
+The SDK exposes `u.checkLock()` to evaluate a lock expression from a script:
 
 ```typescript
-// Check if an actor passes a lock
-const canEnter = await u.checkLock(targetRoom, "connected & builder+");
-
+const canEnter = await u.checkLock(targetRoom, "connected && perm(builder)");
 if (!canEnter) {
   u.send("You don't have permission to enter.");
   return;
@@ -158,10 +158,10 @@ if (!canEnter) {
 **Signature:**
 
 ```typescript
-u.checkLock(target: string | IDBObj, lock: string): Promise<boolean>
+u.checkLock(target: string | IDBObj, lock: string): Promise<boolean>;
 ```
 
-- `target` — the object whose perspective is used to resolve `@indirect` locks
+- `target` — the object whose perspective resolves `@indirect` locks
 - `lock` — any valid lock expression string
 ---
 
@@ -171,16 +171,14 @@ u.checkLock(target: string | IDBObj, lock: string): Promise<boolean>
 |------------|---------|
 | `""` | Always passes (open) |
 | `"connected"` | Actor is logged in |
-| `"player"` | Actor has the player flag |
-| `"builder+"` | Builder level or higher |
-| `"admin+"` | Admin level or higher |
-| `"superuser"` | Superuser only |
-| `"!admin"` | Actor is NOT an admin |
-| `"admin \| wizard"` | Admin or wizard |
-| `"connected & admin+"` | Logged in AND admin+ |
-| `"connected & (admin \| builder)"` | Logged in AND (admin or builder) |
-| `"#5"` | Actor is object #5 |
-| `"sex:Female"` | Actor's sex attribute is "Female" |
-| `"level:>=10"` | Actor's level attribute is ≥ 10 |
+| `"flag(admin)"` | Actor has the admin flag |
+| `"perm(builder)"` | Builder level or higher |
+| `"perm(admin)"` | Admin level or higher |
+| `"!flag(dark)"` | Actor does NOT have the dark flag |
+| `"flag(admin) \|\| flag(wizard)"` | Admin or wizard |
+| `"connected && perm(admin)"` | Logged in AND admin or higher |
+| `"connected && (flag(admin) \|\| flag(builder))"` | Logged in AND (admin or builder) |
+| `"is(#5)"` | Actor is object #5 |
+| `"holds(#12)"` | Actor's inventory includes #12 |
+| `"attr(class, warrior)"` | Actor's `class` attribute is `warrior` |
 | `"@#10"` | Delegates to the lock on object #10 |
-| `"[u.me.state.vip]"` | Passes if actor's vip state is truthy |

--- a/docs/guides/password-reset.md
+++ b/docs/guides/password-reset.md
@@ -85,7 +85,7 @@ curl -X POST https://yourgame.example.com/api/v1/auth/reset-password \
 ```
 
 After a successful reset the player can log in with their new password using the
-normal `POST /api/v1/auth/login` endpoint.
+normal `POST /api/v1/auth` endpoint.
 ---
 
 ## API Reference

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -404,7 +404,17 @@ u.util.template(
 
 // Strip MUSH color codes and ANSI escapes (for storage/validation)
 u.util.stripSubs("%chHello %cgWorld%cn")  // → "Hello World"
+
+// Resolve a format-attr through the format-handler pipeline (v2.3.2+)
+//   priority: stored &NAMEFORMAT attribute → plugin handler → null
+const line = await u.util.resolveFormat(target, "NAMEFORMAT", u.me);
+const row  = await u.util.resolveGlobalFormat("WHOROWFORMAT", u.me, [player]);
 ```
+
+See the [SDK Cookbook](./sdk-cookbook.md#resolveformat--resolveformator) for the
+full format-resolve API and the
+[Customization guide](./customization.md#format-handlers) for the eight slots
+and how to register handlers.
 ---
 
 ## Structured UI (`u.ui`)

--- a/docs/guides/sdk-cookbook.md
+++ b/docs/guides/sdk-cookbook.md
@@ -243,14 +243,16 @@ await u.setFlags(u.me, "builder");
 ## Permission Check (`u.canEdit`)
 
 ```typescript
-if (!u.canEdit(u.me, target)) {
+if (!(await u.canEdit(u.me, target))) {
   u.send("Permission denied.");
   return;
 }
 // proceed with edit
 ```
 
-Returns `true` if the actor owns the target, or is admin/wizard/superuser.
+Returns `Promise<boolean>` — `true` if the actor owns the target, or is
+admin / wizard / superuser. Always `await` the call; omitting `await`
+truthy-tests the Promise object and silently bypasses the check.
 ---
 
 ## Locks (`u.checkLock`)
@@ -529,6 +531,39 @@ const out = u.util.template(
 );
 // → "[ 42] [Post title          ] Alice"
 ```
+
+### resolveFormat / resolveFormatOr
+
+Sandbox-accessible helpers (since v2.3.2) for looking up a format-attr value
+on a target, walking the format-handler pipeline.
+
+```typescript
+// Look up a per-object NAMEFORMAT. Priority:
+//   1. Stored &NAMEFORMAT attribute on the target
+//   2. Plugin-registered format handler for that slot
+//   3. null
+const formatted = await u.util.resolveFormat(target, "NAMEFORMAT", u.me);
+
+// With a fallback string if nothing returns
+const line = await u.util.resolveFormatOr(target, "EXITFORMAT", u.me, "[exit]");
+```
+
+### resolveGlobalFormat / resolveGlobalFormatOr
+
+Two-tier lookup (since v2.3.3) for "global list" formats like WHO and @ps.
+Checks `#0` (the master room object) first, then the enactor.
+
+```typescript
+// e.g. inside a WHO script
+const row = await u.util.resolveGlobalFormat("WHOROWFORMAT", u.me, [player]);
+const fallback = await u.util.resolveGlobalFormatOr("WHOFORMAT", u.me, "");
+```
+
+The eight engine-known slots are `NAMEFORMAT`, `DESCFORMAT`, `CONFORMAT`,
+`EXITFORMAT`, `WHOFORMAT`, `WHOROWFORMAT`, `PSFORMAT`, `PSROWFORMAT`.
+Plugin authors can pass any uppercase slot name (e.g. `"MAILFORMAT"`,
+`"BBROWFORMAT"`) without casting. See
+[Customization → Format Handlers](./customization.md#format-handlers).
 
 ### stripSubs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ templateEngine: [vto, md]
 
   <div class="version-badge" style="cursor:default">
     <svg width="10" height="10" viewBox="0 0 10 10" fill="var(--primary-light)"><circle cx="5" cy="5" r="5"/></svg>
-    v2.0.0 &nbsp;&bull;&nbsp; MIT License
+    v2.6.0 &nbsp;&bull;&nbsp; MIT License
   </div>
 
   <h1>A Modern MUSH Server</h1>
@@ -117,8 +117,32 @@ templateEngine: [vto, md]
     <div class="feature-card-icon">
       <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
     </div>
-    <h3>Wiki &amp; Content</h3>
-    <p>File-based markdown wiki with folder-driven routing, YAML frontmatter, full REST API, and in-game read/search/write commands.</p>
+    <h3>TinyMUX 2.x Softcode</h3>
+    <p>Full 250+ function softcode evaluator: math, string, list, logic, object, register, and output families with all TinyMUX substitutions and ANSI codes.</p>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-card-icon">
+      <svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+    </div>
+    <h3>Stdlib Primitives</h3>
+    <p>Noise (Perlin/Simplex/Worley/FBM), per-instance PRNG, physics, spatial, interpolation, and vector ops re-exported from mod.ts (v2.5.1+).</p>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-card-icon">
+      <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+    </div>
+    <h3>Atomic Plugin Installs</h3>
+    <p>Fail-fast plugin manifests with semver constraints and InstallTxn rollback — every dir and registry mutation rolls back on any error (v2.6.0).</p>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-card-icon">
+      <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+    </div>
+    <h3>Format Handler Pipeline</h3>
+    <p>Eight format slots (NAMEFORMAT, DESCFORMAT, CONFORMAT, EXITFORMAT, WHOFORMAT, WHOROWFORMAT, PSFORMAT, PSROWFORMAT) — register TS handlers or raw softcode templates.</p>
   </div>
 
 </div>

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -2,6 +2,9 @@
 
 > Machine-optimized reference for code generation. Covers all public APIs,
 > types, patterns, and conventions. For human-readable guides see docs/guides/.
+> **Current version: v2.6.0.** Authoritative API surface lives at
+> `src/@types/UrsamuSDK.ts` and is mirrored in
+> `.claude/skills/ursamu-dev/references/api-reference.md`.
 ---
 
 ## Overview
@@ -20,9 +23,26 @@ UrsaMU is a TypeScript/Deno MUSH-style multiplayer game server. Key characterist
 ## Import Paths
 
 ```typescript
-// All public APIs
+// All public APIs (v2.6.0)
 import {
-  addCmd, registerPluginRoute, mu, createObj, DBO, dbojs, gameHooks
+  addCmd, cmds, registerScript, registerCmdMiddleware,
+  registerPluginRoute, registerUIComponent, unregisterUIComponent,
+  getRegisteredUIComponents,
+  mu, createObj, DBO, dbojs, gameHooks, send, joinSocketToRoom,
+  softcodeService, registerSoftcodeFunc, registerSoftcodeSub,
+  evaluateLock, validateLock, registerLockFunc,
+  registerFormatHandler, registerFormatTemplate, unregisterFormatHandler,
+  resolveFormat, resolveFormatOr, resolveGlobalFormat, resolveGlobalFormatOr,
+  header, divider, footer,
+  registerStatSystem, getStatSystem, getDefaultStatSystem, getStatSystemNames,
+  // Stdlib (v2.5.1+): Noise, PRNG, physics, spatial, interpolation, vector
+  Noise, createNoise, seedNoise, perlin1, perlin2, perlin3, simplex2,
+  worley2, fbm2, ridged2, noiseGrid, buildPerm,
+  Rng, createRng,
+  vreflect, pointInAabb, rayAabb,
+  dist2d, dist3d, distSq2d, distSq3d, manhattan, chebyshev, angle2d, bearing,
+  lerp, inverseLerp, remap, smoothstep, smootherstep, clamp,
+  vsize, vsizeSq, vdistance, vdistanceSq, vlerp, vclamp,
 } from "jsr:@ursamu/ursamu";
 
 // Types (zero runtime cost)
@@ -886,4 +906,4 @@ Result: discord no longer declares a `jobs` dependency. It reacts to job
 events whether or not it knows jobs is installed.
 ---
 
-*Generated from `src/@types/UrsamuSDK.ts`, `src/services/Sandbox/worker.ts`, and source review. Last updated: 2026-03-22.*
+*Generated from `src/@types/UrsamuSDK.ts`, `src/services/Sandbox/worker.ts`, and source review. Last updated: 2026-05-15 (v2.6.0).*

--- a/docs/mush_compatibility.md
+++ b/docs/mush_compatibility.md
@@ -10,7 +10,7 @@ UrsaMU is **not a drop-in replacement** for PennMUSH, TinyMUSH, or MUX2. It is a
 
 If you are migrating from a traditional MUSH or hosting your first server, this page tells you exactly what works today and what is planned.
 
-> Updated for v2.0.0.
+> Updated for v2.6.0.
 ---
 
 ## What Works Today
@@ -178,6 +178,39 @@ The `#tagname` shorthand works anywhere an object reference is accepted in softc
 | `@tr` / `@trigger` | `@trigger <obj>/<attr>` command + `u.trigger()` SDK method |
 | `@pemit` / `@remit` | `@pemit` and `@remit` — both implemented |
 | No named-object registry | `@tag` / `@ltag` provide global and personal registries |
+| Lock ops `&` / `\|` only | `&&` / `\|\|` / `!` with parens, plus legacy `&`/`\|` (v2.2.0) |
+| Hard-coded format attrs | 8-slot format pipeline: register TS handlers or raw softcode templates (v2.3.0+) |
+
+## Format-Attribute Pipeline
+
+Eight engine-known format slots route through both softcode attributes on the
+object and plugin-registered handlers (priority: softcode attr → plugin handler
+→ fallback):
+
+`NAMEFORMAT`, `DESCFORMAT`, `CONFORMAT`, `EXITFORMAT`, `WHOFORMAT`,
+`WHOROWFORMAT`, `PSFORMAT`, `PSROWFORMAT`.
+
+Plugins may also register arbitrary uppercase slot names (e.g. `MAILFORMAT`,
+`BBROWFORMAT`) — `FormatSlot` is an open union as of v2.3.4.
+
+```typescript
+// TS handler
+registerFormatHandler("WHOROWFORMAT", (ctx) => `${ctx.name} - idle ${ctx.idle}`);
+
+// Softcode template (v2.4.0)
+registerFormatTemplate("WHOFORMAT", "[center(===,78,=)]%r[u(#1/HEADER)]");
+```
+
+## Lock Expressions (v2.2.0+)
+
+Locks support `&&`, `||`, `!` with `()` grouping plus the legacy `&`/`|`
+operators. Built-in lockfuncs: `flag(name)`, `attr(name[, val])`, `type(name)`,
+`is(#id)`, `holds(#id)`, `perm(level)`. Custom lockfuncs register via
+`registerLockFunc(name, fn)`.
+
+```
+lock: "connected && (flag(wizard) || attr(tribe, glasswalker))"
+```
 
 ---
 

--- a/docs/plugins/basics.md
+++ b/docs/plugins/basics.md
@@ -50,6 +50,20 @@ methods. The interface is intentionally minimal.
 > `addCmd` and `new DBO<T>()` are called at **module-load time**, not inside
 > `init()`. Import `"./commands.ts"` from `index.ts` and the registrations
 > happen automatically.
+
+> **Named handler refs.** Any `gameHooks.on(event, handler)` registered in
+> `init()` must be paired with `gameHooks.off(event, handler)` in `remove()`
+> using the **same named function reference**. Inline arrow functions cannot
+> be unsubscribed. See [hooks.md](./hooks.md#full-example).
+
+> **DBO namespacing.** Collection names must be prefixed with your plugin
+> name to avoid colliding with the core engine or other plugins:
+> `new DBO<T>("my-plugin.records")`. See [database.md](./database.md).
+
+> **Stdlib primitives.** Plugins written in TypeScript can import
+> `Noise`, `Rng`, vector/spatial helpers, interpolation, and physics
+> primitives directly from `jsr:@ursamu/ursamu` (v2.5.1+). No need to vendor
+> `simplex-noise` or `alea`.
 ---
 
 ## A Minimal Plugin

--- a/docs/plugins/commands.md
+++ b/docs/plugins/commands.md
@@ -71,6 +71,23 @@ Controls who can run the command. The player must satisfy the lock expression.
 | `"connected admin+"` | Connected + admin flag or higher |
 | `"connected wizard"` | Connected + wizard flag |
 
+Lock expressions also support callable **lockfuncs** combined with `&&`,
+`||`, `!`, and `()` (v2.2.0+). Built-ins include `flag(name)`, `attr(name,
+val)`, `type(name)`, `is(#id)`, `holds(#id)`, and `perm(level)`. Plugins
+can register custom lockfuncs:
+
+```typescript
+import { registerLockFunc } from "jsr:@ursamu/ursamu";
+
+registerLockFunc("tribe", (enactor, _target, args) =>
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// lock: "connected && tribe(glasswaler)"
+```
+
+See [Lock Expressions](../guides/lock-expressions.md) for the full grammar.
+
 ### `exec`
 
 The function called on match. Receives `u: IUrsamuSDK` — the same SDK object
@@ -310,3 +327,25 @@ addCmd({
   },
 });
 ```
+---
+
+## Related Registrations
+
+Beyond `addCmd`, plugins can register several other engine extensions from
+`init()`:
+
+| API | Purpose |
+|-----|---------|
+| `registerPluginRoute(method, path, handler)` | Mount a REST handler on the main Express app |
+| `registerUIComponent(component)` | Surface a UI panel via `GET /api/v1/ui-manifest` |
+| `unregisterUIComponent(name)` | Remove a UI panel (call from `remove()`) |
+| `registerFormatHandler(slot, handler)` | TS-function format handler (NAMEFORMAT, DESCFORMAT, WHOFORMAT, etc.) |
+| `registerFormatTemplate(slot, mushSource)` | MUSH-softcode shortcut for format handlers (v2.4.0+) |
+| `registerLockFunc(name, fn)` | Custom lockfunc usable in `lock:` strings |
+| `registerSoftcodeFunc(name, fn)` | Custom stdlib function callable from softcode |
+| `registerScript(name, content)` | Override or add a sandbox script by name |
+
+Each of these has a corresponding teardown — `gameHooks.off`,
+`unregisterUIComponent`, `unregisterFormatHandler` — that should run in
+`remove()` so reload is clean. See [API: Core](../api/core.md) for full
+signatures.

--- a/docs/plugins/database.md
+++ b/docs/plugins/database.md
@@ -27,8 +27,11 @@ export interface IMyRecord {
   createdAt: number;   // ms timestamp
 }
 
-// The string key must be globally unique — prefix with "server." by convention
-export const myRecords = new DBO<IMyRecord>("server.my-plugin-records");
+// The collection key must be globally unique — prefix with your plugin name
+// (e.g. "my-plugin.records") so it cannot collide with engine collections or
+// other plugins. The legacy "server." prefix is reserved for core engine
+// collections like dbojs, counters, chans, mail, etc.
+export const myRecords = new DBO<IMyRecord>("my-plugin.records");
 ```
 
 Import the collection wherever you need it:

--- a/docs/plugins/first-plugin.md
+++ b/docs/plugins/first-plugin.md
@@ -209,7 +209,7 @@ deno task server
 
 ```bash
 # Get a token first
-TOKEN=$(curl -s -X POST http://localhost:4203/api/v1/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:4203/api/v1/auth \
   -H "Content-Type: application/json" \
   -d '{"name":"Admin","password":"yourpassword"}' | jq -r .token)
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -122,6 +122,26 @@ Fires when a player speaks on a channel.
 ```typescript
 gameHooks.on("channel:message", ({ channelName, senderId, senderName, message }) => {});
 ```
+
+### Object Events
+
+Fire when DBOs in the main `dbojs` collection are created, modified, or
+destroyed. Useful for cache invalidation, audit logs, or reacting to
+builder-plugin operations.
+
+```typescript
+gameHooks.on("object:created",   ({ id, obj }) => {});
+gameHooks.on("object:modified",  ({ id, before, after }) => {});
+gameHooks.on("object:destroyed", ({ id }) => {});
+```
+
+#### `mail:received`
+
+Fires when in-game mail is delivered to a recipient.
+
+```typescript
+gameHooks.on("mail:received", ({ recipientId, senderId, subject }) => {});
+```
 ---
 
 ### Scene Events

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -132,7 +132,6 @@ import "./commands.ts";
 | `u.send(msg)` | Send a message to the current player |
 | `u.broadcast(msg)` | Send a message to everyone in the room |
 | `u.db.search(query)` | Query the main object database |
-| `u.bb.*` | Bulletin board SDK |
 | `u.chan.*` | Channel SDK |
 | `u.events.*` | Pub/sub EventsService SDK |
 | `u.auth.*` | Auth SDK (hash, setPassword) |
@@ -345,3 +344,19 @@ The bundled plugins demonstrate every capability:
 | `src/plugins/example/` | Minimal template — commands, REST, database, config |
 | `src/plugins/jobs/` | Full CRUD REST API, staff permission checks, in-game commands with switches |
 | `src/plugins/events/` | Sequential IDs, RSVP capacity enforcement, cancelled-event visibility rules, REST + in-game commands |
+---
+
+## Plugin Docs Index
+
+| Page | Topic |
+|------|-------|
+| [basics.md](./basics.md) | `IPlugin` interface, lifecycle, auto-discovery, file layout |
+| [first-plugin.md](./first-plugin.md) | Step-by-step walkthrough of a complete plugin |
+| [commands.md](./commands.md) | `addCmd` reference, patterns, switches, lockfuncs |
+| [database.md](./database.md) | `DBO<T>` collections, queries, namespacing rules |
+| [configuration.md](./configuration.md) | Default config values, `getConfig`, env vars for secrets |
+| [hooks.md](./hooks.md) | `gameHooks` event bus, scene/wiki/event/chargen hooks, `EventsService` |
+| [dependencies.md](./dependencies.md) | Sharing code between plugins, `deps[]` manifest entries |
+| [official-plugins.md](./official-plugins.md) | Plugin registry — channel, discord, jobs, events, bbs, wiki, mail, builder, chargen, help |
+| [chargen.md](./chargen.md) | Bundled chargen plugin — commands, hooks, REST API |
+| [events.md](./events.md) | Bundled events plugin — calendar, RSVPs, REST API |


### PR DESCRIPTION
## Summary

Comprehensive docs audit + restructure across all 49 markdown files. Bumps references to v2.6.0, removes fabricated/dead APIs, surfaces v2.x additions that were missing, fixes broken cross-links and stale endpoint paths.

**Net: 32 files changed, +2024 / -2449 lines** — less invented content.

## What changed by section

### Top-level
- `README.md` — bumped to v2.6.0; themed feature blocks; updated `IPlugin` example; pre-commit checklist aligned with CI; production deployment reflects the v2.4.0 supervised scaffold.

### `docs/api/`
- **core.md**: TOC + grouped by concern. Added the format-handler family, lockfunc registry + `&&` / `||` / `!` operators, registerScript/Middleware/SoftcodeFunc/Sub, UI components, stat systems, `gameHooks` event list, full v2.5.1+ stdlib (Noise / Rng / physics / spatial / interpolation), `PluginInstallError` hierarchy. Removed `u.bb` / `u.mail` (no longer in SDK).
- **rest.md**: corrected from source. Auth path is `/api/v1/auth` (dispatch by suffix), not `/auth/login`. Removed invented mail/help/wiki/building engine routes (those are plugins). Documented scene `/export`, `/join`, `/invite`, `/locations`.

### `docs/guides/` (11 of 21 files touched)
- `lock-expressions.md` rewritten for v2.2.0 syntax + `registerLockFunc`
- `customization.md` gained Format Handlers section (8 slots, `registerFormatTemplate`)
- `sdk-cookbook.md` fixed missing `await` on `u.canEdit`; added `resolveFormat[Or]` / `resolveGlobalFormat[Or]` sections
- `index.md` rebuilt as full TOC of all 21 guides
- `installation.md`, `deployment.md`, `docker.md`, `admin-guide.md` updated for the v2.4.0 supervised scaffold (daemon.sh / restart.sh / SIGUSR2 / JWT_SECRET)
- `cli.md` gained `plugin search`, `scripts list`, v2.6.0 install-behavior note
- `commands.md` gained `@version` and `@poll`

### `docs/plugins/` (light pass — just touched in PR #150)
- `commands.md` — v2.2.0 lock operators + Related Registrations table
- `basics.md` — named-ref pairing, DBO namespace, stdlib re-exports callouts
- `hooks.md` — added missing `object:*` and `mail:received` events
- `database.md` — corrected namespace prefix rule
- `index.md` — full TOC

### `docs/development/`
- `index.md`, `contributing.md`, `testing.md` rewritten end-to-end to match CLAUDE.md surface and remove dead links.

### `docs/extending/` and `docs/child-games/`
- `extending/index.md`: **428 → 144 lines** — replaced fabricated APIs (`registerFlag`, `registerHook`, etc.) with the real registry surface from `mod.ts`.
- `child-games/index.md`: **336 → 122 lines** — removed invented Docker/examples flow; documented the actual CLI scaffold + supervised daemon scripts.

### Top-level docs
- `index.md`, `about.md`, `llms.md`, `mush_compatibility.md`, `configuration/index.md`, `docs/README.md` — bumped to v2.6.0; configuration rewritten from source to match real shape + `JWT_SECRET` env.

## Verification

- [x] `deno lint` clean across 374 files
- [x] `deno check --unstable-kv mod.ts` clean
- [x] Cross-link audit: 3 broken internal links found and fixed (`/plugins/`, `../mush_compatibility/`, `./user-guide`)
- [x] Auth endpoint path `/api/v1/auth` verified against `src/routes/authRouter.ts`

## Known follow-ups (not in this PR)

- `docs/guides/commands.md` still attributes some building commands to the external builder-plugin; several now have native `addCmd` registrations in `src/commands/`. Worth deciding whether to surface as "Native Builder Commands" or note the plugin-override relationship.
- `URSAMU_HTTP_PORT` / `URSAMU_TELNET_PORT` env vars in README weren't independently verified against `src/`.