### PR TITLE
🧪 [Testing] Add test for clampTermWidth

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1733,7 +1733,8 @@
         "minizlib",
         "mkdirp",
         "yallist"
-      ]
+      ],
+      "deprecated": true
     },
     "thenify-all@1.6.0": {
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
@@ -1797,6 +1798,7 @@
     },
     "uuid@10.0.0": {
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": true,
       "bin": true
     },
     "uuid@11.1.0": {
@@ -1805,6 +1807,7 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": true,
       "bin": true
     },
     "vm2@3.9.19": {
@@ -3739,23 +3742,6 @@
       "npm:zod@4.4.3"
     ],
     "members": {
-      "games/roses": {
-        "dependencies": [
-          "jsr:@std/assert@0.224",
-          "jsr:@std/dotenv@0.224",
-          "jsr:@std/flags@0.224",
-          "jsr:@std/fmt@0.224",
-          "jsr:@std/fs@0.224",
-          "jsr:@std/path@0.224",
-          "jsr:@std/semver@1",
-          "jsr:@ursamu/mushcode@0.6",
-          "jsr:@zaubrik/djwt@^3.0.2",
-          "npm:@digibear/tags@1.0.0",
-          "npm:@ursamu/parser@1.2.4",
-          "npm:bcryptjs@2.4.3",
-          "npm:quickjs-emscripten@0.29.0"
-        ]
-      },
       "packages/ai-gm": {
         "dependencies": [
           "jsr:@std/assert@0.224",

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -38,7 +38,7 @@ export function isRateLimitedForAuth(socketId: string): boolean {
 export function clampTermWidth(w: unknown): number | null {
   if (typeof w !== "number" || !Number.isFinite(w)) return null;
   if (w < 40 || w > 250) return null;
-  return w;
+  return Math.floor(w);
 }
 
 function sendToSocket(socketId: string, msg: string): void {

--- a/packages/core/tests/server/websocket.test.ts
+++ b/packages/core/tests/server/websocket.test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { clampTermWidth } from "../../src/server/websocket.ts";
+
+describe("clampTermWidth", () => {
+  it("returns null for non-number types", () => {
+    assertEquals(clampTermWidth("80"), null);
+    assertEquals(clampTermWidth(null), null);
+    assertEquals(clampTermWidth(undefined), null);
+    assertEquals(clampTermWidth(true), null);
+    assertEquals(clampTermWidth({}), null);
+    assertEquals(clampTermWidth([]), null);
+  });
+
+  it("returns null for non-finite numbers", () => {
+    assertEquals(clampTermWidth(NaN), null);
+    assertEquals(clampTermWidth(Infinity), null);
+    assertEquals(clampTermWidth(-Infinity), null);
+  });
+
+  it("returns null for values out of bounds (40-250)", () => {
+    assertEquals(clampTermWidth(39), null);
+    assertEquals(clampTermWidth(251), null);
+    assertEquals(clampTermWidth(-100), null);
+    assertEquals(clampTermWidth(1000), null);
+  });
+
+  it("returns exact value for integers within bounds", () => {
+    assertEquals(clampTermWidth(40), 40);
+    assertEquals(clampTermWidth(80), 80);
+    assertEquals(clampTermWidth(120), 120);
+    assertEquals(clampTermWidth(250), 250);
+  });
+
+  it("floors float values within bounds", () => {
+    assertEquals(clampTermWidth(80.5), 80);
+    assertEquals(clampTermWidth(249.9), 249);
+    assertEquals(clampTermWidth(40.1), 40);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `clampTermWidth` function and corrects the implementation to floor decimals as indicated in the issue description.
📊 **Coverage:** The tests cover out of bounds numeric values, correct bounding limits (40 and 250), float values, and invalid non-number inputs.
✨ **Result:** Test coverage for this pure function is now fully implemented and prevents any regression on websocket terminal width bounds calculation.

---
*PR created automatically by Jules for task [5356651744152011013](https://jules.google.com/task/5356651744152011013) started by @lcanady*