### PR TITLE
🧪 [Testing] Add edge case tests for parseNawsBytes

### DIFF
--- a/packages/core/tests/server/telnet.test.ts
+++ b/packages/core/tests/server/telnet.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { parseNawsBytes, IAC, SB, SE, NAWS_OPTION } from "../../src/server/telnet.ts";
+
+describe("parseNawsBytes", () => {
+  it("should parse valid NAWS bytes", () => {
+    // 80x24: IAC SB NAWS 0 80 0 24 IAC SE
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 80, 0, 24, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, { width: 80, height: 24 });
+  });
+
+  it("should return null for incomplete sequence (too short)", () => {
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 80, 0, 24, IAC]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for invalid start sequence", () => {
+    const bytes = new Uint8Array([255, 251, NAWS_OPTION, 0, 80, 0, 24, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for invalid end sequence", () => {
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 80, 0, 24, IAC, 255]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for width too small", () => {
+    // Width 39
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 39, 0, 24, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for width too large", () => {
+    // Width 251
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 251, 0, 24, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for height too small", () => {
+    // Height 0
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 80, 0, 0, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+
+  it("should return null for height too large", () => {
+    // Height 256
+    const bytes = new Uint8Array([IAC, SB, NAWS_OPTION, 0, 80, 1, 0, IAC, SE]);
+    const result = parseNawsBytes(bytes);
+    assertEquals(result, null);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in `parseNawsBytes` (in `packages/core/src/server/telnet.ts`) is addressed by adding dedicated tests since there were missing edge case tests.

📊 **Coverage:** The tests now cover:
- Valid NAWS bytes sequences
- Incomplete sequences (too short)
- Invalid start sequences
- Invalid end sequences
- Edge cases for `width` (both below 40 and above 250)
- Edge cases for `height` (both below 1 and above 255)

✨ **Result:** Enhanced test coverage and reliability for Telnet Window Size negotiation processing, preventing regressions when making future changes to NAWS parsing logic.

---
*PR created automatically by Jules for task [17504227400270252343](https://jules.google.com/task/17504227400270252343) started by @lcanady*