### PR TITLE
🧪 test: add missing unit tests for trunc function

### DIFF
--- a/packages/cofd/tests/format.test.ts
+++ b/packages/cofd/tests/format.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { trunc } from "../src/support/format.ts";
+
+describe("format support: trunc", () => {
+  it("returns the string unchanged if shorter than width", () => {
+    assertEquals(trunc("abc", 5), "abc");
+  });
+
+  it("returns the string unchanged if equal to width", () => {
+    assertEquals(trunc("abc", 3), "abc");
+  });
+
+  it("truncates and appends '..' if longer than width", () => {
+    assertEquals(trunc("abcdef", 4), "ab..");
+    assertEquals(trunc("hello world", 7), "hello..");
+  });
+
+  it("truncates without '..' if width is 2 or less", () => {
+    assertEquals(trunc("abc", 2), "ab");
+    assertEquals(trunc("abc", 1), "a");
+    assertEquals(trunc("abc", 0), "");
+  });
+
+  it("handles null and undefined gracefully", () => {
+    assertEquals(trunc(null, 5), "");
+    assertEquals(trunc(undefined, 5), "");
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `trunc` function located in `packages/cofd/src/support/format.ts`.
📊 **Coverage:** Covered all logical branches of the `trunc` function:
   - Happy paths (strings shorter than or equal to desired width returned unchanged).
   - Longer strings are truncated with `..` appended.
   - Small widths (<= 2) are correctly truncated without `..` appended.
   - Null and undefined handling graceful returns.
✨ **Result:** Increased codebase reliability and testing coverage for a utility string format helper, allowing for confident future refactoring.

---
*PR created automatically by Jules for task [13881155859736783341](https://jules.google.com/task/13881155859736783341) started by @lcanady*