### PR TITLE
fix: resolve circular self-imports in mush package

### DIFF
--- a/packages/mush/src/routes/config.ts
+++ b/packages/mush/src/routes/config.ts
@@ -10,7 +10,7 @@
 
 import { resolve, join } from "@std/path";
 import { getAllConfig }   from "@ursamu/core";
-import { texts }         from "@ursamu/mush";
+import { texts }         from "../world/dbobjs.ts";
 
 export async function configHandler(req: Request): Promise<Response> {
   const url  = new URL(req.url);

--- a/packages/mush/src/routes/dbobj.ts
+++ b/packages/mush/src/routes/dbobj.ts
@@ -8,7 +8,8 @@
  */
 
 import type { IDBOBJ } from "../world/types.ts";
-import { dbojs, flags, Obj } from "@ursamu/mush";
+import { dbojs, Obj } from "../world/dbobjs.ts";
+import { flags } from "../world/flags.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/packages/mush/src/routes/objects.ts
+++ b/packages/mush/src/routes/objects.ts
@@ -22,7 +22,8 @@
 
 import type { IDBOBJ }    from "../world/types.ts";
 import type { IAttribute } from "../world/types.ts";
-import { dbojs, flags }   from "@ursamu/mush";
+import { dbojs } from "../world/dbobjs.ts";
+import { flags } from "../world/flags.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -290,7 +291,7 @@ async function evalRoute(req: Request, userId: string, target: IDBOBJ): Promise<
   if (!code) return json({ error: "code is required" }, 400);
 
   try {
-    const { runSoftcodeSimple } = await import("@ursamu/mush");
+    const { runSoftcodeSimple } = await import("../softcode/engine.ts");
     const result = await runSoftcodeSimple(code, {
       actorId:    userId,
       executorId: target.id,

--- a/packages/mush/src/routes/players.ts
+++ b/packages/mush/src/routes/players.ts
@@ -8,7 +8,7 @@
  *   GET /api/v1/channels/:id/history        — channel message history (auth required)
  */
 
-import { dbojs, chans, chanHistory, Obj } from "@ursamu/mush";
+import { dbojs, chans, chanHistory, Obj } from "../world/dbobjs.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/packages/mush/src/routes/scenes.ts
+++ b/packages/mush/src/routes/scenes.ts
@@ -14,8 +14,9 @@
  *   PATCH  /api/v1/scenes/:id         — update scene metadata / status
  */
 
-import { dbojs, scenes, Obj, evaluateLock, hydrate, gameHooks } from "@ursamu/mush";
-import { send } from "@ursamu/core";
+import { dbojs, scenes, Obj, hydrate } from "../world/dbobjs.ts";
+import { evaluateLock } from "../world/locks.ts";
+import { send, gameHooks } from "@ursamu/core";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -123,7 +124,7 @@ export async function sceneHandler(req: Request, userId: string): Promise<Respon
     const user = await Obj.get(userId);
     if (!user) return new Response("Unauthorized", { status: 401 });
 
-    const { counters } = await import("@ursamu/mush");
+    const { counters } = await import("../world/dbobjs.ts");
     const counter = await counters.queryOne({ id: "sceneid" });
     const id      = String((counter?.value ?? 0) + 1);
     await counters.modify({ id: "sceneid" }, "$set", { id: "sceneid", value: parseInt(id, 10) });

--- a/packages/mush/src/telnet.ts
+++ b/packages/mush/src/telnet.ts
@@ -1,6 +1,6 @@
 import { dirname, fromFileUrl, join } from "@std/path";
 import { getConfig, initConfig } from "@ursamu/core";
-import { parser } from "@ursamu/mush";
+import parser from "./render/parser.ts";
 import {
   IAC, WILL, DO, DONT, WONT, NAWS_OPTION,
   parseNawsBytes, stripIacBytes, accumulateNaws,


### PR DESCRIPTION
Replaces circular self-imports using @ursamu/mush inside packages/mush/src with relative paths (e.g. to dbobjs, flags, locks, etc.) to resolve LSP/type lookup errors.