### PR TITLE
⚡ Optimize N+1 query in event listing

### DIFF
--- a/packages/events/src/commands.ts
+++ b/packages/events/src/commands.ts
@@ -1,28 +1,42 @@
 import { addCmd, dbojs } from "@ursamu/mush";
 import type { IUrsamuSDK } from "@ursamu/mush";
-import { gameEvents, eventRsvps, getNextEventNumber, parseDateTime, formatDateTime } from "./db.ts";
-import type { IGameEvent, IEventRSVP } from "./types.ts";
+import {
+  eventRsvps,
+  formatDateTime,
+  gameEvents,
+  getNextEventNumber,
+  parseDateTime,
+} from "./db.ts";
+import type { IEventRSVP, IGameEvent } from "./types.ts";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 function isStaff(u: IUrsamuSDK): boolean {
-  return u.me.flags.has("admin") || u.me.flags.has("wizard") || u.me.flags.has("superuser");
+  return u.me.flags.has("admin") || u.me.flags.has("wizard") ||
+    u.me.flags.has("superuser");
 }
 
 function statusColor(s: IGameEvent["status"]): string {
   switch (s) {
-    case "upcoming":  return "%ch%cg";
-    case "active":    return "%ch%cy";
-    case "completed": return "%cn";
-    case "cancelled": return "%ch%cr";
+    case "upcoming":
+      return "%ch%cg";
+    case "active":
+      return "%ch%cy";
+    case "completed":
+      return "%cn";
+    case "cancelled":
+      return "%ch%cr";
   }
 }
 
 function rsvpColor(s: IEventRSVP["status"]): string {
   switch (s) {
-    case "attending": return "%ch%cg";
-    case "maybe":     return "%cy";
-    case "declined":  return "%cr";
+    case "attending":
+      return "%ch%cg";
+    case "maybe":
+      return "%cy";
+    case "declined":
+      return "%cr";
   }
 }
 
@@ -42,7 +56,8 @@ addCmd({
   pattern: /^\+event(?:\/(\S+))?\s*(.*)/i,
   lock: "connected",
   category: "Social",
-  help: `+event[/<switch>] [<args>]  — In-game event calendar with RSVP tracking.
+  help:
+    `+event[/<switch>] [<args>]  — In-game event calendar with RSVP tracking.
 
 Switches (players):
   /list              List all upcoming events (default).
@@ -63,14 +78,14 @@ Examples:
   +event/rsvp 3                    RSVP attending to event #3.
   +event/create Summer Gala=2027-08-01/Annual summer gathering.`,
   exec: async (u: IUrsamuSDK) => {
-    const sw  = (u.cmd.args[0] || "").toLowerCase().trim();
+    const sw = (u.cmd.args[0] || "").toLowerCase().trim();
     const arg = (u.cmd.args[1] || "").trim();
 
     // ── list (default) ─────────────────────────────────────────────────────
     if (!sw || sw === "list") {
       const all = await gameEvents.find({});
       const visible = all
-        .filter(e => e.status !== "cancelled" || isStaff(u))
+        .filter((e) => e.status !== "cancelled" || isStaff(u))
         .sort((a, b) => a.startTime - b.startTime);
 
       if (!visible.length) {
@@ -81,25 +96,39 @@ Examples:
       u.send("%ch%cy+events%cn");
       u.send(
         "%ch" +
-        u.util.rjust("#", 4) + "  " +
-        u.util.ljust("Title", 28) +
-        u.util.ljust("Date", 20) +
-        u.util.rjust("RSVPs", 6) + "  " +
-        "Status" +
-        "%cn"
+          u.util.rjust("#", 4) + "  " +
+          u.util.ljust("Title", 28) +
+          u.util.ljust("Date", 20) +
+          u.util.rjust("RSVPs", 6) + "  " +
+          "Status" +
+          "%cn",
       );
       u.send("%ch" + "-".repeat(68) + "%cn");
 
+      const visibleIds = visible.map((e) => e.id);
+      const allRsvps = await eventRsvps.find({
+        eventId: { $in: visibleIds },
+        status: "attending",
+      });
+      const rsvpsByEventId = new Map<string, typeof allRsvps>();
+      for (const rsvp of allRsvps) {
+        const arr = rsvpsByEventId.get(rsvp.eventId) || [];
+        arr.push(rsvp);
+        rsvpsByEventId.set(rsvp.eventId, arr);
+      }
+
       for (const e of visible) {
-        const rsvps   = await eventRsvps.find({ eventId: e.id, status: "attending" });
-        const cap     = e.maxAttendees > 0 ? `${rsvps.length}/${e.maxAttendees}` : String(rsvps.length);
-        const sc      = statusColor(e.status);
+        const rsvps = rsvpsByEventId.get(e.id) || [];
+        const cap = e.maxAttendees > 0
+          ? `${rsvps.length}/${e.maxAttendees}`
+          : String(rsvps.length);
+        const sc = statusColor(e.status);
         u.send(
           u.util.rjust(String(e.number), 4) + "  " +
-          u.util.ljust(e.title.slice(0, 27), 28) +
-          u.util.ljust(formatDateTime(e.startTime), 20) +
-          u.util.rjust(cap, 6) + "  " +
-          sc + e.status + "%cn"
+            u.util.ljust(e.title.slice(0, 27), 28) +
+            u.util.ljust(formatDateTime(e.startTime), 20) +
+            u.util.rjust(cap, 6) + "  " +
+            sc + e.status + "%cn",
         );
       }
       u.send('Use "+event/view <#>" to see details and RSVP.');
@@ -109,79 +138,138 @@ Examples:
     // ── view <#> ───────────────────────────────────────────────────────────
     if (sw === "view") {
       const num = parseInt(arg, 10);
-      if (isNaN(num)) { u.send("Usage: +event/view <#>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/view <#>");
+        return;
+      }
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
       const sc = statusColor(ev.status);
       u.send(`%ch%cy+event #${ev.number}:%cn ${ev.title}`);
       u.send(`  Status  : ${sc}${ev.status}%cn`);
-      u.send(`  Date    : ${formatDateTime(ev.startTime)}${ev.endTime ? " → " + formatDateTime(ev.endTime) : ""}`);
+      u.send(
+        `  Date    : ${formatDateTime(ev.startTime)}${
+          ev.endTime ? " → " + formatDateTime(ev.endTime) : ""
+        }`,
+      );
       if (ev.location) u.send(`  Where   : ${ev.location}`);
       if (ev.tags.length) u.send(`  Tags    : ${ev.tags.join(", ")}`);
       u.send(`  Host    : ${ev.createdByName}`);
       u.send(`  Desc    : ${ev.description}`);
 
-      const attending = await eventRsvps.find({ eventId: ev.id, status: "attending" });
-      const maybe     = await eventRsvps.find({ eventId: ev.id, status: "maybe" });
-      const cap       = ev.maxAttendees > 0 ? `/${ev.maxAttendees}` : "";
+      const attending = await eventRsvps.find({
+        eventId: ev.id,
+        status: "attending",
+      });
+      const maybe = await eventRsvps.find({ eventId: ev.id, status: "maybe" });
+      const cap = ev.maxAttendees > 0 ? `/${ev.maxAttendees}` : "";
 
-      u.send(`%ch  RSVPs:%cn ${attending.length}${cap} attending, ${maybe.length} maybe`);
-      if (attending.length) u.send(`    Attending: ${attending.map(r => r.playerName).join(", ")}`);
-      if (maybe.length)     u.send(`    Maybe    : ${maybe.map(r => r.playerName).join(", ")}`);
+      u.send(
+        `%ch  RSVPs:%cn ${attending.length}${cap} attending, ${maybe.length} maybe`,
+      );
+      if (attending.length) {
+        u.send(
+          `    Attending: ${attending.map((r) => r.playerName).join(", ")}`,
+        );
+      }
+      if (maybe.length) {
+        u.send(`    Maybe    : ${maybe.map((r) => r.playerName).join(", ")}`);
+      }
 
-      const myRsvp = await eventRsvps.queryOne({ eventId: ev.id, playerId: u.me.id });
+      const myRsvp = await eventRsvps.queryOne({
+        eventId: ev.id,
+        playerId: u.me.id,
+      });
       if (myRsvp) {
         u.send(`  Your RSVP: ${rsvpColor(myRsvp.status)}${myRsvp.status}%cn`);
       } else {
-        u.send('  Use "+event/rsvp <#>" to RSVP, "+event/rsvp <#>=maybe" for maybe.');
+        u.send(
+          '  Use "+event/rsvp <#>" to RSVP, "+event/rsvp <#>=maybe" for maybe.',
+        );
       }
       return;
     }
 
     // ── rsvp <#>[=maybe|decline] ───────────────────────────────────────────
     if (sw === "rsvp") {
-      const eqIdx  = arg.indexOf("=");
+      const eqIdx = arg.indexOf("=");
       const numStr = eqIdx !== -1 ? arg.slice(0, eqIdx).trim() : arg;
-      const choice = (eqIdx !== -1 ? arg.slice(eqIdx + 1).trim() : "attending").toLowerCase();
-      const num    = parseInt(numStr, 10);
+      const choice = (eqIdx !== -1 ? arg.slice(eqIdx + 1).trim() : "attending")
+        .toLowerCase();
+      const num = parseInt(numStr, 10);
 
-      if (isNaN(num)) { u.send("Usage: +event/rsvp <#>[=attending|maybe|decline]"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/rsvp <#>[=attending|maybe|decline]");
+        return;
+      }
       if (!["attending", "maybe", "declined", "decline"].includes(choice)) {
         u.send("RSVP status must be: attending, maybe, or decline");
         return;
       }
-      const status = (choice === "decline" ? "declined" : choice) as IEventRSVP["status"];
+      const status =
+        (choice === "decline" ? "declined" : choice) as IEventRSVP["status"];
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
-      if (ev.status === "cancelled") { u.send("%ch+event:%cn That event has been cancelled."); return; }
-      if (ev.status === "completed") { u.send("%ch+event:%cn That event has already occurred."); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
+      if (ev.status === "cancelled") {
+        u.send("%ch+event:%cn That event has been cancelled.");
+        return;
+      }
+      if (ev.status === "completed") {
+        u.send("%ch+event:%cn That event has already occurred.");
+        return;
+      }
 
       if (status === "attending" && ev.maxAttendees > 0) {
-        const attending = await eventRsvps.find({ eventId: ev.id, status: "attending" });
-        const myRsvp    = await eventRsvps.queryOne({ eventId: ev.id, playerId: u.me.id });
+        const attending = await eventRsvps.find({
+          eventId: ev.id,
+          status: "attending",
+        });
+        const myRsvp = await eventRsvps.queryOne({
+          eventId: ev.id,
+          playerId: u.me.id,
+        });
         const alreadyAttending = myRsvp?.status === "attending";
         if (!alreadyAttending && attending.length >= ev.maxAttendees) {
-          u.send(`%ch+event:%cn Sorry, event #${num} is full (${ev.maxAttendees}/${ev.maxAttendees}).`);
+          u.send(
+            `%ch+event:%cn Sorry, event #${num} is full (${ev.maxAttendees}/${ev.maxAttendees}).`,
+          );
           return;
         }
       }
 
-      const existing = await eventRsvps.queryOne({ eventId: ev.id, playerId: u.me.id });
+      const existing = await eventRsvps.queryOne({
+        eventId: ev.id,
+        playerId: u.me.id,
+      });
       if (existing) {
         await eventRsvps.update({ id: existing.id }, { ...existing, status });
-        u.send(`%ch+event:%cn RSVP updated to ${rsvpColor(status)}${status}%cn for "${ev.title}".`);
+        u.send(
+          `%ch+event:%cn RSVP updated to ${
+            rsvpColor(status)
+          }${status}%cn for "${ev.title}".`,
+        );
       } else {
         await eventRsvps.create({
-          id:         crypto.randomUUID(),
-          eventId:    ev.id,
-          playerId:   u.me.id,
+          id: crypto.randomUUID(),
+          eventId: ev.id,
+          playerId: u.me.id,
           playerName: await getPlayerName(u.me.id),
           status,
-          createdAt:  Date.now(),
+          createdAt: Date.now(),
         });
-        u.send(`%ch+event:%cn RSVP'd ${rsvpColor(status)}${status}%cn for "${ev.title}".`);
+        u.send(
+          `%ch+event:%cn RSVP'd ${
+            rsvpColor(status)
+          }${status}%cn for "${ev.title}".`,
+        );
       }
       return;
     }
@@ -189,13 +277,25 @@ Examples:
     // ── unrsvp <#> ─────────────────────────────────────────────────────────
     if (sw === "unrsvp") {
       const num = parseInt(arg, 10);
-      if (isNaN(num)) { u.send("Usage: +event/unrsvp <#>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/unrsvp <#>");
+        return;
+      }
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
-      const existing = await eventRsvps.queryOne({ eventId: ev.id, playerId: u.me.id });
-      if (!existing) { u.send("%ch+event:%cn You have no RSVP to cancel."); return; }
+      const existing = await eventRsvps.queryOne({
+        eventId: ev.id,
+        playerId: u.me.id,
+      });
+      if (!existing) {
+        u.send("%ch+event:%cn You have no RSVP to cancel.");
+        return;
+      }
 
       await eventRsvps.delete({ id: existing.id });
       u.send(`%ch+event:%cn RSVP cancelled for "${ev.title}".`);
@@ -204,7 +304,10 @@ Examples:
 
     // ── create (staff) ────────────────────────────────────────────────────
     if (sw === "create") {
-      if (!isStaff(u)) { u.send("%ch+event:%cn Permission denied."); return; }
+      if (!isStaff(u)) {
+        u.send("%ch+event:%cn Permission denied.");
+        return;
+      }
 
       const eqIdx = arg.indexOf("=");
       if (eqIdx === -1) {
@@ -212,14 +315,14 @@ Examples:
         return;
       }
       const title = arg.slice(0, eqIdx).trim();
-      const rest  = arg.slice(eqIdx + 1);
+      const rest = arg.slice(eqIdx + 1);
       const slash = rest.indexOf("/");
       if (slash === -1) {
         u.send("Usage: +event/create <title>=<YYYY-MM-DD HH:MM>/<description>");
         return;
       }
       const dateStr = rest.slice(0, slash).trim();
-      const desc    = rest.slice(slash + 1).trim();
+      const desc = rest.slice(slash + 1).trim();
 
       if (!title || !desc) {
         u.send("Usage: +event/create <title>=<YYYY-MM-DD HH:MM>/<description>");
@@ -228,80 +331,114 @@ Examples:
 
       const startTime = parseDateTime(dateStr);
       if (!startTime) {
-        u.send(`%ch+event:%cn Invalid date "${dateStr}". Use format: YYYY-MM-DD or YYYY-MM-DD HH:MM`);
+        u.send(
+          `%ch+event:%cn Invalid date "${dateStr}". Use format: YYYY-MM-DD or YYYY-MM-DD HH:MM`,
+        );
         return;
       }
 
       const num = await getNextEventNumber();
       const now = Date.now();
       const ev: IGameEvent = {
-        id:            `ev-${num}`,
-        number:        num,
+        id: `ev-${num}`,
+        number: num,
         title,
-        description:   desc,
+        description: desc,
         startTime,
-        createdBy:     u.me.id,
+        createdBy: u.me.id,
         createdByName: u.me.name || u.me.id,
-        status:        "upcoming",
-        tags:          [],
-        maxAttendees:  0,
-        createdAt:     now,
-        updatedAt:     now,
+        status: "upcoming",
+        tags: [],
+        maxAttendees: 0,
+        createdAt: now,
+        updatedAt: now,
       };
 
       await gameEvents.create(ev);
-      u.send(`%ch+event:%cn Event #${num} "${title}" created for ${formatDateTime(startTime)}.`);
+      u.send(
+        `%ch+event:%cn Event #${num} "${title}" created for ${
+          formatDateTime(startTime)
+        }.`,
+      );
       return;
     }
 
     // ── edit <#>/<field>=<value> (staff) ──────────────────────────────────
     if (sw === "edit") {
-      if (!isStaff(u)) { u.send("%ch+event:%cn Permission denied."); return; }
+      if (!isStaff(u)) {
+        u.send("%ch+event:%cn Permission denied.");
+        return;
+      }
 
       const slash = arg.indexOf("/");
-      const eq    = arg.indexOf("=");
+      const eq = arg.indexOf("=");
       if (slash === -1 || eq === -1 || eq < slash) {
         u.send("Usage: +event/edit <#>/<field>=<value>");
         return;
       }
 
-      const num   = parseInt(arg.slice(0, slash).trim(), 10);
+      const num = parseInt(arg.slice(0, slash).trim(), 10);
       const field = arg.slice(slash + 1, eq).trim().toLowerCase();
       const value = arg.slice(eq + 1).trim();
-      if (isNaN(num)) { u.send("Usage: +event/edit <#>/<field>=<value>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/edit <#>/<field>=<value>");
+        return;
+      }
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
       const update: Partial<IGameEvent> = { updatedAt: Date.now() };
 
       switch (field) {
-        case "title":        update.title       = value; break;
-        case "description":  update.description = value; break;
-        case "location":     update.location    = value; break;
+        case "title":
+          update.title = value;
+          break;
+        case "description":
+          update.description = value;
+          break;
+        case "location":
+          update.location = value;
+          break;
         case "starttime": {
           const t = parseDateTime(value);
-          if (!t) { u.send(`%ch+event:%cn Invalid date "${value}".`); return; }
+          if (!t) {
+            u.send(`%ch+event:%cn Invalid date "${value}".`);
+            return;
+          }
           update.startTime = t;
           break;
         }
         case "endtime": {
           const t = parseDateTime(value);
-          if (!t) { u.send(`%ch+event:%cn Invalid date "${value}".`); return; }
+          if (!t) {
+            u.send(`%ch+event:%cn Invalid date "${value}".`);
+            return;
+          }
           update.endTime = t;
           break;
         }
         case "maxattendees": {
           const n = parseInt(value, 10);
-          if (isNaN(n) || n < 0) { u.send("%ch+event:%cn maxattendees must be a non-negative integer."); return; }
+          if (isNaN(n) || n < 0) {
+            u.send(
+              "%ch+event:%cn maxattendees must be a non-negative integer.",
+            );
+            return;
+          }
           update.maxAttendees = n;
           break;
         }
         case "tags":
-          update.tags = value.split(",").map(t => t.trim()).filter(Boolean);
+          update.tags = value.split(",").map((t) => t.trim()).filter(Boolean);
           break;
         default:
-          u.send(`%ch+event:%cn Unknown field "${field}". Valid: title, description, location, starttime, endtime, maxattendees, tags`);
+          u.send(
+            `%ch+event:%cn Unknown field "${field}". Valid: title, description, location, starttime, endtime, maxattendees, tags`,
+          );
           return;
       }
 
@@ -312,49 +449,96 @@ Examples:
 
     // ── status <#>=<status> (staff) ───────────────────────────────────────
     if (sw === "status") {
-      if (!isStaff(u)) { u.send("%ch+event:%cn Permission denied."); return; }
+      if (!isStaff(u)) {
+        u.send("%ch+event:%cn Permission denied.");
+        return;
+      }
 
-      const eqIdx  = arg.indexOf("=");
-      if (eqIdx === -1) { u.send("Usage: +event/status <#>=<upcoming|active|completed|cancelled>"); return; }
-      const num    = parseInt(arg.slice(0, eqIdx).trim(), 10);
-      const status = arg.slice(eqIdx + 1).trim().toLowerCase() as IGameEvent["status"];
+      const eqIdx = arg.indexOf("=");
+      if (eqIdx === -1) {
+        u.send(
+          "Usage: +event/status <#>=<upcoming|active|completed|cancelled>",
+        );
+        return;
+      }
+      const num = parseInt(arg.slice(0, eqIdx).trim(), 10);
+      const status = arg.slice(eqIdx + 1).trim()
+        .toLowerCase() as IGameEvent["status"];
 
-      if (isNaN(num)) { u.send("Usage: +event/status <#>=<status>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/status <#>=<status>");
+        return;
+      }
       if (!["upcoming", "active", "completed", "cancelled"].includes(status)) {
         u.send("Status must be: upcoming, active, completed, cancelled");
         return;
       }
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
-      await gameEvents.update({ id: ev.id }, { ...ev, status, updatedAt: Date.now() });
-      u.send(`%ch+event:%cn Event #${num} status set to ${statusColor(status)}${status}%cn.`);
+      await gameEvents.update({ id: ev.id }, {
+        ...ev,
+        status,
+        updatedAt: Date.now(),
+      });
+      u.send(
+        `%ch+event:%cn Event #${num} status set to ${
+          statusColor(status)
+        }${status}%cn.`,
+      );
       return;
     }
 
     // ── cancel <#> (staff) ────────────────────────────────────────────────
     if (sw === "cancel") {
-      if (!isStaff(u)) { u.send("%ch+event:%cn Permission denied."); return; }
+      if (!isStaff(u)) {
+        u.send("%ch+event:%cn Permission denied.");
+        return;
+      }
       const num = parseInt(arg, 10);
-      if (isNaN(num)) { u.send("Usage: +event/cancel <#>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/cancel <#>");
+        return;
+      }
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
-      await gameEvents.update({ id: ev.id }, { ...ev, status: "cancelled", updatedAt: Date.now() });
-      u.send(`%ch+event:%cn Event #${num} "${ev.title}" has been %ch%crcancelled%cn.`);
+      await gameEvents.update({ id: ev.id }, {
+        ...ev,
+        status: "cancelled",
+        updatedAt: Date.now(),
+      });
+      u.send(
+        `%ch+event:%cn Event #${num} "${ev.title}" has been %ch%crcancelled%cn.`,
+      );
       return;
     }
 
     // ── delete <#> (staff) ────────────────────────────────────────────────
     if (sw === "delete") {
-      if (!isStaff(u)) { u.send("%ch+event:%cn Permission denied."); return; }
+      if (!isStaff(u)) {
+        u.send("%ch+event:%cn Permission denied.");
+        return;
+      }
       const num = parseInt(arg, 10);
-      if (isNaN(num)) { u.send("Usage: +event/delete <#>"); return; }
+      if (isNaN(num)) {
+        u.send("Usage: +event/delete <#>");
+        return;
+      }
 
       const ev = await getEventByNumber(num);
-      if (!ev) { u.send(`%ch+event:%cn No event #${num} found.`); return; }
+      if (!ev) {
+        u.send(`%ch+event:%cn No event #${num} found.`);
+        return;
+      }
 
       await gameEvents.delete({ id: ev.id });
       await eventRsvps.delete({ eventId: ev.id });
@@ -365,7 +549,9 @@ Examples:
     // ── help ──────────────────────────────────────────────────────────────
     u.send("%ch+event usage:%cn");
     u.send("  +event [/list]                           — list upcoming events");
-    u.send("  +event/view <#>                          — event details + RSVPs");
+    u.send(
+      "  +event/view <#>                          — event details + RSVPs",
+    );
     u.send("  +event/rsvp <#>[=attending|maybe|decline] — RSVP");
     u.send("  +event/unrsvp <#>                        — cancel RSVP");
     if (isStaff(u)) {
@@ -392,32 +578,52 @@ Examples:
   exec: async (u: IUrsamuSDK) => {
     const all = await gameEvents.find({});
     const visible = all
-      .filter(e => e.status !== "cancelled" || u.me.flags.has("admin") || u.me.flags.has("wizard") || u.me.flags.has("superuser"))
+      .filter((e) =>
+        e.status !== "cancelled" || u.me.flags.has("admin") ||
+        u.me.flags.has("wizard") || u.me.flags.has("superuser")
+      )
       .sort((a, b) => a.startTime - b.startTime);
 
-    if (!visible.length) { u.send("%ch+events:%cn No upcoming events."); return; }
+    if (!visible.length) {
+      u.send("%ch+events:%cn No upcoming events.");
+      return;
+    }
 
     u.send("%ch%cy+events%cn");
     u.send(
       "%ch" +
-      u.util.rjust("#", 4) + "  " +
-      u.util.ljust("Title", 28) +
-      u.util.ljust("Date", 20) +
-      u.util.rjust("RSVPs", 6) + "  " +
-      "Status%cn"
+        u.util.rjust("#", 4) + "  " +
+        u.util.ljust("Title", 28) +
+        u.util.ljust("Date", 20) +
+        u.util.rjust("RSVPs", 6) + "  " +
+        "Status%cn",
     );
     u.send("%ch" + "-".repeat(68) + "%cn");
 
+    const visibleIds = visible.map((e) => e.id);
+    const allRsvps = await eventRsvps.find({
+      eventId: { $in: visibleIds },
+      status: "attending",
+    });
+    const rsvpsByEventId = new Map<string, typeof allRsvps>();
+    for (const rsvp of allRsvps) {
+      const arr = rsvpsByEventId.get(rsvp.eventId) || [];
+      arr.push(rsvp);
+      rsvpsByEventId.set(rsvp.eventId, arr);
+    }
+
     for (const e of visible) {
-      const rsvps = await eventRsvps.find({ eventId: e.id, status: "attending" });
-      const cap   = e.maxAttendees > 0 ? `${rsvps.length}/${e.maxAttendees}` : String(rsvps.length);
-      const sc    = statusColor(e.status);
+      const rsvps = rsvpsByEventId.get(e.id) || [];
+      const cap = e.maxAttendees > 0
+        ? `${rsvps.length}/${e.maxAttendees}`
+        : String(rsvps.length);
+      const sc = statusColor(e.status);
       u.send(
         u.util.rjust(String(e.number), 4) + "  " +
-        u.util.ljust(e.title.slice(0, 27), 28) +
-        u.util.ljust(formatDateTime(e.startTime), 20) +
-        u.util.rjust(cap, 6) + "  " +
-        sc + e.status + "%cn"
+          u.util.ljust(e.title.slice(0, 27), 28) +
+          u.util.ljust(formatDateTime(e.startTime), 20) +
+          u.util.rjust(cap, 6) + "  " +
+          sc + e.status + "%cn",
       );
     }
     u.send('Use "+event/view <#>" for details.');

--- a/packages/events/tests/benchmark.ts
+++ b/packages/events/tests/benchmark.ts
@@ -1,0 +1,80 @@
+import { eventRsvps, gameEvents } from "../src/db.ts";
+import type { IGameEvent } from "../src/types.ts";
+
+async function runBenchmark() {
+  console.log("Setting up data...");
+  await gameEvents.clear();
+  await eventRsvps.clear();
+
+  const numEvents = 100;
+  const numRsvpsPerEvent = 10;
+
+  const events: IGameEvent[] = [];
+
+  for (let i = 0; i < numEvents; i++) {
+    const ev: IGameEvent = {
+        id: `ev-${i}`,
+        number: i,
+        title: `Test Event ${i}`,
+        description: `This is a test event ${i}`,
+        startTime: Date.now() + 1000 * 60 * 60 * 24 * i,
+        createdBy: "player-1",
+        createdByName: "Player 1",
+        status: "upcoming",
+        tags: [],
+        maxAttendees: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+    };
+    await gameEvents.create(ev);
+    events.push(ev);
+
+    for (let j = 0; j < numRsvpsPerEvent; j++) {
+        await eventRsvps.create({
+            id: crypto.randomUUID(),
+            eventId: ev.id,
+            playerId: `player-${j}`,
+            playerName: `Player ${j}`,
+            status: "attending",
+            createdAt: Date.now()
+        });
+    }
+  }
+
+  const visible = events;
+  console.log(`Testing with ${numEvents} events and ${numRsvpsPerEvent} RSVPs each.`);
+
+  // Baseline: N+1
+  const startNPlus1 = performance.now();
+  for (const e of visible) {
+    const rsvps = await eventRsvps.find({ eventId: e.id, status: "attending" });
+  }
+  const endNPlus1 = performance.now();
+
+  // Optimization: 1 Query + In-Memory Grouping
+  const startOpt = performance.now();
+  const visibleIds = visible.map(e => e.id);
+  const allRsvps = await eventRsvps.find({ eventId: { $in: visibleIds }, status: "attending" });
+
+  const rsvpsByEventId = new Map<string, typeof allRsvps>();
+  for (const rsvp of allRsvps) {
+    const arr = rsvpsByEventId.get(rsvp.eventId) || [];
+    arr.push(rsvp);
+    rsvpsByEventId.set(rsvp.eventId, arr);
+  }
+
+  for (const e of visible) {
+    const rsvps = rsvpsByEventId.get(e.id) || [];
+  }
+  const endOpt = performance.now();
+
+  console.log(`N+1 time taken: ${(endNPlus1 - startNPlus1).toFixed(2)}ms`);
+  console.log(`Optimized time taken: ${(endOpt - startOpt).toFixed(2)}ms`);
+
+  console.log("Cleaning up data...");
+  await gameEvents.clear();
+  await eventRsvps.clear();
+
+}
+
+runBenchmark().then(() => Deno.exit(0));


### PR DESCRIPTION
💡 **What:** The optimization implemented replaces the N+1 query loops in `+event` (default list) and the `+events` alias with a single query using the `$in` operator and an in-memory `Map` to group RSVPs by `eventId`. A benchmark test has also been introduced.
🎯 **Why:** Previously, the commands fetched the RSVPs individually for every single visible event by iterating through a loop and awaiting a query for each. This created an N+1 scaling issue that severely degraded the command's responsiveness as the number of events grew.
📊 **Measured Improvement:** The new `packages/events/tests/benchmark.ts` script simulates 100 events each having 10 RSVPs. Testing this scenario shows an immense performance difference:
- Baseline N+1 approach: ~3114.29ms
- Optimized grouping approach: ~37.62ms
This change delivers roughly a 100x speed boost.

---
*PR created automatically by Jules for task [4282624569353937046](https://jules.google.com/task/4282624569353937046) started by @lcanady*