### PR TITLE
🧪 add tests for checkApproved in mekton validation

### DIFF
--- a/packages/mekton/tests/mekton-zeta.test.ts
+++ b/packages/mekton/tests/mekton-zeta.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { rollInterlock, rollDamage } from "../roll.ts";
 import { derivedStats, skillPointsSpent, effectiveMA } from "../derived.ts";
-import { validateStat, validateSkillLevel, validateStatPool } from "../validation.ts";
+import { validateStat, validateSkillLevel, validateStatPool, checkApproved } from "../validation.ts";
 import { rollBasicLifepath, rollProfessionalEvent } from "../lifepath.ts";
 import { findGearByName, gearByCategory } from "../catalog.ts";
 import { findTemplate } from "../templates.ts";
@@ -167,6 +167,23 @@ describe("checkRequired", () => {
     const char = makeChar({ chargenStatus: "approved" });
     // approved chars are locked but checkRequired is for submit validation
     assertEquals(char.chargenStatus, "approved");
+  });
+});
+
+describe("checkApproved", () => {
+  it("returns true when chargenStatus is approved", () => {
+    const char = makeChar({ chargenStatus: "approved" });
+    assertEquals(checkApproved(char), true);
+  });
+
+  it("returns false when chargenStatus is draft", () => {
+    const char = makeChar({ chargenStatus: "draft" });
+    assertEquals(checkApproved(char), false);
+  });
+
+  it("returns false when chargenStatus is submitted", () => {
+    const char = makeChar({ chargenStatus: "submitted" });
+    assertEquals(checkApproved(char), false);
   });
 });
 


### PR DESCRIPTION
🎯 **What:** The testing gap for the `checkApproved` function in `packages/mekton/validation.ts` has been addressed.

📊 **Coverage:** The tests now cover scenarios where `chargenStatus` is `"approved"` (expecting `true`) as well as boundary cases like `"draft"` and `"submitted"` (expecting `false`). The mock character factory function (`makeChar`) was leveraged for consistent setups.

✨ **Result:** Improved test coverage for character state validation, ensuring `checkApproved` correctly identifies approved character sheets. This provides a safety net against regressions if character generation status options change in the future.

---
*PR created automatically by Jules for task [5818789535580781505](https://jules.google.com/task/5818789535580781505) started by @lcanady*