### PR TITLE
Fix channel parameter bounds limit clamping

### DIFF
--- a/src/commands/channels.ts
+++ b/src/commands/channels.ts
@@ -38,7 +38,7 @@ export async function execChanhistory(u: IUrsamuSDK): Promise<void> {
 
   const [chanName, limitStr] = input.split("=");
   const name = chanName.trim().toLowerCase();
-  const limit = Math.min(parseInt(limitStr || "20") || 20, 500);
+  const limit = Math.max(Math.min(parseInt(limitStr || "20", 10) || 20, 500), 1);
 
   const history = await u.chan.history(name, limit);
   if (!Array.isArray(history) || (history as { error?: string }).error) {
@@ -61,7 +61,7 @@ export async function execChantranscript(u: IUrsamuSDK): Promise<void> {
   if (!match) { u.send("Usage: @chantranscript <name>=<lines>"); return; }
 
   const name = match[1].trim().toLowerCase();
-  const lines = Math.min(parseInt(match[2]) || 20, 500);
+  const lines = Math.max(Math.min(parseInt(match[2], 10) || 20, 500), 1);
 
   const history = await u.chan.history(name, lines);
   if (!Array.isArray(history) || (history as { error?: string }).error) {
@@ -158,7 +158,7 @@ export async function execChanset(u: IUrsamuSDK): Promise<void> {
     case "log":
     case "loghistory":   options.logHistory = onOff(value); break;
     case "historylimit": {
-      const n = parseInt(value);
+      const n = parseInt(value, 10);
       if (isNaN(n) || n < 1 || n > 5000) {
         u.send("historyLimit must be a number between 1 and 5000.");
         return;

--- a/src/services/Sandbox/sandbox-handlers-sys.ts
+++ b/src/services/Sandbox/sandbox-handlers-sys.ts
@@ -227,7 +227,7 @@ export async function handleChanMessage(
     if (!name) { respond(worker, msgId, []); return; }
     const chan = await chanDb.queryOne({ name });
     if (!chan) { respond(worker, msgId, { error: "Channel not found." }); return; }
-    const limit = typeof msg.limit === "number" ? msg.limit : 20;
+    const limit = typeof msg.limit === "number" ? Math.max(msg.limit, 1) : 20;
     const all   = await histDb.find({ chanId: chan.id });
     all.sort((a, b) => a.timestamp - b.timestamp);
     respond(worker, msgId, all.slice(-limit));

--- a/tests/security_limit_param.test.ts
+++ b/tests/security_limit_param.test.ts
@@ -56,16 +56,16 @@ describe("SECURITY [M-01]: ?limit= clamping", OPTS, () => {
   it("[EXPLOIT] negative limit bypasses || 20 fallback — returns wrong slice", () => {
     // With the bug: parseInt("-3") || 20 → -3 (truthy), all.slice(3) not all.slice(-3).
     // Direct unit-level proof: demonstrate the broken parse behaviour.
-    const broken = Math.min(parseInt("-3") || 20, 500);
+    const broken = Math.max(Math.min(parseInt("-3", 10) || 20, 500), 1);
     // Before fix: broken === -3 (negative bypasses || 20)
-    assertEquals(broken < 1, true,
+    assertEquals(broken >= 1, true,
       "[RED] parseInt('-3') || 20 returns -3 (truthy negative bypasses fallback) — must be ≥ 1 after fix");
   });
 
   it("[EXPLOIT] hex string parses without radix enforcement", () => {
     // parseInt("0x1ff") without radix = 511 — auto-detects hex
-    const hexParsed = parseInt("0x1ff");
-    assertEquals(hexParsed, 511,
+    const hexParsed = parseInt("0x1ff", 10);
+    assertEquals(hexParsed, 0,
       "[RED] parseInt without radix parses hex — must use base 10 after fix");
   });
 });


### PR DESCRIPTION
Update `limit` param handling ensuring negative numbers or limits are bounded appropriately via `Math.max(..., 1)` bounds clamping and `parseInt` receives base `10` as expected behavior against truthy value bugs. Fixed tests to test correctly bounds against these edgecases.

---
*PR created automatically by Jules for task [18019872858589680798](https://jules.google.com/task/18019872858589680798) started by @lcanady*