### PR TITLE
🧪 Add tests for formatQualifier

### DIFF
--- a/packages/cofd/tests/merit_qualifiers.test.ts
+++ b/packages/cofd/tests/merit_qualifiers.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "@std/testing/bdd";
 import {
   parseMeritRef,
   formatMeritLabel,
+  formatQualifier,
   splitMeritStorageKey,
 } from "../src/dictionary/merits.ts";
 import { defaultSheet } from "../src/stats/sheet.ts";
@@ -37,6 +38,21 @@ describe("parseMeritRef", () => {
     assertEquals(r.merit, "giant");
     assertEquals(r.qualifier, "");
     assertEquals(r.storageKey, "giant");
+  });
+});
+
+describe("formatQualifier", () => {
+  it("returns empty string for empty input", () => {
+    assertEquals(formatQualifier(""), "");
+  });
+
+  it("title-cases a single word", () => {
+    assertEquals(formatQualifier("spanish"), "Spanish");
+  });
+
+  it("title-cases and replaces hyphens with spaces for multi-word slugs", () => {
+    assertEquals(formatQualifier("black-market"), "Black Market");
+    assertEquals(formatQualifier("very-black-market"), "Very Black Market");
   });
 });
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing unit tests for the pure string manipulation function `formatQualifier` in `packages/cofd/src/dictionary/merits.ts`.
📊 **Coverage:** What scenarios are now tested: Empty string inputs, single-word inputs (e.g., 'spanish'), and multi-word hyphenated slug inputs (e.g., 'black-market').
✨ **Result:** The improvement in test coverage: Increased confidence in the string formatting utility for merits, allowing for safe refactoring.

---
*PR created automatically by Jules for task [5517301776920673002](https://jules.google.com/task/5517301776920673002) started by @lcanady*