### PR TITLE
feat(telnet): support server.standaloneTelnet option to skip in-process Telnet transport

### DIFF
--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts"

--- a/packages/mush/src/main.ts
+++ b/packages/mush/src/main.ts
@@ -290,7 +290,9 @@ export const initializeEngine = async (
   const server = createServer();
   server.addTransport(websocketTransport);
   server.addTransport(httpTransport);
-  server.addTransport(telnetTransport);
+  if (getConfig<boolean>("server.standaloneTelnet") !== true && tnPort > 0) {
+    server.addTransport(telnetTransport);
+  }
   await server.start();
 
   // Initialize all registered plugins


### PR DESCRIPTION
Adds server.standaloneTelnet option to allow running Telnet as an independent proxy process so Telnet connections persist across engine restarts.