### PR TITLE
feat: gradient monikers, Discord avatars, two-way channel bridge

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -40,6 +40,7 @@
     "npm:@deno/sandbox@0.10.0": "0.10.0",
     "npm:@digibear/tags@1.0.0": "1.0.0",
     "npm:@electric-sql/pglite@*": "0.5.2",
+    "npm:@electric-sql/pglite@~0.5.2": "0.5.2",
     "npm:@js-temporal/polyfill@0.4.4": "0.4.4",
     "npm:@langchain/core@0.3": "0.3.80",
     "npm:@langchain/google-genai@0.2": "0.2.18_@langchain+core@0.3.80",
@@ -80,7 +81,6 @@
     "npm:tweetnacl@1.0.3": "1.0.3",
     "npm:unpdf@0.11": "0.11.0",
     "npm:vm2@3.9.19": "3.9.19",
-    "npm:zod@*": "4.4.3",
     "npm:zod@4.4.3": "4.4.3",
     "npm:zod@^3.23.0": "3.25.76"
   },
@@ -3867,6 +3867,8 @@
           "jsr:@ursamu/mushcode@0.7",
           "jsr:@zaubrik/djwt@^3.0.2",
           "npm:@digibear/tags@1.0.0",
+          "npm:@electric-sql/pglite@~0.5.2",
+          "npm:@nicia-ai/typegraph@0.31",
           "npm:@ursamu/parser@1.2.4",
           "npm:bcryptjs@2.4.3",
           "npm:lodash@^4.18.1",
@@ -3920,7 +3922,7 @@
       "packages/builder": {
         "dependencies": [
           "jsr:@std/assert@0.224",
-          "jsr:@ursamu/help@~0.1.2",
+          "jsr:@ursamu/help@~0.1.5",
           "jsr:@ursamu/mush@~0.1.3"
         ]
       },
@@ -3928,7 +3930,7 @@
         "dependencies": [
           "jsr:@std/assert@0.224",
           "jsr:@ursamu/core@0.1",
-          "jsr:@ursamu/help@~0.1.2",
+          "jsr:@ursamu/help@~0.1.5",
           "jsr:@ursamu/mush@~0.1.3"
         ]
       },
@@ -3952,8 +3954,12 @@
           "jsr:@std/path@0.224",
           "jsr:@std/semver@1",
           "jsr:@std/testing@0.224",
-          "jsr:@ursamu/core@0.1",
-          "jsr:@ursamu/help@~0.1.2",
+          "jsr:@ursamu/combat@0.8",
+          "jsr:@ursamu/core@~0.1.1",
+          "jsr:@ursamu/help@~0.1.3",
+          "jsr:@ursamu/jobs@~0.1.1",
+          "jsr:@ursamu/mail@^2.4.0",
+          "jsr:@ursamu/mush@~0.1.5",
           "jsr:@ursamu/mushcode@0.7",
           "jsr:@zaubrik/djwt@^3.0.2",
           "npm:@digibear/tags@1.0.0",
@@ -3976,7 +3982,10 @@
           "jsr:@std/fs@0.224",
           "jsr:@std/path@0.224",
           "jsr:@std/semver@1",
-          "jsr:@zaubrik/djwt@^3.0.2"
+          "jsr:@zaubrik/djwt@^3.0.2",
+          "npm:@electric-sql/pglite@~0.5.2",
+          "npm:@nicia-ai/typegraph@0.31",
+          "npm:zod@4.4.3"
         ]
       },
       "packages/discord": {
@@ -4066,7 +4075,7 @@
           "jsr:@std/dotenv@0.224",
           "jsr:@std/fs@0.224",
           "jsr:@std/path@0.224",
-          "jsr:@ursamu/core@0.1",
+          "jsr:@ursamu/core@~0.1.5",
           "jsr:@ursamu/mushcode@0.7",
           "jsr:@zaubrik/djwt@^3.0.2",
           "npm:@digibear/tags@1.0.0",

--- a/packages/bbs/src/index.ts
+++ b/packages/bbs/src/index.ts
@@ -39,7 +39,7 @@ const plugin: IPlugin = {
 
   init: () => {
     registerHelpDir(
-      new URL("../help", import.meta.url).pathname,
+      new URL("../help", import.meta.url),
       "bbs",
     );
     registerPluginRoute("/api/v1/boards", bboardsRouteHandler);

--- a/packages/builder/deno.json
+++ b/packages/builder/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/builder",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "exports": "./mod.ts",
   "tasks": {
     "test":  "deno test tests/ --allow-all --unstable-kv --no-check",
@@ -11,11 +11,18 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@^0.224.0",
     "@ursamu/mush": "jsr:@ursamu/mush@^0.1.3",
-    "@ursamu/help": "jsr:@ursamu/help@^0.1.2",
-    "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.2"
+    "@ursamu/help": "jsr:@ursamu/help@^0.1.5",
+    "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.5"
   },
   "publish": {
-    "include": ["src", "mod.ts", "deno.json", "README.md"],
+    "include": [
+      "src",
+      "help",
+      "mod.ts",
+      "deno.json",
+      "README.md",
+      "LICENSE"
+    ],
     "exclude": ["tests"]
   },
   "lint": { "rules": { "tags": ["recommended"] } }

--- a/packages/builder/mod.ts
+++ b/packages/builder/mod.ts
@@ -55,7 +55,7 @@ const onLogin = (_e: SessionEvent): void => {
 
 export const builderPlugin: IPlugin = {
   name:        "builder",
-  version:     "1.3.0",
+  version:     "1.3.2",
   description: "World-building commands and REST API — @dig, @open, @link, @desc, @examine, and more.",
 
   init: async () => {

--- a/packages/builder/mod.ts
+++ b/packages/builder/mod.ts
@@ -78,7 +78,7 @@ export const builderPlugin: IPlugin = {
     // Soft-register help directory with @ursamu/help (optional dependency)
     try {
       const { registerHelpDir } = await import("@ursamu/help");
-      registerHelpDir(new URL("./help", import.meta.url).pathname, "building");
+      registerHelpDir(new URL("./help", import.meta.url), "building");
     } catch {
       // @ursamu/help not installed
     }

--- a/packages/builder/tests/builder.test.ts
+++ b/packages/builder/tests/builder.test.ts
@@ -491,7 +491,7 @@ describe("plugin lifecycle", () => {
     // Check version without importing the full engine (avoids KV/fetch leaks in test env)
     const path = new URL("../deno.json", import.meta.url).pathname;
     const json = JSON.parse(await Deno.readTextFile(path));
-    assertEquals(json.version, "1.3.0");
+    assertEquals(json.version, "1.3.2");
     assertEquals(json.name, "@ursamu/builder");
   });
 });

--- a/packages/channels/deno.json
+++ b/packages/channels/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/channels",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts",
     "./channel-events": "./src/channel-events.ts"
@@ -15,11 +15,18 @@
     "@std/assert": "jsr:@std/assert@^0.224.0",
     "@ursamu/mush": "jsr:@ursamu/mush@^0.1.3",
     "@ursamu/core": "jsr:@ursamu/core@^0.1.0",
-    "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.2",
-    "@ursamu/help": "jsr:@ursamu/help@^0.1.2"
+    "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.5",
+    "@ursamu/help": "jsr:@ursamu/help@^0.1.5"
   },
   "publish": {
-    "include": ["src", "mod.ts", "deno.json", "README.md"],
+    "include": [
+      "src",
+      "help",
+      "mod.ts",
+      "deno.json",
+      "README.md",
+      "LICENSE"
+    ],
     "exclude": ["tests"]
   },
   "lint": { "rules": { "tags": ["recommended"] } }

--- a/packages/channels/mod.ts
+++ b/packages/channels/mod.ts
@@ -48,7 +48,10 @@ const onReady = async (): Promise<void> => {
 
   for (const def of defaults) {
     const id = def.name.toLowerCase();
-    const existing = await chans.queryOne({ id });
+    // Match by id or name — older engine seeds used id "pub" for Public.
+    const existing =
+      (await chans.queryOne({ id })) ||
+      (await chans.queryOne({ name: def.name }));
     if (!existing) {
       await chans.create({
         id,
@@ -60,6 +63,29 @@ const onReady = async (): Promise<void> => {
         owner: "",
       });
       console.log(`[channels] Seeded default channel: ${def.name}`);
+      continue;
+    }
+    // Heal legacy rows (missing lock, wrong alias, old id "pub").
+    const patch: Record<string, unknown> = {};
+    if (!existing.alias) patch.alias = def.alias;
+    if (existing.lock == null || existing.lock === "") {
+      patch.lock = def.lock || "";
+    }
+    if (
+      def.lock &&
+      existing.lock &&
+      existing.lock !== def.lock &&
+      // Upgrade bare "admin+" → "connected admin+"
+      !String(existing.lock).includes("connected")
+    ) {
+      patch.lock = def.lock;
+    }
+    if (Object.keys(patch).length) {
+      await chans.modify({ id: existing.id }, "$set", patch);
+      console.log(
+        `[channels] Updated channel ${def.name}:`,
+        patch,
+      );
     }
   }
 };
@@ -78,7 +104,7 @@ export const channelsPlugin: IPlugin = {
   init: () => {
     import("./src/commands/verbs.ts");
     registerHelpDir(
-      new URL("./help", import.meta.url).pathname,
+      new URL("./help", import.meta.url),
       "channels",
     );
     gameHooks.on("player:login", onLogin);

--- a/packages/channels/src/middleware/joinChans.ts
+++ b/packages/channels/src/middleware/joinChans.ts
@@ -6,15 +6,18 @@ const chans = new DBO<IChannel>(() =>
   getConfig<string>("plugins.channels.db", "server.chans"),
 );
 
+type ChanDefault = { name: string; alias: string; lock?: string };
+
 /**
  * Subscribe a socket to channels the player is eligible for.
  * Called from the player:login gameHook — socketId comes from SessionEvent.
  *
  * Behaviour:
- *   - Channel already in data.channels + active  → silently rejoin room socket.
- *   - Channel already in data.channels + inactive → leave alone (player chose off).
- *   - Channel not yet in data.channels + eligible → add, join, and announce.
- *   - Channel in data.channels but no longer eligible → remove entry silently.
+ *   - Not in data.channels + eligible → add, join, announce
+ *     (this is how defaults re-attach after clearcom/delcom)
+ *   - In list + active → silently rejoin socket room
+ *   - In list + inactive → leave alone (player chose off via allcom)
+ *   - In list + no longer eligible → remove silently
  */
 export async function joinChans(
   playerId: string,
@@ -23,39 +26,81 @@ export async function joinChans(
   const player = await dbojs.queryOne({ id: playerId });
   if (!player) return;
 
-  const allChans = await chans.query({});
+  const allChans = (await chans.query({})) as IChannel[];
   const playerHydrated = hydrate(player);
+
+  // Login just set `connected` on the DB row; a concurrent read can still
+  // miss it. We're past auth with a live socket — treat as connected for
+  // lock checks so defaults with lock "connected" always match.
+  if (!playerHydrated.flags.has("connected")) {
+    playerHydrated.flags.add("connected");
+  }
 
   rooms.join(socketId, `#${playerId}`);
   if (player.location) rooms.join(socketId, `#${player.location}`);
 
-  // Work on a stable snapshot; push mutations back at the end.
   player.data ||= {};
-  player.data.channels ||= [];
+  // Prefer data.channels; fall back to state.channels (older shapes).
+  const fromState = (playerHydrated.state as Record<string, unknown>)
+    ?.channels;
+  if (!Array.isArray(player.data.channels)) {
+    player.data.channels = Array.isArray(fromState) ? fromState : [];
+  }
   const chs = player.data.channels as IChanEntry[];
   let dirty = false;
+
+  // Config defaults are always candidates (even if missing from DB seed).
+  const defaults = getConfig<ChanDefault[]>(
+    "plugins.channels.defaults",
+  ) ?? [];
+  const defaultNames = new Set(
+    defaults.map((d) => d.name.toLowerCase()),
+  );
 
   for (const channel of allChans) {
     if (!channel.alias) continue;
 
-    const eligible = await evaluateLock(
-      channel.lock || "",
-      playerHydrated,
-      playerHydrated,
-    );
+    let eligible = false;
+    try {
+      eligible = await evaluateLock(
+        channel.lock || "",
+        playerHydrated,
+        playerHydrated,
+      );
+    } catch (e: unknown) {
+      console.error(
+        `[channels] lock eval failed for ${channel.name}:`,
+        e,
+      );
+      continue;
+    }
 
     const existingIdx = chs.findIndex(
       (c: IChanEntry) =>
         c.channel.toLowerCase() === channel.name.toLowerCase(),
     );
     const existing = existingIdx >= 0 ? chs[existingIdx] : null;
+    const isDefault = defaultNames.has(channel.name.toLowerCase());
 
     if (eligible) {
       if (existing) {
-        // Already a member — silently restore the socket subscription if active.
-        if (existing.active) rooms.join(socketId, channel.name);
+        // Already a member — restore socket if active.
+        // Defaults: if entry is missing alias, repair it.
+        if (!existing.alias && channel.alias) {
+          existing.alias = channel.alias;
+          existing.active = true;
+          dirty = true;
+        }
+        if (existing.active !== false) {
+          // Join by name and id so Discord inject can find listeners
+          // regardless of which key it broadcasts on.
+          rooms.join(socketId, channel.name);
+          if (channel.id !== channel.name) {
+            rooms.join(socketId, channel.id);
+          }
+        }
       } else {
-        // First time on this channel — add, subscribe, and announce.
+        // Missing from list — auto-join (defaults and any open channel).
         chs.push({
           id: channel.id,
           channel: channel.name,
@@ -64,16 +109,22 @@ export async function joinChans(
         });
         dirty = true;
         rooms.join(socketId, channel.name);
+        if (channel.id !== channel.name) {
+          rooms.join(socketId, channel.id);
+        }
         send(
           [socketId],
           `You have joined ${channel.name} ` +
             `with the alias '${channel.alias}'.`,
         );
       }
-    } else if (existing) {
-      // No longer eligible — remove the entry silently.
+    } else if (existing && !isDefault) {
+      // Drop non-default channels the player can no longer access.
       chs.splice(existingIdx, 1);
       dirty = true;
+    } else if (existing && isDefault && !eligible) {
+      // Keep the row but don't subscribe (e.g. Admin without staff).
+      // Do not force-remove defaults so a later promotion can rejoin.
     }
   }
 

--- a/packages/channels/src/middleware/matchChannel.ts
+++ b/packages/channels/src/middleware/matchChannel.ts
@@ -119,7 +119,13 @@ export async function matchChannel(
   const channel = userChans.find((c: IChanEntry) => c.alias === trig);
   if (!channel) return false;
 
-  const chan = await chans.queryOne({ name: channel.channel });
+  // Match by display name or id (links/discord use lowercase ids).
+  const allChans = await chans.all();
+  const want = channel.channel.toLowerCase();
+  const chan = allChans.find((c) =>
+    c.name.toLowerCase() === want ||
+    c.id.toLowerCase() === want
+  );
   if (!chan) return false;
 
   const enHydrated = hydrate(en);

--- a/packages/cli/src/create-project.ts
+++ b/packages/cli/src/create-project.ts
@@ -90,6 +90,31 @@ async function copySystemScripts(targetDir: string): Promise<void> {
   console.log(`Created system/scripts/ (${copied} scripts)`);
 }
 
+/**
+ * Game-level ./help/ is optional site overrides only.
+ * Plugin topics load from each package's help/ via registerHelpDir
+ * (local file: or JSR https://) — do not vendor package help here.
+ */
+async function noteHelpDir(targetDir: string): Promise<void> {
+  const dest = join(targetDir, "help");
+  await Deno.mkdir(dest, { recursive: true });
+  await Deno.writeTextFile(
+    join(dest, "README.md"),
+    [
+      "# Site help overrides",
+      "",
+      "Put game-specific `.md` topics here only.",
+      "Plugin help lives in each package's `help/` folder and is",
+      "registered with `registerHelpDir` — the FileProvider loads",
+      "it from the package (local checkout or JSR publish).",
+      "",
+    ].join("\n"),
+  );
+  console.log(
+    "Created help/ (overrides only — plugins ship their own help)",
+  );
+}
+
 export interface ProjectScaffoldOpts {
   isLocal: boolean;
   engineRelPath: string;
@@ -133,6 +158,7 @@ export async function scaffoldProject(
   console.log("Created wiki/home.md");
 
   await copySystemScripts(targetDir);
+  await noteHelpDir(targetDir);
 
   await Deno.writeTextFile(join(targetDir, "src", "main.ts"),   gameMainTs(name, isLocal));
   console.log("Created src/main.ts");

--- a/packages/cli/src/create-templates.ts
+++ b/packages/cli/src/create-templates.ts
@@ -173,7 +173,7 @@ const ${varName}Plugin: IPlugin = {
 
   init: () => {
     registerPluginRoute("/api/v1/${name}", ${handlerName});
-    registerHelpDir(new URL("./help", import.meta.url).pathname, "${name}");
+    registerHelpDir(new URL("./help", import.meta.url), "${name}");
     // gameHooks.on("player:login", onLogin);
     return true;
   },
@@ -998,7 +998,7 @@ import { registerHelpDir } from "jsr:@ursamu/help-plugin";
 export const plugin: IPlugin = {
   init: async () => {
     registerHelpDir(
-      new URL("../help", import.meta.url).pathname,
+      new URL("../help", import.meta.url),
       "${name}",  // section name shown in +help index
     );
     return true;

--- a/packages/cli/src/create-templates.ts
+++ b/packages/cli/src/create-templates.ts
@@ -1412,7 +1412,8 @@ gameHooks.emit("gm:system:register" as never, { system: myStatSystem });
 **Privilege levels** (for \`@tel\`, \`@force\`, admin commands):
 - \`superuser\` (3) → \`admin\` (2) → \`wizard\` (1) → \`player\` (0)
 
-**Flags:** \`"wizard"\` is level 9, code \`"wiz"\`, locked to superuser.
+**Flags:** \`"wizard"\` is level 9, code \`"W"\`; \`"staff"\` is code \`"w"\`
+(upper/lower codes are distinct). Locked to superuser for wizard.
 Use \`isStaff(flags)\` and \`isWizard(flags)\` utilities (exported from engine).
 
 **Hidden/internal attributes:** prefix with \`_\` to make wiz-only.

--- a/packages/cofd/index.ts
+++ b/packages/cofd/index.ts
@@ -167,7 +167,7 @@ export const plugin: IPlugin = {
   ],
 
   init: () => {
-    registerHelpDir(new URL("./help", import.meta.url).pathname, "cofd");
+    registerHelpDir(new URL("./help", import.meta.url), "cofd");
     registerJobBuckets(["SHEET", "DOWNTIME"]);
     registerPluginRoute("/api/v1/cofd", routeHandler);
     gameHooks.on("player:move", onPlayerMove);

--- a/packages/cofd/src/npc/archetypes.ts
+++ b/packages/cofd/src/npc/archetypes.ts
@@ -76,7 +76,8 @@ export function templateToArchetype(t: NpcTemplate): NpcArchetype {
       ? { dreadPowers: [...t.dreadPowers] }
       : {}),
     integrity: t.integrity,
-    size: t.size,
+    // CoD default Size is 5 (adult human) when the template omits it.
+    size: t.size ?? 5,
     ...(t.defaultWeapon
       ? { defaultWeapon: t.defaultWeapon }
       : {}),

--- a/packages/cofd/src/support/look_format.ts
+++ b/packages/cofd/src/support/look_format.ts
@@ -130,10 +130,15 @@ function getCharShortDesc(obj: IDBObj): string {
 }
 
 function roleTag(obj: IDBObj): string {
+  // Empty array is truthy — treat missing/empty as built-in defaults.
   const configured = getConfig<
     Array<{ flag: string; display: string }>
-  >("plugins.globals.theme.look.roleTags") || ROLE_TAGS;
-  for (const t of configured) {
+  >("plugins.globals.theme.look.roleTags");
+  const tags =
+    Array.isArray(configured) && configured.length > 0
+      ? configured
+      : ROLE_TAGS;
+  for (const t of tags) {
     if (obj.flags?.has(t.flag)) return t.display;
   }
   return "";

--- a/packages/cofd/tests/npc_archetypes.test.ts
+++ b/packages/cofd/tests/npc_archetypes.test.ts
@@ -24,7 +24,8 @@ Deno.test("every archetype has required fields and sane ranges", OPTS, () => {
     assert(a.label.length > 0);
     assert(a.blurb.length > 0);
     assert(["minor", "major", "storyteller"].includes(a.tier), `${key} bad tier ${a.tier}`);
-    assertEquals(a.size, 5);
+    // Adult human default is 5; some templates (e.g. hobs) differ.
+    assert(a.size >= 1 && a.size <= 10, `${key} size ${a.size} out of 1..10`);
 
     // Attributes: 1..5 each
     const attrs = a.attributes;

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -20,7 +20,7 @@
     "@std/fs": "jsr:@std/fs@^0.224.0",
     "@std/semver": "jsr:@std/semver@^1.0.0",
     "djwt": "jsr:@zaubrik/djwt@^3.0.2",
-    "zod": "npm:zod@^4.4.3",
+    "zod": "npm:zod@4.4.3",
     "@nicia-ai/typegraph": "npm:@nicia-ai/typegraph@^0.31.0",
     "@nicia-ai/typegraph/postgres/pglite":
       "npm:@nicia-ai/typegraph@^0.31.0/postgres/pglite",

--- a/packages/core/src/database/typegraph.ts
+++ b/packages/core/src/database/typegraph.ts
@@ -12,12 +12,16 @@ interface WithId {
   id: string;
 }
 
+// typegraph peers on zod@4. Cast avoids TS2740 when a monorepo
+// workspace still resolves a second zod major for type-only imports.
+const documentSchema = z.object({
+  namespace: z.string(),
+  originalId: z.string(),
+  content: z.string(),
+});
 const DocumentNode = defineNode("Document", {
-  schema: z.object({
-    namespace: z.string(),
-    originalId: z.string(),
-    content: z.string(),
-  }),
+  // deno-lint-ignore no-explicit-any
+  schema: documentSchema as any,
 });
 
 const DocumentGraph = defineGraph({

--- a/packages/discord/deno.json
+++ b/packages/discord/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/discord",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "exports": "./mod.ts",
   "tasks": {
     "test": "deno test tests/ --allow-all --unstable-kv --no-check",

--- a/packages/discord/src/channel-bridge.ts
+++ b/packages/discord/src/channel-bridge.ts
@@ -4,8 +4,8 @@
  * Discord → game uses injectChannelMessage + source flag.
  */
 
-import { DBO, rooms } from "@ursamu/core";
-import { clean, toLatin1 } from "./helpers.ts";
+import { DBO, rooms, sessions, send } from "@ursamu/core";
+import { clean, stripMushMarkup } from "./helpers.ts";
 import { getWebhookUrl } from "./config.ts";
 import { postWebhook } from "./webhook.ts";
 
@@ -21,7 +21,8 @@ export interface IChannelMessageEvent {
 interface IChanRow {
   id: string;
   name: string;
-  header: string;
+  header?: string;
+  alias?: string;
 }
 
 /**
@@ -35,7 +36,6 @@ export async function onGameChannelMessage(
   const url = await getWebhookUrl(ev.channelName.toLowerCase());
   if (!url) return;
 
-  // Dynamic import to avoid circular hard deps in tests
   const { getDiscordConfig } = await import("./config.ts");
   const { resolveAvatar } = await import("./helpers.ts");
   const cfg = await getDiscordConfig();
@@ -44,10 +44,14 @@ export async function onGameChannelMessage(
     ev.senderName,
     cfg.publicUrl,
   );
+  console.log(
+    `[discord] outbound ${ev.channelName} id=${ev.senderId} ` +
+      `avatar=${avatar ?? "(none)"}`,
+  );
   postWebhook(url, {
     username: clean(ev.senderName),
-    avatar_url: avatar,
-    content: ev.message.slice(0, 2000),
+    ...(avatar ? { avatar_url: avatar } : {}),
+    content: stripMushMarkup(ev.message).slice(0, 2000),
   });
 }
 
@@ -76,6 +80,94 @@ export function formatDiscordChannelBody(
   return `[Discord] ${who} says, "${text}"`;
 }
 
+/** Resolve a game channel by id, name, or alias (case-insensitive). */
+export async function resolveGameChannel(
+  raw: string,
+): Promise<IChanRow | null> {
+  const key = raw.toLowerCase().trim();
+  if (!key) return null;
+
+  const chans = new DBO<IChanRow>("server.chans");
+  const all = await chans.all();
+  const hit = all.find((c) => {
+    const id = String(c.id ?? "").toLowerCase();
+    const name = String(c.name ?? "").toLowerCase();
+    const alias = String(c.alias ?? "").toLowerCase();
+    return id === key || name === key || alias === key;
+  });
+  return hit ?? null;
+}
+
+/**
+ * Deliver a line to everyone listening on a game channel.
+ * Tries room membership first; falls back to scanning player
+ * data.channels so Discord traffic is not dropped when the room
+ * key does not match joinChans' room name.
+ */
+async function deliverToGameChannel(
+  chan: IChanRow,
+  line: string,
+): Promise<number> {
+  const roomKeys = new Set<string>([
+    chan.name,
+    chan.id,
+    chan.name.toLowerCase(),
+    chan.id.toLowerCase(),
+  ]);
+  if (chan.alias) roomKeys.add(chan.alias);
+
+  const seen = new Set<string>();
+  for (const key of roomKeys) {
+    for (const sid of rooms.members(key)) {
+      seen.add(sid);
+    }
+  }
+
+  // Fallback: any connected session whose player has this channel.
+  if (seen.size === 0) {
+    try {
+      const { dbojs } = await import("@ursamu/mush");
+      for (const s of sessions.list()) {
+        const actorId = (s as { actorId?: string }).actorId;
+        if (!actorId) continue;
+        const p = await dbojs.queryOne({ id: actorId });
+        if (!p) continue;
+        const list = (p.data?.channels ?? []) as Array<{
+          channel?: string;
+          id?: string;
+          alias?: string;
+          active?: boolean;
+        }>;
+        const on = list.some((e) => {
+          if (e.active === false) return false;
+          const cn = String(e.channel ?? "").toLowerCase();
+          const cid = String(e.id ?? "").toLowerCase();
+          const al = String(e.alias ?? "").toLowerCase();
+          return (
+            cn === chan.name.toLowerCase() ||
+            cid === chan.id.toLowerCase() ||
+            (chan.alias != null && al === chan.alias.toLowerCase())
+          );
+        });
+        if (on) seen.add(s.socketId);
+      }
+    } catch (e: unknown) {
+      console.error("[discord] deliver fallback failed:", e);
+    }
+  }
+
+  if (seen.size === 0) {
+    console.warn(
+      `[discord] inject: no listeners for channel ` +
+        `${chan.name} (${chan.id})`,
+    );
+    return 0;
+  }
+
+  send([...seen], line);
+  return seen.size;
+}
+
 /**
  * Inbound: inject a Discord message into a game channel.
  * Does not re-emit channel:message — caller emits with source:"discord".
@@ -85,15 +177,16 @@ export async function injectChannelMessage(opts: {
   displayName: string;
   text: string;
 }): Promise<boolean> {
-  // Query by `id` (always lowercase) — `name` preserves input case
-  // and may not match a lowercased lookup.
-  const id = opts.channelName.toLowerCase().trim();
-  const chans = new DBO<IChanRow>("server.chans");
-  const allChans = await chans.all();
-  console.log(`[discord] All channels in DB:`, JSON.stringify(allChans));
-  const chan = await chans.queryOne({ id });
+  const chan = await resolveGameChannel(opts.channelName);
   if (!chan) {
-    console.warn(`[discord] inject: unknown channel "${id}"`);
+    const chans = new DBO<IChanRow>("server.chans");
+    const known = (await chans.all()).map(
+      (c) => `${c.id}/${c.name}/${c.alias ?? ""}`,
+    );
+    console.warn(
+      `[discord] inject: unknown channel ` +
+        `"${opts.channelName}" known=[${known.join(", ")}]`,
+    );
     return false;
   }
 
@@ -101,6 +194,11 @@ export async function injectChannelMessage(opts: {
   if (!body) return false;
 
   const header = chan.header ? `${chan.header} ` : "";
-  rooms.broadcast(chan.name, `${header}${body}`);
+  const line = `${header}${body}`;
+  const n = await deliverToGameChannel(chan, line);
+  console.log(
+    `[discord] inject → ${chan.name} ` +
+      `(${n} listener${n === 1 ? "" : "s"})`,
+  );
   return true;
 }

--- a/packages/discord/src/config.ts
+++ b/packages/discord/src/config.ts
@@ -24,18 +24,39 @@ function emptyCfg(): IDiscordConfig {
   return { id: "discord", webhooks: {}, links: {}, publicUrl: "" };
 }
 
+/** Env fallback when DBO publicUrl is empty (court, docker, etc.). */
+function envPublicUrl(): string {
+  const raw =
+    Deno.env.get("DISCORD_PUBLIC_URL")?.trim() ||
+    Deno.env.get("PUBLIC_URL")?.trim() ||
+    Deno.env.get("URSAMU_PUBLIC_URL")?.trim() ||
+    "";
+  return raw.replace(/\/+$/, "");
+}
+
 async function load(): Promise<IDiscordConfig> {
   const cfg = await db.queryOne({ id: "discord" });
   if (!cfg) {
-    console.log("[discord] config: no config found in database, returning empty config.");
-    return emptyCfg();
+    console.log(
+      "[discord] config: no config found in database, " +
+        "returning empty config.",
+    );
+    return { ...emptyCfg(), publicUrl: envPublicUrl() };
   }
-  console.log("[discord] config loaded:", JSON.stringify({ webhooks: cfg.webhooks, links: cfg.links }));
+  const publicUrl = (cfg.publicUrl ?? "").trim() || envPublicUrl();
+  console.log(
+    "[discord] config loaded:",
+    JSON.stringify({
+      webhooks: cfg.webhooks,
+      links: cfg.links,
+      publicUrl: publicUrl || "(not set)",
+    }),
+  );
   return {
     id: "discord",
     webhooks: cfg.webhooks ?? {},
     links: cfg.links ?? {},
-    publicUrl: cfg.publicUrl ?? "",
+    publicUrl,
   };
 }
 

--- a/packages/discord/src/gateway.ts
+++ b/packages/discord/src/gateway.ts
@@ -158,8 +158,15 @@ async function onMessage(token: string, raw: string): Promise<void> {
         _botUserId = payload.d?.user?.id ?? null;
         console.log("[discord] Gateway READY.");
       } else if (t === "MESSAGE_CREATE") {
-        console.log(`[discord] Received MESSAGE_CREATE from ${payload.d?.author?.username}: "${payload.d?.content}"`);
+        console.log(
+          `[discord] Received MESSAGE_CREATE from ` +
+            `${payload.d?.author?.username}: ` +
+            `"${payload.d?.content}"`,
+        );
         await onMessageCreate(token, payload.d);
+      } else if (t === "INTERACTION_CREATE") {
+        // Slash commands without a public HTTPS interactions URL.
+        await onInteractionCreate(token, payload.d);
       }
       break;
     }
@@ -175,6 +182,99 @@ async function onMessage(token: string, raw: string): Promise<void> {
   }
 }
 
+/**
+ * Respond to a slash/autocomplete interaction via REST callback.
+ * Works without a public Interactions Endpoint URL.
+ */
+// deno-lint-ignore no-explicit-any
+async function onInteractionCreate(
+  _token: string,
+  interaction: any,
+): Promise<void> {
+  if (!interaction?.id || !interaction?.token) return;
+
+  const type = interaction.type as number;
+  const name = interaction.data?.name as string | undefined;
+  const callbackUrl =
+    `${API}/interactions/${interaction.id}/${interaction.token}/callback`;
+
+  try {
+    let body: Record<string, unknown>;
+
+    // type 2 APPLICATION_COMMAND, type 4 AUTOCOMPLETE
+    if (type === 2 && name === "help") {
+      const {
+        buildHelpEmbeds,
+        helpCommandPayload,
+      } = await import("./interactions/help-command.ts");
+      const options =
+        (interaction.data?.options as Array<
+          { name: string; value?: string }
+        >) ?? [];
+      const embeds = await buildHelpEmbeds(options);
+      body = helpCommandPayload(embeds);
+    } else if (type === 4 && name === "help") {
+      const { buildHelpAutocomplete } = await import(
+        "./interactions/help-command.ts"
+      );
+      const options =
+        (interaction.data?.options as Array<
+          { name: string; value?: string; focused?: boolean }
+        >) ?? [];
+      const focused = options.find((o) => o.focused) ??
+        options.find((o) => o.name === "topic");
+      body = await buildHelpAutocomplete(
+        focused
+          ? {
+            name: focused.name,
+            value: String(focused.value ?? ""),
+          }
+          : undefined,
+      );
+    } else if (type === 2) {
+      // Unknown slash — acknowledge so Discord doesn't show an error.
+      body = {
+        type: 4,
+        data: {
+          flags: 64,
+          content: `Unknown command: \`${name ?? "?"}\``,
+        },
+      };
+    } else {
+      return;
+    }
+
+    const res = await fetch(callbackUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(
+        `[discord] Interaction callback ${res.status}: ${text}`,
+      );
+    }
+  } catch (e: unknown) {
+    console.error("[discord] INTERACTION_CREATE failed:", e);
+    try {
+      await fetch(callbackUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: 4,
+          data: {
+            flags: 64,
+            content: "Help failed to load. Try `+help` in chat.",
+          },
+        }),
+      });
+    } catch {
+      /* ignore secondary failure */
+    }
+  }
+}
+
 // deno-lint-ignore no-explicit-any
 async function onMessageCreate(token: string, msg: any): Promise<void> {
   if (!msg || msg.webhook_id) return; // loop: ignore webhook posts
@@ -184,50 +284,37 @@ async function onMessageCreate(token: string, msg: any): Promise<void> {
   const channelId = String(msg.channel_id ?? "");
   if (!channelId) return;
 
-  let content = String(msg.content ?? "").trim();
+  const content = String(msg.content ?? "").trim();
 
   // Handle +help trigger directly in Discord chat (works in any channel)
   if (content.toLowerCase().startsWith("+help")) {
-    const topicArg = content.slice(5).trim();
-    const { helpRegistry, slugify } = await import("@ursamu/help");
-    const { embedForEntry, embedForIndex, embedNotFound } = await import("./help-embed.ts");
-    
-    let embed;
-    if (topicArg) {
-      const slug = slugify(topicArg);
-      const entry = await helpRegistry.lookup(slug);
-      if (entry) {
-        embed = embedForEntry(entry);
-      } else {
-        // Fall back to checking if the argument is a section name
-        const { embedForSection } = await import("./help-embed.ts");
-        const sectionEntries = await helpRegistry.inSection(slug);
-        if (sectionEntries.length > 0) {
-          embed = embedForSection(topicArg, sectionEntries);
-        } else {
-          embed = embedNotFound(topicArg);
-        }
-      }
-    } else {
-      const sections = await helpRegistry.sections();
-      const all = await helpRegistry.all();
-      const visible = all.filter((e) => !e.hidden);
-      embed = embedForIndex(sections, visible.length);
-    }
-
-    // Post the reply to the same channel via Discord REST API
     try {
-      await fetch(`${API}/channels/${channelId}/messages`, {
+      const topicArg = content.slice(5).trim();
+      const options = topicArg
+        ? [{ name: "topic", value: topicArg }]
+        : [];
+      const { buildHelpEmbeds } = await import(
+        "./interactions/help-command.ts"
+      );
+      const embeds = await buildHelpEmbeds(options);
+
+      const res = await fetch(`${API}/channels/${channelId}/messages`, {
         method: "POST",
         headers: {
           Authorization: `Bot ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          embeds: [embed],
-          message_reference: { message_id: msg.id }, // Reply to the user's message
+          embeds,
+          message_reference: { message_id: msg.id },
         }),
       });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        console.error(
+          `[discord] +help reply ${res.status}: ${text}`,
+        );
+      }
     } catch (e: unknown) {
       console.error("[discord] Failed to reply with help embed:", e);
     }
@@ -427,8 +514,16 @@ async function onMessageCreate(token: string, msg: any): Promise<void> {
   if (isSceneMsg) return;
 
   const gameChan = await gameChannelForDiscord(channelId);
-  console.log(`[discord] Resolved Discord channel ${channelId} -> Game channel "${gameChan || "(none)"}"`);
-  if (!gameChan) return;
+  if (!gameChan) {
+    console.log(
+      `[discord] No game link for Discord channel ${channelId}`,
+    );
+    return;
+  }
+  console.log(
+    `[discord] ${channelId} → game "${gameChan}" ` +
+      `from ${msg.author?.username}: ${content.slice(0, 80)}`,
+  );
   
   // Append URLs of any attachments (images, videos, files)
   if (Array.isArray(msg.attachments) && msg.attachments.length > 0) {

--- a/packages/discord/src/help-embed.ts
+++ b/packages/discord/src/help-embed.ts
@@ -4,17 +4,14 @@
  */
 
 import type { HelpEntry } from "@ursamu/help";
-import { COLORS } from "./helpers.ts";
+import { COLORS, stripMushMarkup } from "./helpers.ts";
 import type { DiscordEmbed } from "./webhook.ts";
 
 const DESC_MAX = 4096;
 
 /** Strip MUSH codes and normalize markdown for Discord embeds. */
 export function markdownToDiscord(md: string): string {
-  let out = md;
-  out = out.replace(/%(ch|cn|c[rgbcmyw]|b[rgbcmyw]|[rnthiub])/gi, "");
-  // deno-lint-ignore no-control-regex
-  out = out.replace(/\x1b\[[0-9;]*m/g, "");
+  let out = stripMushMarkup(md);
   // YAML frontmatter
   out = out.replace(/^---[\s\S]*?---\n?/m, "");
   // ATX headers → bold lines

--- a/packages/discord/src/helpers.ts
+++ b/packages/discord/src/helpers.ts
@@ -26,34 +26,63 @@ export function toLatin1(str: string): string {
 }
 
 /**
- * Strip MUSH/ANSI codes, enforce Latin-1, and clamp to Discord's 80-char username limit.
+ * Strip MUSH markup for plain-text targets (Discord, logs).
+ * Handles truecolor `<#RRGGBB>`, `%c`/`%x` codes, and ANSI.
+ * Discord has no per-character color — drop codes, keep text.
  */
-export function clean(str: string): string {
-  const sanitized = str
-    .replace(/%c[a-zA-Z0-9]/gi, "")
+export function stripMushMarkup(str: string): string {
+  return str
+    // %x<#rrggbb> / %c<#…> / %X<#…> / %C<#…> then bare <#…>
+    .replace(/%[xcXC]?<#[0-9a-fA-F]{3,8}>/g, "")
+    .replace(/<#[0-9a-fA-F]{3,8}>/g, "")
+    // %ch %cn %cr %cR %x0 %c#123 …
+    .replace(/%[cx][#]?[a-zA-Z0-9]/gi, "")
     .replace(/%[nrtbR]/g, "")
     // deno-lint-ignore no-control-regex
     .replace(/\x1b\[[0-9;]*m/g, "");
-  
-  return toLatin1(sanitized).trim().slice(0, 80) || "Unknown";
 }
 
 /**
- * Resolve avatar_url: player's saved image if present, else RoboHash fallback.
+ * Strip MUSH/ANSI codes, enforce Latin-1, clamp to Discord
+ * username limit (80).
+ */
+export function clean(str: string): string {
+  const sanitized = stripMushMarkup(str);
+  return toLatin1(sanitized).trim().slice(0, 80) || "Unknown";
+}
+
+const AVATARS_DIR = "data/avatars";
+
+/** Normalize base URL (no trailing slash). */
+export function normalizePublicUrl(raw: string): string {
+  return raw.trim().replace(/\/+$/, "");
+}
+
+/**
+ * Resolve avatar_url for Discord webhooks.
+ * Returns local @avatar URL or undefined (omit avatar_url).
+ *
+ * Discord quirks (verified on webhooks):
+ * - Silently drops avatar_url if the URL has a query string
+ * - Third-party hosts (robohash, gravatar, github, …) often
+ *   yield author.avatar=null — only our publicUrl host is reliable
+ * - Prefer path with real extension: /avatars/{id}.jpg
+ * - No query cache-busters (they void the override)
  */
 export async function resolveAvatar(
   playerId: string,
-  playerName: string,
+  _playerName: string,
   publicUrl: string,
-): Promise<string> {
-  if (publicUrl) {
-    try {
-      for await (const entry of Deno.readDir("data/avatars")) {
-        if (entry.name.startsWith(playerId + ".")) {
-          return `${publicUrl}/avatars/${playerId}`;
-        }
-      }
-    } catch { /* no avatars dir yet */ }
-  }
-  return `https://robohash.org/${encodeURIComponent(playerName)}?set=set4&size=80x80`;
+): Promise<string | undefined> {
+  const base = normalizePublicUrl(publicUrl);
+  if (!base || !playerId) return undefined;
+  try {
+    for await (const entry of Deno.readDir(AVATARS_DIR)) {
+      if (!entry.isFile) continue;
+      if (!entry.name.startsWith(playerId + ".")) continue;
+      // Use real filename (id.ext). No query string.
+      return `${base}/avatars/${entry.name}`;
+    }
+  } catch { /* no avatars dir yet */ }
+  return undefined;
 }

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -57,7 +57,7 @@ const discordPlugin: IPlugin = {
   init: () => {
     setupCommands();
     registerHelpDir(
-      new URL("../help", import.meta.url).pathname,
+      new URL("../help", import.meta.url),
       "discord",
     );
     // Single prefix handler: interactions first, then staff REST

--- a/packages/discord/src/interactions/handler.ts
+++ b/packages/discord/src/interactions/handler.ts
@@ -69,7 +69,14 @@ export async function handleInteraction(req: Request): Promise<Response> {
       >) ?? [];
 
     if (name === "help") {
-      return await handleHelpCommand(options);
+      try {
+        return await handleHelpCommand(options);
+      } catch (e: unknown) {
+        console.error("[discord] HTTP /help failed:", e);
+        return ephemeralText(
+          "Help failed to load. Try again in a moment.",
+        );
+      }
     }
     
     // Resolve Discord User ID from member or direct user payload

--- a/packages/discord/src/interactions/help-command.ts
+++ b/packages/discord/src/interactions/help-command.ts
@@ -1,5 +1,9 @@
 /**
  * Discord /help slash command + autocomplete.
+ *
+ * Payload builders are shared by:
+ *   - HTTP interactions endpoint (public HTTPS)
+ *   - Gateway INTERACTION_CREATE (no inbound HTTP required)
  */
 
 import { helpRegistry, slugify } from "@ursamu/help";
@@ -13,40 +17,72 @@ import type { DiscordEmbed } from "../webhook.ts";
 
 const EPHEMERAL = 1 << 6; // 64
 
-export function ephemeralEmbeds(embeds: DiscordEmbed[]): Response {
-  return Response.json({
+/** Interaction callback body for an ephemeral embed reply. */
+export function helpCommandPayload(
+  embeds: DiscordEmbed[],
+): Record<string, unknown> {
+  return {
     type: 4, // CHANNEL_MESSAGE_WITH_SOURCE
     data: {
       flags: EPHEMERAL,
       embeds,
     },
-  });
+  };
 }
 
-export async function handleHelpCommand(
-  options: Array<{ name: string; value?: string }>,
-): Promise<Response> {
-  const topicOpt = options.find((o) => o.name === "topic");
+export function ephemeralEmbeds(embeds: DiscordEmbed[]): Response {
+  return Response.json(helpCommandPayload(embeds));
+}
 
+/** Build embeds for /help [topic]. */
+export async function buildHelpEmbeds(
+  options: Array<{ name: string; value?: string }>,
+): Promise<DiscordEmbed[]> {
+  const topicOpt = options.find((o) => o.name === "topic");
   const topic = typeof topicOpt?.value === "string"
     ? slugify(topicOpt.value)
     : "";
 
   if (topic) {
     const entry = await helpRegistry.lookup(topic);
-    if (!entry) return ephemeralEmbeds([embedNotFound(topic)]);
-    return ephemeralEmbeds([embedForEntry(entry)]);
+    if (!entry) {
+      // Section name fallback (same as +help gateway path)
+      const sectionEntries = await helpRegistry.inSection(topic);
+      if (sectionEntries.length > 0) {
+        return [embedForSection(topic, sectionEntries)];
+      }
+      return [embedNotFound(topic)];
+    }
+    return [embedForEntry(entry)];
   }
 
   const sections = await helpRegistry.sections();
   const all = await helpRegistry.all();
   const visible = all.filter((e) => !e.hidden);
-  return ephemeralEmbeds([embedForIndex(sections, visible.length)]);
+  return [embedForIndex(sections, visible.length)];
 }
 
-export async function handleHelpAutocomplete(
-  focused: { name: string; value: string } | undefined,
+export async function handleHelpCommand(
+  options: Array<{ name: string; value?: string }>,
 ): Promise<Response> {
+  try {
+    const embeds = await buildHelpEmbeds(options);
+    return ephemeralEmbeds(embeds);
+  } catch (e: unknown) {
+    console.error("[discord] /help failed:", e);
+    return ephemeralEmbeds([{
+      color: 0xe74c3c,
+      title: "Help error",
+      description:
+        "Something went wrong loading help. Try again in a moment.",
+    }]);
+  }
+}
+
+/** Autocomplete choices payload (type 8). */
+export async function buildHelpAutocomplete(
+  focused: { name: string; value: string } | undefined,
+): Promise<Record<string, unknown>> {
   const prefix = (focused?.value ?? "").toLowerCase().trim();
   const all = await helpRegistry.all();
   let names = all
@@ -63,10 +99,21 @@ export async function handleHelpAutocomplete(
     value: n.slice(0, 100),
   }));
 
-  return Response.json({
+  return {
     type: 8, // APPLICATION_COMMAND_AUTOCOMPLETE_RESULT
     data: { choices },
-  });
+  };
+}
+
+export async function handleHelpAutocomplete(
+  focused: { name: string; value: string } | undefined,
+): Promise<Response> {
+  try {
+    return Response.json(await buildHelpAutocomplete(focused));
+  } catch (e: unknown) {
+    console.error("[discord] /help autocomplete failed:", e);
+    return Response.json({ type: 8, data: { choices: [] } });
+  }
 }
 
 /** Slash command JSON body for Discord API registration. */

--- a/packages/discord/src/job-hooks.ts
+++ b/packages/discord/src/job-hooks.ts
@@ -95,7 +95,7 @@ const onJobCreated = async (job: IJob): Promise<void> => {
   
   const payload = {
     username: clean(job.submitterName),
-    avatar_url: avatar,
+    ...(avatar ? { avatar_url: avatar } : {}),
     embeds: [{
       color: COLORS.green,
       title: `New Job #${job.number} — ${job.title}`,
@@ -192,7 +192,7 @@ const onJobCommented = async (
     jobNumber: job.number,
     payload: {
       username: clean(comment.authorName),
-      avatar_url: avatar,
+      ...(avatar ? { avatar_url: avatar } : {}),
       embeds: [{
         color: COLORS.blurple,
         title: "New Comment",

--- a/packages/discord/src/scene-bridge.ts
+++ b/packages/discord/src/scene-bridge.ts
@@ -1,5 +1,6 @@
 import { dbojs, hydrate, gameHooks } from "@ursamu/mush";
 import { getBotCredentials } from "./config.ts";
+import { clean, stripMushMarkup } from "./helpers.ts";
 
 const API = "https://discord.com/api/v10";
 
@@ -43,15 +44,16 @@ async function onGameScenePose(e: {
   const creds = getBotCredentials();
   if (!creds?.botToken) return;
 
-  const speaker = e.actorName;
+  const speaker = clean(e.actorName);
+  const msg = stripMushMarkup(e.msg);
   let text = "";
 
   if (e.type === "ooc") {
-    text = `*OOC: ${speaker}: ${e.msg}*`;
+    text = `*OOC: ${speaker}: ${msg}*`;
   } else if (e.type === "set") {
-    text = `*[Scene Set] ${e.msg}*`;
+    text = `*[Scene Set] ${msg}*`;
   } else {
-    text = `**${speaker}** ${e.msg}`;
+    text = `**${speaker}** ${msg}`;
   }
 
   // 1. Post to public bridged channel/thread if linked

--- a/packages/discord/tests/channel_bridge.test.ts
+++ b/packages/discord/tests/channel_bridge.test.ts
@@ -49,6 +49,20 @@ Deno.test("formatDiscordChannelBody strips MUSH in name", OPTS, () => {
   );
 });
 
+Deno.test(
+  "formatDiscordChannelBody strips truecolor moniker",
+  OPTS,
+  () => {
+    assertEquals(
+      formatDiscordChannelBody(
+        "<#ff0000>B<#00ff00>o<#0000ff>b%cn",
+        "yo",
+      ),
+      `[Discord] Bob says, "yo"`,
+    );
+  },
+);
+
 Deno.test("formatDiscordChannelBody rejects empty", OPTS, () => {
   assertEquals(formatDiscordChannelBody("Alice", "   "), null);
 });

--- a/packages/discord/tests/discord.test.ts
+++ b/packages/discord/tests/discord.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { describe, it, beforeAll, afterAll } from "@std/testing/bdd";
-import { clean, resolveAvatar } from "../src/helpers.ts";
+import { clean, stripMushMarkup, resolveAvatar } from "../src/helpers.ts";
 import {
   getDiscordConfig,
   setWebhook,
@@ -20,9 +20,42 @@ describe("Discord Plugin — Helpers", () => {
     assertEquals(clean("   "), "Unknown");
   });
 
-  it("resolveAvatar returns RoboHash fallback when no public url", async () => {
-    const url = await resolveAvatar("p1", "PlayerOne", "");
-    assertStringIncludes(url, "robohash.org/PlayerOne");
+  it("clean strips truecolor moniker tags", () => {
+    const moniker =
+      "<#ff0000>D<#ff1905>i<#ff320a>a%cn";
+    assertEquals(clean(moniker), "Dia");
+  });
+
+  it("stripMushMarkup drops truecolor and keeps text", () => {
+    const raw =
+      "<#ff0000>D<#ff1905>i<#ff320a>a%cn tests.";
+    assertEquals(stripMushMarkup(raw), "Dia tests.");
+  });
+
+  it("resolveAvatar is undefined without public url or file", async () => {
+    assertEquals(await resolveAvatar("p1", "PlayerOne", ""), undefined);
+    assertEquals(
+      await resolveAvatar("missing", "X", "https://game.example"),
+      undefined,
+    );
+  });
+
+  it("resolveAvatar uses public file with extension", async () => {
+    await Deno.mkdir("data/avatars", { recursive: true });
+    const id = "avatar_resolve_test_p1";
+    const path = `data/avatars/${id}.png`;
+    await Deno.writeFile(path, new Uint8Array([1, 2, 3]));
+    try {
+      const url = await resolveAvatar(
+        id,
+        "PlayerOne",
+        "https://game.example/",
+      );
+      // Real filename, no query string (Discord drops those).
+      assertEquals(url, `https://game.example/avatars/${id}.png`);
+    } finally {
+      await Deno.remove(path).catch(() => {});
+    }
   });
 });
 

--- a/packages/discord/tests/help_embed.test.ts
+++ b/packages/discord/tests/help_embed.test.ts
@@ -21,11 +21,14 @@ dark: true
 ---
 # Title
 %ch%cyBold%cn line
+<#ff00aa>truecolor%cn
 `;
   const out = markdownToDiscord(md);
   assertStringIncludes(out, "**Title**");
   assertEquals(out.includes("%ch"), false);
   assertEquals(out.includes("---"), false);
+  assertEquals(out.includes("<#ff00aa>"), false);
+  assertStringIncludes(out, "truecolor");
 });
 
 Deno.test("truncateDiscord appends marker when over max", OPTS, () => {

--- a/packages/dnd/index.ts
+++ b/packages/dnd/index.ts
@@ -20,7 +20,7 @@ export const plugin: IPlugin = {
   ],
 
   init: () => {
-    registerHelpDir(new URL("./help", import.meta.url).pathname, "dnd");
+    registerHelpDir(new URL("./help", import.meta.url), "dnd");
     initDndCombat();
 
     const dropCmd = cmds.find(c => c.name === "drop");

--- a/packages/help/deno.json
+++ b/packages/help/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/help",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "exports": "./mod.ts",
   "tasks": {
     "test": "deno test tests/ --allow-all --unstable-kv --no-check",

--- a/packages/help/mod.ts
+++ b/packages/help/mod.ts
@@ -13,8 +13,9 @@
  * export const plugin: IPlugin = {
  *   name: "myplugin",
  *   init: () => {
+ *     // Prefer URL (works for local file: and JSR https://)
  *     registerHelpDir(
- *       new URL("./help", import.meta.url).pathname,
+ *       new URL("./help", import.meta.url),
  *       "myplugin",
  *     );
  *     return true;

--- a/packages/help/src/index.ts
+++ b/packages/help/src/index.ts
@@ -1,50 +1,61 @@
 /**
  * src/index.ts — IPlugin bootstrap for the help system.
  *
- * Phase 1 (module load): imports commands.ts — all addCmd() calls run immediately.
- * Phase 2 (init):        registers providers, wires REST routes, primes file cache.
- * Phase 3 (remove):      removes providers from the registry.
+ * Phase 1 (module load): imports commands.ts — addCmd() at load time.
+ * Phase 2 (init):        providers + own help dir; prime on engine:ready
+ *                        after every plugin has called registerHelpDir.
+ * Phase 3 (remove):      remove providers + ready listener.
  */
 
 import "./commands.ts";
 import "./hooks.ts";
 import "./routes.ts";
 import type { IPlugin } from "@ursamu/mush";
+import { gameHooks } from "@ursamu/mush";
 import { helpRegistry } from "./registry.ts";
 import { CommandProvider } from "./providers/command.ts";
-import { FileProvider, registerHelpDir } from "./providers/file.ts";
+import {
+  FileProvider,
+  registerHelpDir,
+  bustCache,
+} from "./providers/file.ts";
 import { DbProvider } from "./providers/database.ts";
-import { fromFileUrl } from "@std/path";
 
 const commandProvider = new CommandProvider();
-const fileProvider    = new FileProvider();
-const dbProvider      = new DbProvider();
+const fileProvider = new FileProvider();
+const dbProvider = new DbProvider();
+
+/** After all plugins init, rebuild once from every registerHelpDir. */
+const onReady = async (): Promise<void> => {
+  bustCache();
+  const n = (await fileProvider.all()).length;
+  console.log(`[help] File cache ready (${n} file topic(s)).`);
+};
 
 export const plugin: IPlugin = {
-  name:        "help",
-  version:     "1.0.0",
-  description: "API-first help system — aggregates command inline help, per-plugin help folders, and runtime entries.",
+  name: "help",
+  version: "1.0.1",
+  description:
+    "API-first help — command inline help, per-package help/ " +
+    "folders via registerHelpDir, and runtime DB entries.",
 
-  init: async () => {
-    // Register this plugin's own help/ directory
-    if (import.meta.url.startsWith("file:")) {
-      registerHelpDir(
-        fromFileUrl(new URL("../help", import.meta.url)),
-        "help",
-      );
-    }
+  init: () => {
+    // Own package help/ (file: checkout or JSR https://).
+    registerHelpDir(
+      new URL("../help", import.meta.url),
+      "help",
+    );
 
     helpRegistry.addProvider(dbProvider);
     helpRegistry.addProvider(fileProvider);
     helpRegistry.addProvider(commandProvider);
 
-    // Prime the file cache eagerly so the first lookup is fast
-    await fileProvider.all();
-
+    gameHooks.on("engine:ready", onReady);
     return true;
   },
 
   remove: () => {
+    gameHooks.off("engine:ready", onReady);
     helpRegistry.removeProvider(dbProvider);
     helpRegistry.removeProvider(fileProvider);
     helpRegistry.removeProvider(commandProvider);

--- a/packages/help/src/providers/file.ts
+++ b/packages/help/src/providers/file.ts
@@ -3,82 +3,251 @@
  *   1. ./help/              (game-level root, always scanned)
  *   2. Any directory registered via registerHelpDir()
  *
- * Section derivation:
- *   ./help/<section>/<topic>.md   → section = folder name
- *   ./help/<topic>.md             → section = "general"
- *   registerHelpDir(path, sect)   → section = explicit argument
+ * registerHelpDir accepts:
+ *   - Absolute filesystem paths (local / file: plugins)
+ *   - file: URLs
+ *   - https://jsr.io/@scope/pkg/ver/... URLs
+ *   - Deno JSR pathnames (/@scope/pkg/ver/...) from
+ *     `new URL("./help", import.meta.url).pathname`
  *
- * Files are cached at init() time. Call bustCache() to rescan
- * (triggered by the +help/reload command).
+ * JSR packages store help as remote assets (not on a real FS).
+ * Those are loaded via the package `_meta.json` manifest + fetch.
  *
  * Priority 50 — below DB (100) but above CommandProvider (10).
- *
- * Security:
- *   - scanDir resolves every file path with Deno.realPath() before reading and
- *     verifies it is contained within the originally registered root directory.
- *     This prevents symlink traversal attacks where a .md symlink inside the
- *     help directory points to a sensitive file outside it.
- *   - registerHelpDir logs a warning when the resolved path is outside cwd.
- *     Plugins installed via JSR may legitimately live outside cwd, but an
- *     accidental or malicious registration of "/" or "/etc" is surfaced clearly.
  */
 
 import type { HelpEntry, HelpProvider } from "../registry.ts";
 import { slugify } from "../registry.ts";
 
 interface RegisteredDir {
+  /** Filesystem path, or "" when remote-only. */
   path: string;
+  /**
+   * Remote base URL ending with /, e.g.
+   * https://jsr.io/@ursamu/mail/2.4.0/help/
+   */
+  baseUrl?: string;
   section: string;
 }
 
 const _registeredDirs: RegisteredDir[] = [];
 let _cache: Map<string, HelpEntry> | null = null;
+/** In-flight build — coalesces concurrent cache() callers. */
+let _build: Promise<Map<string, HelpEntry>> | null = null;
+
+/** True for Deno's virtual JSR pathname form: /@scope/name/ver/... */
+function isJsrPathname(p: string): boolean {
+  return /^\/@[^/]+\/[^/]+\//.test(p);
+}
+
+/**
+ * Normalize a registerHelpDir argument into fs path and/or remote URL.
+ */
+function resolveRegistration(
+  path: string | URL,
+): { path: string; baseUrl?: string } | null {
+  if (path instanceof URL) {
+    if (path.protocol === "file:") {
+      return { path: path.pathname };
+    }
+    if (path.protocol === "https:" || path.protocol === "http:") {
+      const href = path.href.endsWith("/") ? path.href : `${path.href}/`;
+      return { path: "", baseUrl: href };
+    }
+    return null;
+  }
+
+  const raw = String(path);
+
+  if (raw.startsWith("file:")) {
+    try {
+      return { path: new URL(raw).pathname };
+    } catch {
+      return { path: raw };
+    }
+  }
+
+  if (raw.startsWith("https://") || raw.startsWith("http://")) {
+    const href = raw.endsWith("/") ? raw : `${raw}/`;
+    return { path: "", baseUrl: href };
+  }
+
+  // Plugins often pass `.pathname` of a JSR import.meta.url, which
+  // yields `/@scope/pkg/ver/help` with no protocol. Reconstruct.
+  if (isJsrPathname(raw)) {
+    const href = `https://jsr.io${raw.endsWith("/") ? raw : `${raw}/`}`;
+    return { path: "", baseUrl: href };
+  }
+
+  // Reject bare http-looking leftovers and npm-style virtual roots
+  if (
+    raw.startsWith("http:") ||
+    raw.startsWith("https:") ||
+    raw.startsWith("/http")
+  ) {
+    return null;
+  }
+
+  return { path: raw };
+}
 
 /**
  * Register a directory to be scanned for help files.
  * Call this in your plugin's init() to include your plugin's help/ folder.
  *
- * @param path    Absolute path to the directory (use `new URL("./help", import.meta.url).pathname`)
- * @param section Section name for all topics in this directory
+ * Prefer passing a URL so JSR and file: both work:
+ *   registerHelpDir(new URL("./help", import.meta.url), "mail");
  *
- * @example
- * // In your plugin's init():
- * registerHelpDir(new URL("./help", import.meta.url).pathname, "mail");
+ * `.pathname` still works for local file: plugins and for JSR
+ * (pathname `/@scope/pkg/ver/help` is reconstructed to jsr.io).
+ *
+ * @param path    Absolute path, file:/https: URL, or JSR pathname
+ * @param section Section name for all topics in this directory
  */
-export function registerHelpDir(path: string | URL, section: string): void {
-  let resolvedPath = "";
-  if (path instanceof URL) {
-    if (path.protocol !== "file:") return;
-    resolvedPath = path.pathname;
-  } else if (typeof path === "string" && path.startsWith("file:")) {
-    try {
-      resolvedPath = new URL(path).pathname;
-    } catch {
-      resolvedPath = path;
-    }
-  } else {
-    resolvedPath = String(path);
-    if (resolvedPath.startsWith("/@") || resolvedPath.startsWith("http:") || resolvedPath.startsWith("https:")) {
-      return;
-    }
-  }
-  _registeredDirs.push({ path: resolvedPath, section });
-  _cache = null; // invalidate
+export function registerHelpDir(
+  path: string | URL,
+  section: string,
+): void {
+  const resolved = resolveRegistration(path);
+  if (!resolved) return;
+  if (!resolved.path && !resolved.baseUrl) return;
+
+  // Dedupe — plugins may re-init; avoid stacking identical dirs.
+  const exists = _registeredDirs.some(
+    (d) =>
+      d.section === section &&
+      d.path === resolved.path &&
+      d.baseUrl === resolved.baseUrl,
+  );
+  if (exists) return;
+
+  _registeredDirs.push({
+    path: resolved.path,
+    baseUrl: resolved.baseUrl,
+    section,
+  });
+  _cache = null;
+  _build = null;
 }
 
 /** Clear file cache so the next lookup triggers a rescan. */
 export function bustCache(): void {
   _cache = null;
+  _build = null;
+}
+
+/** True if any path segment is underscore-prefixed (_admin, _draft.md). */
+function pathImpliesHidden(relativePath: string): boolean {
+  return relativePath
+    .replace(/^\//, "")
+    .split("/")
+    .some((seg) => seg.startsWith("_"));
+}
+
+/** Truthy YAML scalar: true / yes / 1 (case-insensitive). */
+function isYamlTrue(value: string): boolean {
+  const v = value.trim().toLowerCase();
+  return v === "true" || v === "yes" || v === "1";
+}
+
+/**
+ * Parse optional YAML frontmatter from markdown content.
+ *
+ * Hide keys (any one is enough):
+ *   hidden: true
+ *   dark: true     (help-file convention / Claude.md)
+ */
+function parseFrontmatter(raw: string): {
+  content: string;
+  hidden: boolean;
+  tags: string[];
+  aliases: string[];
+  section?: string;
+  topic?: string;
+} {
+  let content = raw;
+  let hidden = false;
+  let tags: string[] = [];
+  let aliases: string[] = [];
+  let section: string | undefined;
+  let topic: string | undefined;
+
+  if (!content.startsWith("---")) {
+    return { content, hidden, tags, aliases };
+  }
+
+  // Allow EOF right after closing --- (body may be empty).
+  const fmMatch = content.match(
+    /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/,
+  );
+  if (!fmMatch) return { content, hidden, tags, aliases };
+
+  const yaml = fmMatch[1];
+  content = fmMatch[2];
+
+  for (const line of yaml.split("\n")) {
+    const parts = line.split(":");
+    if (parts.length < 2) continue;
+    const key = parts[0].trim().toLowerCase();
+    const value = parts.slice(1).join(":").trim();
+
+    if ((key === "hidden" || key === "dark") && isYamlTrue(value)) {
+      hidden = true;
+    } else if (key === "tags" || key === "aliases") {
+      const list = value
+        .replace(/[\[\]]/g, "")
+        .split(",")
+        .map((t) => slugify(t.trim()))
+        .filter(Boolean);
+      if (key === "tags") tags = list;
+      else aliases = list;
+    } else if (key === "section" && value) {
+      section = slugify(value.replace(/^["']|["']$/g, ""));
+    } else if (key === "topic" && value) {
+      topic = slugify(value.replace(/^["']|["']$/g, ""));
+    }
+  }
+
+  return { content, hidden, tags, aliases, section, topic };
+}
+
+function entryFromFile(
+  relativePath: string,
+  section: string,
+  raw: string,
+): HelpEntry {
+  // relativePath uses / separators, no leading slash, may include dirs
+  const cleaned = relativePath.replace(/^\//, "");
+  const noExt = cleaned.replace(/\.(md|txt)$/i, "");
+  const parts = noExt.split("/").filter(Boolean);
+  const rawName = (parts.pop() ?? "index").toLowerCase();
+  const prefix = parts.map((p) => p.toLowerCase()).join("/");
+  const isIndex = rawName === "index" || rawName === "readme";
+  const topicName = prefix
+    ? (isIndex ? prefix : `${prefix}/${rawName}`)
+    : (isIndex ? section : rawName);
+
+  const fm = parseFrontmatter(raw);
+  const hidden = fm.hidden || pathImpliesHidden(cleaned);
+  const name = slugify(
+    fm.topic ||
+      (isIndex && !prefix ? section : topicName),
+  );
+  const resolvedSection = fm.section || section;
+  const tags = [...new Set([...fm.tags, ...fm.aliases])];
+
+  return {
+    name,
+    section: resolvedSection,
+    content: fm.content,
+    source: "file",
+    tags,
+    hidden,
+  };
 }
 
 /**
  * Recursively scan a directory, returning HelpEntry objects.
- *
- * @param dirPath     Directory to scan (may be a sub-path within resolvedRoot).
- * @param section     Section name for all entries found here.
- * @param prefix      Sub-topic prefix accumulated during recursion.
- * @param resolvedRoot Canonicalized root path — every file read must be
- *                    contained within this path to prevent symlink traversal.
  */
 async function scanDir(
   dirPath: string,
@@ -95,7 +264,9 @@ async function scanDir(
       dirEntries.push(e);
     }
   } catch (e) {
-    console.warn(`[help] Failed to read directory "${dirPath}": ${e}`);
+    console.warn(
+      `[help] Failed to read directory "${dirPath}": ${e}`,
+    );
     return entries;
   }
 
@@ -104,15 +275,13 @@ async function scanDir(
 
     const fullPath = `${dirPath}/${entry.name}`;
 
-    // ── Path containment check (C1 — symlink traversal defence) ──────────
-    // Resolve the real path (follows symlinks) and verify it stays within the
-    // registered root. This guards against .md symlinks that escape the root.
     let realPath: string;
     try {
       realPath = await Deno.realPath(fullPath);
     } catch {
-      // Can't resolve (broken symlink, race condition, etc.) — skip safely
-      console.warn(`[help] Cannot resolve path "${fullPath}" — skipping.`);
+      console.warn(
+        `[help] Cannot resolve path "${fullPath}" — skipping.`,
+      );
       continue;
     }
 
@@ -122,86 +291,144 @@ async function scanDir(
 
     if (!isContained) {
       console.warn(
-        `[help] Skipping "${fullPath}" — resolves to "${realPath}" which is outside scan root "${resolvedRoot}".`,
+        `[help] Skipping "${fullPath}" — resolves to ` +
+          `"${realPath}" outside scan root "${resolvedRoot}".`,
       );
       continue;
     }
-    // ── End containment check ─────────────────────────────────────────────
 
     if (entry.isDirectory) {
       const subSection = prefix
         ? `${prefix}/${entry.name.toLowerCase()}`
         : entry.name.toLowerCase();
-      const subEntries = await scanDir(fullPath, section, subSection, resolvedRoot);
+      const subEntries = await scanDir(
+        fullPath,
+        section,
+        subSection,
+        resolvedRoot,
+      );
       entries.push(...subEntries);
       continue;
     }
 
     if (!entry.isFile) continue;
-    if (!entry.name.endsWith(".md") && !entry.name.endsWith(".txt")) continue;
-
-    const rawName = entry.name.replace(/\.(md|txt)$/, "").toLowerCase();
-    const isIndex = rawName === "index" || rawName === "readme";
-    const topicName = prefix ? `${prefix}/${rawName}` : rawName;
+    if (!entry.name.endsWith(".md") && !entry.name.endsWith(".txt")) {
+      continue;
+    }
 
     let content: string;
     try {
       content = await Deno.readTextFile(fullPath);
     } catch (e) {
-      console.warn(`[help] Failed to read file "${fullPath}": ${e}`);
+      console.warn(
+        `[help] Failed to read file "${fullPath}": ${e}`,
+      );
       continue;
     }
 
-    let hidden = false;
-    let tags: string[] = [];
+    const rel = prefix
+      ? `${prefix}/${entry.name}`
+      : entry.name;
+    entries.push(entryFromFile(rel, section, content));
+  }
 
-    // Parse simple frontmatter if present
-    if (content.startsWith("---")) {
-      const fmMatch = content.match(
-        /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/,
+  return entries;
+}
+
+/**
+ * Load help files published inside a JSR package via _meta.json.
+ *
+ * baseUrl example:
+ *   https://jsr.io/@ursamu/mail/2.4.0/help/
+ */
+async function scanJsrHelp(
+  baseUrl: string,
+  section: string,
+): Promise<HelpEntry[]> {
+  const entries: HelpEntry[] = [];
+
+  const m = baseUrl.match(
+    /^https?:\/\/jsr\.io\/(@[^/]+\/[^/]+)\/([^/]+)\/(.*)$/,
+  );
+  if (!m) {
+    console.warn(
+      `[help] Not a JSR help URL, skipping: ${baseUrl}`,
+    );
+    return entries;
+  }
+
+  const pkg = m[1]; // @ursamu/mail
+  const ver = m[2]; // 2.4.0
+  const sub = m[3].replace(/\/+$/, ""); // help
+  const prefix = `/${sub}`; // /help
+
+  const metaUrl = `https://jsr.io/${pkg}/${ver}_meta.json`;
+  let manifest: Record<string, unknown> = {};
+  try {
+    const res = await fetch(metaUrl);
+    if (!res.ok) {
+      console.warn(
+        `[help] JSR meta ${metaUrl} → HTTP ${res.status}`,
       );
-      if (fmMatch) {
-        const yaml = fmMatch[1];
-        content = fmMatch[2];
+      return entries;
+    }
+    const json = await res.json() as {
+      manifest?: Record<string, unknown>;
+    };
+    manifest = json.manifest ?? {};
+  } catch (e: unknown) {
+    console.warn(
+      `[help] Failed to fetch JSR meta ${metaUrl}: ${e}`,
+    );
+    return entries;
+  }
 
-        for (const line of yaml.split("\n")) {
-          const parts = line.split(":");
-          if (parts.length >= 2) {
-            const key = parts[0].trim().toLowerCase();
-            const value = parts.slice(1).join(":").trim();
-            if (key === "hidden" && value === "true") {
-              hidden = true;
-            } else if (key === "tags") {
-              tags = value
-                .replace(/[\[\]]/g, "")
-                .split(",")
-                .map((t) => slugify(t.trim()))
-                .filter(Boolean);
-            }
-          }
+  const mdKeys = Object.keys(manifest).filter((k) => {
+    if (!k.startsWith(prefix + "/") && k !== prefix) return false;
+    return k.endsWith(".md") || k.endsWith(".txt");
+  });
+
+  if (mdKeys.length === 0) {
+    console.warn(
+      `[help] JSR package ${pkg}@${ver} has no .md under ` +
+        `${prefix}/ — was help/ included in publish?`,
+    );
+    return entries;
+  }
+
+  console.log(
+    `[help] Loading ${mdKeys.length} topic(s) from ` +
+      `${pkg}@${ver}${prefix}/`,
+  );
+
+  // Parallel fetch — sequential cold loads of large packages
+  // (e.g. cofd ~140 files) stall the event loop for seconds.
+  const settled = await Promise.all(
+    mdKeys.map(async (filePath) => {
+      const url = `https://jsr.io/${pkg}/${ver}${filePath}`;
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          console.warn(
+            `[help] JSR fetch ${url} → HTTP ${res.status}`,
+          );
+          return null;
         }
+        const raw = await res.text();
+        const rel = filePath
+          .slice(prefix.length)
+          .replace(/^\//, "");
+        if (!rel) return null;
+        return entryFromFile(rel, section, raw);
+      } catch (e: unknown) {
+        console.warn(`[help] JSR fetch failed ${url}: ${e}`);
+        return null;
       }
-    }
+    }),
+  );
 
-    if (isIndex) {
-      entries.push({
-        name: slugify(prefix || section),
-        section,
-        content,
-        source: "file",
-        tags,
-        hidden,
-      });
-    } else {
-      entries.push({
-        name: slugify(topicName),
-        section,
-        content,
-        source: "file",
-        tags,
-        hidden,
-      });
-    }
+  for (const entry of settled) {
+    if (entry) entries.push(entry);
   }
 
   return entries;
@@ -211,42 +438,68 @@ async function buildCache(): Promise<Map<string, HelpEntry>> {
   const map = new Map<string, HelpEntry>();
   const cwd = Deno.cwd();
 
-  // ── Scan game-level root ./help/ ─────────────────────────────────────────
+  // ── Optional game-level ./help/ (site-specific overrides only) ──
+  // Plugin topics come from registerHelpDir (package help/), not
+  // a vendored copy of every package under the game root.
   let rootResolved: string | null = null;
   try {
     rootResolved = await Deno.realPath("./help");
   } catch {
-    // ./help doesn't exist — fine, skip it silently
+    // ./help doesn't exist — fine
   }
 
   if (rootResolved) {
-    const rootEntries = await scanDir("./help", "general", "", rootResolved);
+    const rootEntries = await scanDir(
+      "./help",
+      "general",
+      "",
+      rootResolved,
+    );
     for (const entry of rootEntries) {
       map.set(entry.name, entry);
     }
   }
 
-  // ── Scan plugin-registered dirs ───────────────────────────────────────────
-  for (const dir of _registeredDirs) {
-    let resolvedRoot: string;
-    try {
-      resolvedRoot = await Deno.realPath(dir.path);
-    } catch (e) {
-      console.warn(`[help] Registered help dir "${dir.path}" cannot be resolved — skipping: ${e}`);
-      continue;
-    }
+  // ── Plugin-registered dirs (file: checkout or JSR https://) ────
+  // Load in parallel; single-flight cache() coalesces callers.
+  const batches = await Promise.all(
+    _registeredDirs.map(async (dir) => {
+      if (dir.baseUrl) {
+        return await scanJsrHelp(dir.baseUrl, dir.section);
+      }
+      if (!dir.path) return [] as HelpEntry[];
 
-    // H1 — warn when the registered path is outside the game working directory.
-    // Plugins installed via JSR legitimately live outside cwd, so this is a
-    // warning (not a hard rejection), but it surfaces accidental mis-registrations.
-    if (!resolvedRoot.startsWith(cwd)) {
-      console.warn(
-        `[help] Registered help dir "${resolvedRoot}" is outside the game directory "${cwd}". ` +
-          `This is expected for JSR-installed plugins but unusual otherwise.`,
+      let resolvedRoot: string;
+      try {
+        resolvedRoot = await Deno.realPath(dir.path);
+      } catch (e) {
+        console.warn(
+          `[help] Registered help dir "${dir.path}" cannot ` +
+            `be resolved — skipping: ${e}`,
+        );
+        return [] as HelpEntry[];
+      }
+
+      if (!resolvedRoot.startsWith(cwd)) {
+        console.warn(
+          `[help] Registered help dir "${resolvedRoot}" is ` +
+            `outside the game directory "${cwd}". Expected ` +
+            `for JSR/local plugin checkouts.`,
+        );
+      }
+
+      return await scanDir(
+        dir.path,
+        dir.section,
+        "",
+        resolvedRoot,
       );
-    }
+    }),
+  );
 
-    const entries = await scanDir(dir.path, dir.section, "", resolvedRoot);
+  // Plugin files win over game-root on name collision only when
+  // game root did not already define the topic (overrides first).
+  for (const entries of batches) {
     for (const entry of entries) {
       if (!map.has(entry.name)) {
         map.set(entry.name, entry);
@@ -261,8 +514,20 @@ export class FileProvider implements HelpProvider {
   readonly priority = 50;
 
   private async cache(): Promise<Map<string, HelpEntry>> {
-    if (!_cache) _cache = await buildCache();
-    return _cache;
+    if (_cache) return _cache;
+    if (!_build) {
+      _build = buildCache()
+        .then((m) => {
+          _cache = m;
+          _build = null;
+          return m;
+        })
+        .catch((e: unknown) => {
+          _build = null;
+          throw e;
+        });
+    }
+    return _build;
   }
 
   async get(topic: string): Promise<HelpEntry | null> {

--- a/packages/help/src/routes.ts
+++ b/packages/help/src/routes.ts
@@ -23,88 +23,114 @@ async function isAdmin(userId: string): Promise<boolean> {
   return flagSet.has("admin") || flagSet.has("wizard") || flagSet.has("superuser");
 }
 
-registerPluginRoute("/api/v1/help", async (req, _userId) => {
-  // Route: GET /api/v1/help
-  if (req.method === "GET") {
+/**
+ * Single prefix handler for /api/v1/help and /api/v1/help/<topic>.
+ * dispatchPluginRoute matches by startsWith(prefix+"/"), so a separate
+ * "/api/v1/help/:topic" registration never receives traffic — the bare
+ * "/api/v1/help" handler always wins. Handle both paths here.
+ */
+registerPluginRoute("/api/v1/help", async (req, userId) => {
+  const url = new URL(req.url);
+  const rest = url.pathname
+    .replace(/^\/api\/v1\/help\/?/, "")
+    .replace(/\/+$/, "");
+  const topic = rest ? slugify(rest) : "";
+
+  // GET /api/v1/help — index (hide dark/hidden topics from listings)
+  if (!topic && req.method === "GET") {
     const sections = await helpRegistry.sections();
-    const topics   = await helpRegistry.all();
+    const topics = (await helpRegistry.all()).filter((e) => !e.hidden);
     return Response.json({ sections, topics });
   }
 
-  return Response.json({ error: "Method not allowed" }, { status: 405 });
-});
-
-registerPluginRoute("/api/v1/help/:topic", async (req, userId) => {
-  const url    = new URL(req.url);
-  // Extract topic from path: /api/v1/help/<topic>
-  const topic  = slugify(url.pathname.replace(/^\/api\/v1\/help\//, ""));
-
   if (!topic) {
-    return Response.json({ error: "Topic is required" }, { status: 400 });
+    return Response.json(
+      { error: "Method not allowed" },
+      { status: 405 },
+    );
   }
 
-  // GET — public
+  // GET /api/v1/help/<topic>
   if (req.method === "GET") {
     const entry = await helpRegistry.lookup(topic);
     if (!entry) {
       return Response.json({ error: "Not found" }, { status: 404 });
     }
-    // Support raw markdown via ?format=md
     if (url.searchParams.get("format") === "md") {
       return new Response(entry.content, {
-        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+        },
       });
     }
     return Response.json({ entry });
   }
 
-  // Write operations require auth
   if (!userId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // POST — create/update (admin only)
+  // POST /api/v1/help/<topic>
   if (req.method === "POST") {
     if (!(await isAdmin(userId))) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    let body: { content?: unknown; section?: unknown; tags?: unknown };
+    let body: {
+      content?: unknown;
+      section?: unknown;
+      tags?: unknown;
+    };
     try {
       body = await req.json();
     } catch {
-      return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+      return Response.json(
+        { error: "Invalid JSON body" },
+        { status: 400 },
+      );
     }
 
     if (typeof body.content !== "string" || !body.content.trim()) {
-      return Response.json({ error: "content is required" }, { status: 400 });
+      return Response.json(
+        { error: "content is required" },
+        { status: 400 },
+      );
     }
 
-    const section = typeof body.section === "string" && body.section
-      ? body.section.toLowerCase()
-      : (topic.includes("/") ? topic.split("/")[0] : "general");
+    const section =
+      typeof body.section === "string" && body.section
+        ? body.section.toLowerCase()
+        : (topic.includes("/") ? topic.split("/")[0] : "general");
 
-    const tags = Array.isArray(body.tags) && body.tags.every((t) => typeof t === "string")
-      ? body.tags as string[]
-      : [];
+    const tags =
+      Array.isArray(body.tags) &&
+        body.tags.every((t) => typeof t === "string")
+        ? body.tags as string[]
+        : [];
 
     const entry = await upsertEntry({
-      name:      topic,
+      name: topic,
       section,
-      content:   body.content.trim(),
+      content: body.content.trim(),
       tags,
-      source:    "database",
+      source: "database",
       createdBy: userId,
     });
 
     emitHelp("help:register", {
-      entry: { name: entry.name, section: entry.section, content: entry.content, source: "database", tags: entry.tags },
+      entry: {
+        name: entry.name,
+        section: entry.section,
+        content: entry.content,
+        source: "database",
+        tags: entry.tags,
+      },
     });
 
     return Response.json({ entry }, { status: 201 });
   }
 
-  // DELETE (admin only)
+  // DELETE /api/v1/help/<topic>
   if (req.method === "DELETE") {
     if (!(await isAdmin(userId))) {
       return Response.json({ error: "Forbidden" }, { status: 403 });

--- a/packages/help/tests/help.test.ts
+++ b/packages/help/tests/help.test.ts
@@ -197,6 +197,65 @@ describe("FileProvider", () => {
   it("registerHelpDir() is a function", () => {
     assertEquals(typeof registerHelpDir, "function");
   });
+
+  it("honors dark: true and hidden: true frontmatter", async () => {
+    const dir = await Deno.makeTempDir({ prefix: "help_dark_" });
+    try {
+      await Deno.writeTextFile(
+        `${dir}/visible.md`,
+        "# Visible\n\nShown in index.\n",
+      );
+      await Deno.writeTextFile(
+        `${dir}/staff-only.md`,
+        "---\ndark: true\n---\n# Staff\n\nHidden body.\n",
+      );
+      await Deno.writeTextFile(
+        `${dir}/legacy-hide.md`,
+        "---\nhidden: true\n---\n# Legacy\n\nAlso hidden.\n",
+      );
+      bustCache();
+      registerHelpDir(dir, "test-dark");
+      const entries = await new FileProvider().all();
+      const byName = new Map(entries.map((e) => [e.name, e]));
+
+      assertEquals(byName.get("visible")?.hidden, false);
+      assertEquals(byName.get("staff-only")?.hidden, true);
+      assertEquals(byName.get("legacy-hide")?.hidden, true);
+    } finally {
+      bustCache();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("hides underscore-prefixed files and folders", async () => {
+    const dir = await Deno.makeTempDir({ prefix: "help_us_" });
+    try {
+      await Deno.mkdir(`${dir}/_admin`);
+      await Deno.writeTextFile(
+        `${dir}/_admin/reboot.md`,
+        "# Reboot\n\nAdmin only.\n",
+      );
+      await Deno.writeTextFile(
+        `${dir}/_draft.md`,
+        "# Draft\n\nNot listed.\n",
+      );
+      await Deno.writeTextFile(
+        `${dir}/public.md`,
+        "# Public\n\nListed.\n",
+      );
+      bustCache();
+      registerHelpDir(dir, "test-us");
+      const entries = await new FileProvider().all();
+      const byName = new Map(entries.map((e) => [e.name, e]));
+
+      assertEquals(byName.get("public")?.hidden, false);
+      assertEquals(byName.get("draft")?.hidden, true);
+      assertEquals(byName.get("admin/reboot")?.hidden, true);
+    } finally {
+      bustCache();
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  });
 });
 
 // ── DbProvider ────────────────────────────────────────────────────────────────

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -29,7 +29,7 @@ const jobsPlugin: IPlugin = {
     registerPluginRoute("/api/v1/jobs", jobsRouteHandler);
     registerNotifyHooks();
     registerHelpDir(
-      new URL("../help", import.meta.url).pathname,
+      new URL("../help", import.meta.url),
       "jobs",
     );
 

--- a/packages/lang/src/help.ts
+++ b/packages/lang/src/help.ts
@@ -13,12 +13,13 @@
 
 import { registerHelpDir } from "@ursamu/help-plugin";
 
-const HELP_DIR = new URL("../help", import.meta.url).pathname;
+const HELP_DIR = new URL("../help", import.meta.url);
 const SECTION  = "language";
 
 export function registerHelp(): void {
   registerHelpDir(HELP_DIR, SECTION);
   console.log(
-    `[sgp-language] Registered help directory ${HELP_DIR} (section "${SECTION}").`,
+    `[sgp-language] Registered help directory ${HELP_DIR.href} ` +
+      `(section "${SECTION}").`,
   );
 }

--- a/packages/mail/src/index.ts
+++ b/packages/mail/src/index.ts
@@ -78,7 +78,7 @@ export const plugin: IPlugin = {
     registerPluginRoute("/api/v1/mail", mailRouteHandler);
     try {
       registerHelpDir(
-        new URL("../help", import.meta.url).pathname,
+        new URL("../help", import.meta.url),
         "mail",
       );
     } catch (e: unknown) {

--- a/packages/mekton/index.ts
+++ b/packages/mekton/index.ts
@@ -62,7 +62,7 @@ export const plugin: IPlugin = {
   description: "Mekton Zeta chargen, gear, combat, and AI GM bridge for UrsaMU.",
 
   init: () => {
-    registerHelpDir(new URL("./help", import.meta.url).pathname, "mekton-zeta");
+    registerHelpDir(new URL("./help", import.meta.url), "mekton-zeta");
     gameHooks.on("player:login", onLogin);
     gameHooks.emit("gm:system:register" as never, {
       system: mektonSystem,

--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts"

--- a/packages/mush/mod.ts
+++ b/packages/mush/mod.ts
@@ -16,7 +16,7 @@ export * from "@ursamu/core";
 // World model
 export type { IDBObj, IDBOBJ, IAttribute, IGameTime } from "./src/world/types.ts";
 export { dbojs, counters, chans, texts, scenes, chanHistory, Obj, createObj, userFuncs, serverTags, playerTags, zoneMemberships } from "./src/world/dbobjs.ts";
-export { flags }                             from "./src/world/flags.ts";
+export { flags, flagCodes, dbrefWithFlags } from "./src/world/flags.ts";
 export { evaluateLock, validateLock, registerLockFunc, registerLockEvaluator, callLockFunc } from "./src/world/locks.ts";
 export type { LockFunc } from "./src/world/locks.ts";
 export { hydrate }                           from "./src/world/dbobjs.ts";

--- a/packages/mush/src/commands/addCmd.ts
+++ b/packages/mush/src/commands/addCmd.ts
@@ -164,6 +164,7 @@ export async function loadDefaultCommands(): Promise<void> {
   await import("../verbs/js-eval.ts");
   await import("../verbs/avatar.ts");
   await import("../verbs/moniker.ts");
+  await import("../verbs/gradient.ts");
   await import("../verbs/softcode-trigger.ts");
   await import("../verbs/softcode-wait.ts");
   await import("../verbs/softcode-dolist.ts");

--- a/packages/mush/src/events/hooks.ts
+++ b/packages/mush/src/events/hooks.ts
@@ -144,11 +144,17 @@ export const hooks = {
     } catch (e) {
       console.error("[Hooks] aconnect error:", e);
     }
-    gameHooks.emit("player:login", {
-      actorId:   player.id,
-      actorName: (player.data?.name as string) || player.id,
-      socketId,
-    }).catch(e => console.error("[GameHooks] player:login:", e));
+    // Await listeners (channel auto-join, etc.) so login finishes
+    // only after data.channels is updated and rooms are joined.
+    try {
+      await gameHooks.emit("player:login", {
+        actorId: player.id,
+        actorName: (player.data?.name as string) || player.id,
+        socketId,
+      });
+    } catch (e: unknown) {
+      console.error("[GameHooks] player:login:", e);
+    }
   },
 
   adisconnect: async (player: IDBOBJ, socketId?: string): Promise<void> => {

--- a/packages/mush/src/main.ts
+++ b/packages/mush/src/main.ts
@@ -516,26 +516,41 @@ async function repairPlayerLocations(
 }
 
 /**
- * Initialize default channels if they don't exist
+ * Initialize default channels if they don't exist.
+ * Prefer plugins.channels.defaults (same shape as @ursamu/channels)
+ * so the engine and plugin seed identical records.
  */
 async function initializeDefaultChannels() {
   const channels = await chans.all();
+  if (channels.length) return;
 
-  if (!channels.length) {
-    await chans.create({
-      id: "pub",
-      name: "Public",
-      header: "%ch%cc[Public]%cn",
-      alias: "pub",
-    });
+  // Skip when @ursamu/channels will seed on engine:ready —
+  // avoids duplicate Public rows (id "pub" vs "public").
+  const pluginList = getConfig<string[]>("server.plugins", []) ?? [];
+  if (pluginList.some((p) => /channels/i.test(p))) {
+    console.log(
+      "[startup] Skipping built-in channel seed — " +
+        "@ursamu/channels will seed from config.",
+    );
+    return;
+  }
 
+  type ChanDef = { name: string; alias: string; lock?: string };
+  const defaults = getConfig<ChanDef[]>("plugins.channels.defaults") ?? [
+    { name: "Public", alias: "pub", lock: "connected" },
+    { name: "Admin", alias: "ad", lock: "connected admin+" },
+  ];
+
+  for (const def of defaults) {
+    const id = def.name.toLowerCase();
     await chans.create({
-      id: "admin",
-      name: "Admin",
-      header: "%ch%cy[Admin]%cn",
-      alias: "ad",
-      lock: "admin+",
+      id,
+      name: def.name,
+      header: `%ch%cc[${def.name}]%cn`,
+      alias: def.alias,
+      lock: def.lock || "",
     });
+    console.log(`[startup] Seeded channel ${def.name} (${def.alias})`);
   }
 }
 

--- a/packages/mush/src/routes/index.ts
+++ b/packages/mush/src/routes/index.ts
@@ -256,28 +256,39 @@ const EXT_MIME: Record<string, string> = {
   png: "image/png", jpg: "image/jpeg", gif: "image/gif", webp: "image/webp",
 };
 
-/** Public: serve an avatar image by player ID. Used by tests and fallback handler. */
+/**
+ * Public: serve avatar by id or id.ext
+ *   /avatars/2       → data/avatars/2.*
+ *   /avatars/2.jpg   → data/avatars/2.jpg (exact)
+ * Discord webhooks need a path ending in an image extension.
+ */
 export async function avatarServe(urlPath: string): Promise<Response> {
-  const id = urlPath.slice("/avatars/".length);
-  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) {
+  const raw = urlPath.slice("/avatars/".length).split("?")[0];
+  // id or id.ext — no path traversal
+  if (!raw || !/^[a-zA-Z0-9_-]+(\.(png|jpe?g|gif|webp))?$/i.test(raw)) {
     return new Response("Not Found", { status: 404 });
   }
+  const wantExact = raw.includes(".");
+  const id = wantExact ? raw.replace(/\.[^.]+$/, "") : raw;
   try {
     for await (const entry of Deno.readDir("data/avatars")) {
-      if (entry.name.startsWith(id + ".")) {
-        const ext  = (entry.name.split(".").pop() ?? "").toLowerCase();
-        const file = await Deno.readFile(`data/avatars/${entry.name}`);
-        return new Response(file, {
-          status: 200,
-          headers: {
-            "Content-Type":  EXT_MIME[ext] ?? "application/octet-stream",
-            "Cache-Control": "public, max-age=3600",
-            // Bypass interstitial warning pages on ngrok and localtunnel
-            "ngrok-skip-browser-warning": "true",
-            "bypass-tunnel-reminder": "true",
-          },
-        });
-      }
+      const hit = wantExact
+        ? entry.name.toLowerCase() === raw.toLowerCase()
+        : entry.name.startsWith(id + ".");
+      if (!hit) continue;
+      const ext = (entry.name.split(".").pop() ?? "").toLowerCase();
+      const file = await Deno.readFile(`data/avatars/${entry.name}`);
+      return new Response(file, {
+        status: 200,
+        headers: {
+          "Content-Type": EXT_MIME[ext] ?? "application/octet-stream",
+          // Short cache — Discord rejects ?query cache-busters on
+          // avatar_url, so replacements rely on re-fetch.
+          "Cache-Control": "public, max-age=300",
+          "ngrok-skip-browser-warning": "true",
+          "bypass-tunnel-reminder": "true",
+        },
+      });
     }
   } catch { /* data/avatars doesn't exist yet */ }
   return new Response("Not Found", { status: 404 });

--- a/packages/mush/src/telnet.ts
+++ b/packages/mush/src/telnet.ts
@@ -168,7 +168,7 @@ async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, _welcome:
   let isReconnecting = false;
   // True while JWT reauth is in flight — hold cmds until auth:true.
   let pendingReauth = false;
-  let reauthTimer: number | undefined;
+  let reauthTimer: ReturnType<typeof setTimeout> | undefined;
   let manuallyClosed = false;
 
   const encoder = new TextEncoder();

--- a/packages/mush/src/verbs/auth.ts
+++ b/packages/mush/src/verbs/auth.ts
@@ -39,6 +39,19 @@ export async function execCreate(u: IUrsamuSDK): Promise<void> {
     state: { name, password },
   });
 
+  // Grant first-user superuser BEFORE login so player:login hooks
+  // (e.g. channel auto-join with admin+ locks) see elevated flags.
+  let firstUser = false;
+  try {
+    const superusers = await u.db.search({ flags: /superuser/ });
+    if (!superusers.length) {
+      await u.setFlags(player.id, "superuser");
+      firstUser = true;
+    }
+  } catch (e: unknown) {
+    console.warn("[create] superuser check failed:", e);
+  }
+
   await u.auth.login(player.id);
 
   try {
@@ -48,14 +61,8 @@ export async function execCreate(u: IUrsamuSDK): Promise<void> {
     console.warn("[create] Failed to issue session token:", e);
   }
 
-  try {
-    const superusers = await u.db.search({ flags: /superuser/ });
-    if (!superusers.length) {
-      await u.setFlags(player.id, "superuser");
-      u.send("%ch%cyYou are the first user — superuser access granted.%cn");
-    }
-  } catch (e: unknown) {
-    console.warn("[create] superuser check failed:", e);
+  if (firstUser) {
+    u.send("%ch%cyYou are the first user — superuser access granted.%cn");
   }
 
   u.send(`Welcome, ${name}! Your character has been created.`);
@@ -86,6 +93,21 @@ export async function execConnect(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
+  // Elevate before login so channel auto-join sees staff locks.
+  let grantedSuper = false;
+  try {
+    if (!player.flags.has("superuser")) {
+      const superusers = await u.db.search({ flags: /superuser/ });
+      if (!superusers.length) {
+        await u.setFlags(player.id, "superuser");
+        player.flags.add("superuser");
+        grantedSuper = true;
+      }
+    }
+  } catch (e: unknown) {
+    console.warn("auth: superuser check failed:", e);
+  }
+
   await u.auth.login(player.id);
 
   try {
@@ -95,16 +117,8 @@ export async function execConnect(u: IUrsamuSDK): Promise<void> {
     console.warn("[auth] Failed to issue session token:", e);
   }
 
-  try {
-    if (!player.flags.has("superuser")) {
-      const superusers = await u.db.search({ flags: /superuser/ });
-      if (!superusers.length) {
-        await u.setFlags(player.id, "superuser");
-        u.send("%ch%cyYou are the first user — superuser access granted.%cn");
-      }
-    }
-  } catch (e: unknown) {
-    console.warn("auth: superuser check failed:", e);
+  if (grantedSuper) {
+    u.send("%ch%cyYou are the first user — superuser access granted.%cn");
   }
 
   u.send(`Welcome back, ${u.util.displayName(player, player)}.`);

--- a/packages/mush/src/verbs/avatar-fetch.ts
+++ b/packages/mush/src/verbs/avatar-fetch.ts
@@ -1,0 +1,166 @@
+/**
+ * SSRF-safe image fetch for @avatar.
+ * HTTPS keeps the hostname (TLS cert/SNI). HTTP pins the
+ * resolved public IP against DNS rebinding.
+ */
+
+import type { IUrsamuSDK } from "../commands/types.ts";
+
+const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+const FETCH_HEADERS = {
+  "User-Agent": "UrsaMU-Avatar/1.0",
+  "Accept": "image/avif,image/webp,image/*,*/*;q=0.8",
+} as const;
+
+const ALLOWED_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+export const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+/**
+ * Returns true if `hostname` is private, loopback, link-local, or
+ * otherwise internal (SSRF guard).
+ */
+export function isPrivateHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost") return true;
+  if (/^::ffff:/i.test(h)) return isPrivateHost(h.slice(7));
+  if (
+    h === "::1" || h.startsWith("fc") || h.startsWith("fd") ||
+    h.startsWith("fe80")
+  ) {
+    return true;
+  }
+  const parts = h.split(".").map(Number);
+  if (parts.length !== 4 || parts.some(isNaN)) return false;
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    a >= 240
+  );
+}
+
+/**
+ * Returns a copy of `originalUrl` with hostname replaced by
+ * `resolvedIp`. Used for plain-HTTP IP pinning only.
+ */
+export function buildPinnedFetchUrl(
+  originalUrl: string,
+  resolvedIp: string,
+): string {
+  const parsed = new URL(originalUrl);
+  if (resolvedIp.includes(":")) {
+    const portPart = parsed.port ? `:${parsed.port}` : "";
+    parsed.host = `[${resolvedIp}]${portPart}`;
+  } else {
+    parsed.hostname = resolvedIp;
+  }
+  return parsed.toString();
+}
+
+/** Resolve A/AAAA; reject if any record is private. */
+export async function resolvePublicIps(
+  hostname: string,
+  u: IUrsamuSDK,
+): Promise<string[] | null> {
+  if (isPrivateHost(hostname)) {
+    u.send("URL resolves to a private or internal address.");
+    return null;
+  }
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(":")) {
+    return [hostname];
+  }
+
+  let aRecords: string[] = [];
+  let aaaaRecords: string[] = [];
+  try {
+    aRecords = await Deno.resolveDns(hostname, "A").catch(() => []);
+    aaaaRecords = await Deno.resolveDns(hostname, "AAAA").catch(() => []);
+  } catch {
+    // DNS API failure — fetch may still succeed by hostname.
+  }
+  const all = [...aRecords, ...aaaaRecords];
+  if (all.some(isPrivateHost)) {
+    u.send("URL resolves to a private or internal address.");
+    return null;
+  }
+  return all;
+}
+
+/**
+ * HTTPS keeps the real hostname so TLS works. Plain HTTP pins the
+ * first public IP and sets Host for virtual hosts.
+ */
+export function chooseFetchTarget(
+  url: URL,
+  resolvedIps: string[],
+): { fetchUrl: string; hostHeader?: string } {
+  const ip = resolvedIps[0];
+  if (url.protocol === "http:" && ip) {
+    return {
+      fetchUrl: buildPinnedFetchUrl(url.toString(), ip),
+      hostHeader: url.hostname,
+    };
+  }
+  return { fetchUrl: url.toString() };
+}
+
+export async function fetchAndValidate(
+  url: URL,
+  u: IUrsamuSDK,
+): Promise<{ bytes: Uint8Array; ext: string } | null> {
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const ips = await resolvePublicIps(hostname, u);
+  if (ips === null) return null;
+
+  const { fetchUrl, hostHeader } = chooseFetchTarget(url, ips);
+  const headers: Record<string, string> = { ...FETCH_HEADERS };
+  if (hostHeader) headers["Host"] = hostHeader;
+
+  let res: Response;
+  try {
+    res = await fetch(fetchUrl, {
+      redirect: "error",
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    u.send("Could not fetch that URL.");
+    return null;
+  }
+  if (!res.ok) {
+    u.send(
+      `Request failed (${res.status}). Check the URL and try again.`,
+    );
+    return null;
+  }
+
+  const mime = (res.headers.get("content-type") || "")
+    .split(";")[0].trim().toLowerCase();
+  if (!ALLOWED_MIME.has(mime)) {
+    u.send("URL must point to a PNG, JPEG, GIF, or WebP image.");
+    return null;
+  }
+
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  if (bytes.length > MAX_BYTES) {
+    u.send("Image must be 2 MB or smaller.");
+    return null;
+  }
+  return { bytes, ext: MIME_TO_EXT[mime] || "png" };
+}

--- a/packages/mush/src/verbs/avatar.ts
+++ b/packages/mush/src/verbs/avatar.ts
@@ -3,38 +3,21 @@ import type { IUrsamuSDK } from "../commands/types.ts";
 import { dbojs } from "../world/dbobjs.ts";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
+import {
+  fetchAndValidate,
+  isPrivateHost,
+  buildPinnedFetchUrl,
+  chooseFetchTarget,
+} from "./avatar-fetch.ts";
+
+export {
+  isPrivateHost,
+  buildPinnedFetchUrl,
+  chooseFetchTarget,
+  fetchAndValidate,
+} from "./avatar-fetch.ts";
 
 const AVATARS_DIR = "data/avatars";
-const MAX_BYTES = 2 * 1024 * 1024; // 2 MB
-
-/**
- * Returns true if `hostname` is private, loopback, link-local, or otherwise
- * internal (SSRF guard).
- */
-export function isPrivateHost(hostname: string): boolean {
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (h === "localhost") return true;
-  if (/^::ffff:/i.test(h)) return isPrivateHost(h.slice(7));
-  if (h === "::1" || h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80")) return true;
-  const parts = h.split(".").map(Number);
-  if (parts.length !== 4 || parts.some(isNaN)) return false;
-  const [a, b] = parts;
-  return (
-    a === 0   ||
-    a === 10  ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168) ||
-    a >= 240
-  );
-}
-
-const ALLOWED_MIME = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
-const MIME_TO_EXT: Record<string, string> = {
-  "image/png": "png", "image/jpeg": "jpg", "image/gif": "gif", "image/webp": "webp",
-};
 
 async function removeExistingAvatar(id: string): Promise<void> {
   try {
@@ -48,63 +31,10 @@ async function removeExistingAvatar(id: string): Promise<void> {
   }
 }
 
-/**
- * Returns a copy of `originalUrl` with its hostname replaced by `resolvedIp`.
- */
-export function buildPinnedFetchUrl(originalUrl: string, resolvedIp: string): string {
-  const parsed = new URL(originalUrl);
-  if (resolvedIp.includes(":")) {
-    const portPart = parsed.port ? `:${parsed.port}` : "";
-    parsed.host = `[${resolvedIp}]${portPart}`;
-  } else {
-    parsed.hostname = resolvedIp;
-  }
-  return parsed.toString();
-}
-
-async function fetchAndValidate(url: URL, u: IUrsamuSDK): Promise<Uint8Array | null> {
-  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (isPrivateHost(hostname)) { u.send("URL resolves to a private or internal address."); return null; }
-  
-  let resolvedIp = "";
-  try {
-    const aRecords    = await Deno.resolveDns(hostname, "A").catch(() => [] as string[]);
-    const aaaaRecords = await Deno.resolveDns(hostname, "AAAA").catch(() => [] as string[]);
-    const allRecords  = [...aRecords, ...aaaaRecords];
-    if (allRecords.some(isPrivateHost)) {
-      u.send("URL resolves to a private or internal address.");
-      return null;
-    }
-    resolvedIp = allRecords[0];
-  } catch {
-    // DNS resolution failure is not fatal
-  }
-
-  let res: Response;
-  try {
-    const fetchUrl = resolvedIp ? buildPinnedFetchUrl(url.toString(), resolvedIp) : url.toString();
-    const headers: Record<string, string> = {};
-    if (resolvedIp) {
-      headers["Host"] = url.hostname;
-    }
-    res = await fetch(fetchUrl, {
-      redirect: "error",
-      headers,
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch { u.send("Could not fetch that URL."); return null; }
-  if (!res.ok) { u.send(`Request failed (${res.status}). Check the URL and try again.`); return null; }
-
-  const mime = (res.headers.get("content-type") || "").split(";")[0].trim().toLowerCase();
-  if (!ALLOWED_MIME.has(mime)) { u.send("URL must point to a PNG, JPEG, GIF, or WebP image."); return null; }
-
-  const bytes = new Uint8Array(await res.arrayBuffer());
-  if (bytes.length > MAX_BYTES) { u.send("Image must be 2 MB or smaller."); return null; }
-  return bytes;
-}
-
 export async function execAvatar(u: IUrsamuSDK): Promise<void> {
-  const arg = (u.cmd.args[0] || "").trim();
+  const raw = u.cmd.args[0] || "";
+  const arg = (u.util?.stripSubs ? u.util.stripSubs(raw) : raw)
+    .trim();
 
   if (!arg || arg.toLowerCase() === "clear") {
     await removeExistingAvatar(u.me.id);
@@ -119,27 +49,35 @@ export async function execAvatar(u: IUrsamuSDK): Promise<void> {
   }
 
   let url: URL;
-  try { url = new URL(arg); } catch { u.send("Invalid URL."); return; }
+  try {
+    url = new URL(arg);
+  } catch {
+    u.send("Invalid URL.");
+    return;
+  }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    u.send("URL must use http or https."); return;
+    u.send("URL must use http or https.");
+    return;
   }
 
-  const mime = (url.toString().match(/\.(png|jpg|jpeg|gif|webp)(\?|$)/i)?.[1] || "").toLowerCase();
-  const bytes = await fetchAndValidate(url, u);
-  if (!bytes) return;
-
-  const contentMime = mime || "image/png";
-  const ext = MIME_TO_EXT[contentMime] || "png";
+  const result = await fetchAndValidate(url, u);
+  if (!result) return;
 
   const player = await dbojs.queryOne({ id: u.me.id });
-  if (!player) { u.send("Error: could not find your player record."); return; }
+  if (!player) {
+    u.send("Error: could not find your player record.");
+    return;
+  }
 
   await ensureDir(AVATARS_DIR);
   await removeExistingAvatar(u.me.id);
-  await Deno.writeFile(join(AVATARS_DIR, `${u.me.id}.${ext}`), bytes);
+  await Deno.writeFile(
+    join(AVATARS_DIR, `${u.me.id}.${result.ext}`),
+    result.bytes,
+  );
 
   player.data ||= {};
-  player.data.avatarExt = ext;
+  player.data.avatarExt = result.ext;
   await dbojs.modify({ id: player.id }, "$set", player);
   u.send("Avatar saved.");
 }

--- a/packages/mush/src/verbs/gradient-colors.ts
+++ b/packages/mush/src/verbs/gradient-colors.ts
@@ -1,0 +1,102 @@
+/**
+ * Color parsing and gradient sampling for +gradient.
+ */
+
+export type Rgb = readonly [number, number, number];
+
+const NAMED: Record<string, Rgb> = {
+  black: [0, 0, 0],
+  red: [255, 0, 0],
+  green: [0, 200, 0],
+  blue: [0, 100, 255],
+  yellow: [255, 220, 0],
+  cyan: [0, 220, 255],
+  magenta: [255, 0, 200],
+  purple: [160, 32, 240],
+  orange: [255, 140, 0],
+  pink: [255, 105, 180],
+  white: [255, 255, 255],
+  gray: [160, 160, 160],
+  grey: [160, 160, 160],
+  brown: [139, 90, 43],
+  lime: [50, 255, 50],
+  teal: [0, 180, 180],
+  navy: [0, 0, 128],
+  gold: [255, 200, 40],
+  silver: [192, 192, 192],
+  r: [255, 0, 0],
+  g: [0, 200, 0],
+  b: [0, 100, 255],
+  y: [255, 220, 0],
+  c: [0, 220, 255],
+  m: [255, 0, 200],
+  w: [255, 255, 255],
+  x: [0, 0, 0],
+};
+
+/** Parse one color token to RGB, or null if invalid. */
+export function parseColor(raw: string): Rgb | null {
+  const s = raw.trim().toLowerCase();
+  if (!s) return null;
+  if (NAMED[s]) return NAMED[s];
+
+  let hex = s.startsWith("#") ? s.slice(1) : s;
+  if (/^[0-9a-f]{3}$/i.test(hex)) {
+    hex = hex.split("").map((c) => c + c).join("");
+  }
+  if (!/^[0-9a-f]{6}$/i.test(hex)) return null;
+
+  return [
+    parseInt(hex.slice(0, 2), 16),
+    parseInt(hex.slice(2, 4), 16),
+    parseInt(hex.slice(4, 6), 16),
+  ];
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return Math.round(a + (b - a) * t);
+}
+
+function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  return [
+    lerp(a[0], b[0], t),
+    lerp(a[1], b[1], t),
+    lerp(a[2], b[2], t),
+  ];
+}
+
+function toHex([r, g, b]: Rgb): string {
+  const h = (n: number) =>
+    Math.max(0, Math.min(255, n)).toString(16).padStart(2, "0");
+  return `${h(r)}${h(g)}${h(b)}`;
+}
+
+/** Sample multi-stop gradient at t in [0, 1]. */
+export function sampleGradient(stops: Rgb[], t: number): Rgb {
+  if (stops.length === 0) return [255, 255, 255];
+  if (stops.length === 1) return stops[0];
+  const clamped = Math.max(0, Math.min(1, t));
+  const seg = (stops.length - 1) * clamped;
+  const i = Math.min(Math.floor(seg), stops.length - 2);
+  return mix(stops[i], stops[i + 1], seg - i);
+}
+
+/** Wrap each character in truecolor codes along stops. Ends with %cn. */
+export function gradientText(text: string, stops: Rgb[]): string {
+  const chars = Array.from(text);
+  if (chars.length === 0) return "%cn";
+  if (stops.length === 0) return `${text}%cn`;
+
+  let out = "";
+  for (let i = 0; i < chars.length; i++) {
+    const t = chars.length === 1 ? 0 : i / (chars.length - 1);
+    const hex = toHex(sampleGradient(stops, t));
+    out += `<#${hex}>${chars[i]}`;
+  }
+  return `${out}%cn`;
+}
+
+/** Split a color list on commas. */
+export function splitColors(raw: string): string[] {
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}

--- a/packages/mush/src/verbs/gradient.ts
+++ b/packages/mush/src/verbs/gradient.ts
@@ -1,0 +1,113 @@
+/**
+ * +gradient — preview or set a smooth multi-stop name gradient.
+ *
+ * Colors: hex (#RGB / #RRGGBB / RRGGBB) or common names (red, cyan, …).
+ * Output uses truecolor codes: <#RRGGBB> per character.
+ */
+
+import { addCmd } from "../commands/addCmd.ts";
+import type { IUrsamuSDK } from "../commands/types.ts";
+import {
+  parseColor,
+  gradientText,
+  splitColors,
+  type Rgb,
+} from "./gradient-colors.ts";
+
+export {
+  parseColor,
+  sampleGradient,
+  gradientText,
+  splitColors,
+} from "./gradient-colors.ts";
+export type { Rgb } from "./gradient-colors.ts";
+
+function actorName(u: IUrsamuSDK): string {
+  const raw = String(u.me.state?.name || u.me.name || "Unknown");
+  return u.util.stripSubs(raw).trim() || "Unknown";
+}
+
+function parseStops(u: IUrsamuSDK, raw: string): Rgb[] | null {
+  const parts = splitColors(raw);
+  if (parts.length < 2) {
+    u.send(
+      "Usage: +gradient <color>, <color>[, <color>...]\n" +
+        "Need at least two colors (hex or name).",
+    );
+    return null;
+  }
+  if (parts.length > 12) {
+    u.send("Too many colors (max 12).");
+    return null;
+  }
+
+  const stops: Rgb[] = [];
+  for (const p of parts) {
+    const rgb = parseColor(p);
+    if (!rgb) {
+      u.send(
+        `Unknown color '%ch${u.util.stripSubs(p)}%cn'. ` +
+          `Use hex (#ff00aa) or a name (red, cyan, gold…).`,
+      );
+      return null;
+    }
+    stops.push(rgb);
+  }
+  return stops;
+}
+
+async function applyGradient(
+  u: IUrsamuSDK,
+  stops: Rgb[],
+  save: boolean,
+): Promise<void> {
+  const name = actorName(u);
+  const painted = gradientText(name, stops);
+
+  if (!save) {
+    u.send(`Preview: ${painted}`);
+    u.send(
+      "To wear it: %ch+gradient/set <colors>%cn  ·  " +
+        "Clear: %ch+gradient/clear%cn",
+    );
+    return;
+  }
+
+  await u.db.modify(u.me.id, "$set", { "data.moniker": painted });
+  u.send(`Moniker set: ${painted}`);
+}
+
+addCmd({
+  name: "+gradient",
+  pattern: /^\+gradient(?:\/(set|clear|preview))?\s*(.*)/i,
+  lock: "connected",
+  category: "General",
+  help:
+    `+gradient <c1>, <c2>[, <c3>...]  — Name color gradient preview.
++gradient/set <c1>, <c2>[, ...]    — Save as your moniker.
++gradient/clear                    — Clear moniker.
+
+Colors: hex (#f0a, #ff00aa) or names (red, blue, gold, cyan…).
+At least two colors. Blends smoothly across your name.
+
+Examples:
+  +gradient red, blue
+  +gradient #ff0000, #00ff00, #0000ff
+  +gradient/set orange, pink, purple
+  +gradient/clear`,
+  exec: async (u: IUrsamuSDK) => {
+    const sw = (u.cmd.args[0] ?? "").toLowerCase().trim();
+    const arg = u.util.stripSubs(u.cmd.args[1] ?? "").trim();
+
+    if (sw === "clear") {
+      await u.db.modify(u.me.id, "$unset", { "data.moniker": "" });
+      u.send("Moniker cleared. Your plain name will show again.");
+      return;
+    }
+
+    const stops = parseStops(u, arg);
+    if (!stops) return;
+
+    await applyGradient(u, stops, sw === "set");
+  },
+});

--- a/packages/mush/src/verbs/look.ts
+++ b/packages/mush/src/verbs/look.ts
@@ -2,17 +2,44 @@ import { addCmd } from "../commands/addCmd.ts";
 import type { IUrsamuSDK, IDBObj } from "../commands/types.ts";
 import { resolveFormat, header, divider, footer, registerFormatHandler } from "../format/handlers.ts";
 import { getConfig } from "@ursamu/core";
+import { dbrefWithFlags } from "../world/flags.ts";
 
 const WIDTH = 78;
 const NO_DESCRIPTION = "You see nothing special.";
 
-function headerName(target: IDBObj, canEdit: boolean): string {
+/**
+ * Name, or Name(#idFLAGS) for staff/editors.
+ * Flag short-codes follow the dbref (dark exit → `#12ed`).
+ */
+function nameWithDbref(
+  display: string,
+  obj: IDBObj,
+  showDbref: boolean,
+): string {
+  if (!showDbref) return display;
+  return `${display}(${dbrefWithFlags(obj.id, obj.flags)})`;
+}
+
+/** Staff or canEdit → show (#id + flag codes). */
+function showStaffDbref(actor: IDBObj, canEdit: boolean): boolean {
+  return canEdit || canSeeDark(actor);
+}
+
+function headerName(
+  target: IDBObj,
+  actor: IDBObj,
+  canEdit: boolean,
+): string {
   const base =
     (target.state?.moniker as string | undefined) ||
     (target.state?.name as string | undefined) ||
     target.name ||
     "Unknown";
-  return canEdit ? `${base}(#${target.id})` : base;
+  return nameWithDbref(
+    base,
+    target,
+    showStaffDbref(actor, canEdit),
+  );
 }
 
 const visualLen = (s: string): number =>
@@ -67,10 +94,44 @@ function exitDisplay(e: IDBObj): string {
   return name;
 }
 
+/** Staff+ always see dark exits; others need canEdit (owner/control). */
+function canSeeDark(actor: IDBObj): boolean {
+  return (
+    actor.flags.has("wizard") ||
+    actor.flags.has("admin") ||
+    actor.flags.has("superuser") ||
+    actor.flags.has("staff") ||
+    actor.flags.has("storyteller")
+  );
+}
+
+/**
+ * Exits listed on look. DARK exits are hidden unless the looker is
+ * staff or can edit the exit. When none remain, callers skip the
+ * whole Exits section (including parent EXITFORMAT).
+ */
+export async function visibleExitsForLook(
+  u: IUrsamuSDK,
+  actor: IDBObj,
+  exits: IDBObj[],
+): Promise<IDBObj[]> {
+  const out: IDBObj[] = [];
+  const staff = canSeeDark(actor);
+  for (const e of exits) {
+    if (!e.flags.has("exit")) continue;
+    if (!e.flags.has("dark") || staff) {
+      out.push(e);
+      continue;
+    }
+    if (await u.canEdit(actor, e)) out.push(e);
+  }
+  return out;
+}
+
 async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showContents: boolean, canEdit: boolean): Promise<string> {
   const lines: string[] = [];
 
-  const displayName = headerName(target, canEdit);
+  const displayName = headerName(target, actor, canEdit);
   const nameOverride = await resolveFormat(u, target, "NAMEFORMAT", displayName);
   lines.push(nameOverride ?? header(displayName, "=", WIDTH));
   lines.push("");
@@ -92,7 +153,11 @@ async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCont
   const contents = target.contents || [];
   const characters = contents.filter((o) => o.flags.has("player") && o.flags.has("connected"));
   const objects = contents.filter((o) => !o.flags.has("player") && !o.flags.has("exit") && !o.flags.has("room"));
-  const exits = contents.filter((o) => o.flags.has("exit"));
+  const exits = await visibleExitsForLook(
+    u,
+    actor,
+    contents.filter((o) => o.flags.has("exit")),
+  );
 
   if (showContents) {
     const visible = [...characters, ...objects];
@@ -107,7 +172,13 @@ async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCont
           for (const c of characters) {
             const disp = u.util.displayName(c, actor);
             const canEditChar = await u.canEdit(actor, c);
-            lines.push(` ${canEditChar ? `${disp}(#${c.id})` : disp}`);
+            lines.push(
+              ` ${nameWithDbref(
+                disp,
+                c,
+                showStaffDbref(actor, canEditChar),
+              )}`,
+            );
           }
         }
         if (objects.length > 0) {
@@ -115,13 +186,20 @@ async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCont
           for (const o of objects) {
             const disp = u.util.displayName(o, actor);
             const canEditObj = await u.canEdit(actor, o);
-            lines.push(` ${canEditObj ? `${disp}(#${o.id})` : disp}`);
+            lines.push(
+              ` ${nameWithDbref(
+                disp,
+                o,
+                showStaffDbref(actor, canEditObj),
+              )}`,
+            );
           }
         }
       }
     }
   }
 
+  // No visible exits → omit section entirely (no divider, no EXITFORMAT).
   if (exits.length > 0) {
     const idList = exits.map((e) => `#${e.id}`).join(" ");
     const exitOverride = await resolveFormat(u, target, "EXITFORMAT", idList);
@@ -132,7 +210,11 @@ async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCont
       const exitStrings = await Promise.all(exits.map(async (e) => {
         const disp = exitDisplay(e);
         const canEditExit = await u.canEdit(actor, e);
-        return canEditExit ? `${disp}(#${e.id})` : disp;
+        return nameWithDbref(
+          disp,
+          e,
+          showStaffDbref(actor, canEditExit),
+        );
       }));
       lines.push(nColumn(exitStrings, 3, WIDTH));
     }
@@ -145,7 +227,7 @@ async function renderRoom(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCont
 async function renderSingle(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showContents: boolean, canEdit: boolean): Promise<string> {
   const lines: string[] = [];
 
-  const displayName = headerName(target, canEdit);
+  const displayName = headerName(target, actor, canEdit);
   const nameOverride = await resolveFormat(u, target, "NAMEFORMAT", displayName);
   lines.push(nameOverride ?? header(displayName, "=", WIDTH));
   lines.push("");
@@ -179,7 +261,13 @@ async function renderSingle(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCo
           for (const c of players) {
             const disp = u.util.displayName(c, actor);
             const canEditChar = await u.canEdit(actor, c);
-            lines.push(` ${canEditChar ? `${disp}(#${c.id})` : disp}`);
+            lines.push(
+              ` ${nameWithDbref(
+                disp,
+                c,
+                showStaffDbref(actor, canEditChar),
+              )}`,
+            );
           }
         }
         if (things.length > 0) {
@@ -187,7 +275,13 @@ async function renderSingle(u: IUrsamuSDK, actor: IDBObj, target: IDBObj, showCo
           for (const o of things) {
             const disp = u.util.displayName(o, actor);
             const canEditObj = await u.canEdit(actor, o);
-            lines.push(` ${canEditObj ? `${disp}(#${o.id})` : disp}`);
+            lines.push(
+              ` ${nameWithDbref(
+                disp,
+                o,
+                showStaffDbref(actor, canEditObj),
+              )}`,
+            );
           }
         }
       }
@@ -345,7 +439,11 @@ export const defaultConformatHandler = async (
       const role = roleTag(c);
       const desc = getShortDesc(c) || SHORTDESC_PROMPT;
       const canEditChar = await u.canEdit(actor, c);
-      const nameWithRef = canEditChar ? `${cName}(#${c.id})` : cName;
+      const nameWithRef = nameWithDbref(
+        cName,
+        c,
+        showStaffDbref(actor, canEditChar),
+      );
 
       const namePad = " ".repeat(Math.max(1, 21 - visualLen(nameWithRef)));
       const rolePad = " ".repeat(Math.max(1, 13 - visualLen(role)));
@@ -360,7 +458,11 @@ export const defaultConformatHandler = async (
     for (const o of objects) {
       const disp = o.name || u.util.displayName(o, actor);
       const canEditObj = await u.canEdit(actor, o);
-      const name = canEditObj ? `${disp}(#${o.id})` : disp;
+      const name = nameWithDbref(
+        disp,
+        o,
+        showStaffDbref(actor, canEditObj),
+      );
       // Classic MUSH: room things show short-desc after the name.
       const sd = getShortDesc(o);
       if (sd) {

--- a/packages/mush/src/verbs/look.ts
+++ b/packages/mush/src/verbs/look.ts
@@ -289,18 +289,34 @@ function formatIdle(lastCommand: number | undefined): string {
 }
 
 function getShortDesc(obj: IDBObj): string {
-  const attrsState = (obj.state?.attributes as { name?: string; value?: string }[]) || [];
-  const attrsData = (obj.data?.attributes as { name?: string; value?: string }[]) || [];
-  const attrs = [...attrsState, ...attrsData];
+  // Hydrated objects expose storage `data` as `state`.
+  const attrs =
+    (obj.state?.attributes as { name?: string; value?: string }[]) ||
+    [];
   const sd = attrs.find((a) =>
-    a.name?.toLowerCase() === "short-desc" || a.name?.toLowerCase() === "shortdesc"
+    a.name?.toLowerCase() === "short-desc" ||
+    a.name?.toLowerCase() === "shortdesc"
   );
-  return sd?.value || "";
+  if (sd?.value) return sd.value;
+  // Flat state keys used by some plugins / set commands.
+  const flat =
+    (obj.state?.["short-desc"] as string | undefined) ||
+    (obj.state?.shortdesc as string | undefined);
+  return flat || "";
 }
 
 function roleTag(obj: IDBObj): string {
-  const configured = getConfig<Array<{ flag: string; display: string }>>("plugins.globals.theme.look.roleTags") || ROLE_TAGS;
-  for (const t of configured) if (obj.flags?.has(t.flag)) return t.display;
+  // Empty array is truthy — treat missing/empty as "use built-in defaults".
+  const configured = getConfig<
+    Array<{ flag: string; display: string }>
+  >("plugins.globals.theme.look.roleTags");
+  const tags =
+    Array.isArray(configured) && configured.length > 0
+      ? configured
+      : ROLE_TAGS;
+  for (const t of tags) {
+    if (obj.flags?.has(t.flag)) return t.display;
+  }
   return "";
 }
 

--- a/packages/mush/src/world/flags.ts
+++ b/packages/mush/src/world/flags.ts
@@ -1,26 +1,77 @@
 import { Tags } from "@digibear/tags";
 
+/**
+ * Flag registry — every `code` is a single letter.
+ * Upper/lower are distinct flags (e.g. wizard=`W`, staff=`w`).
+ * Digibear matches codes case-sensitively; names stay case-insensitive.
+ *
+ *   Privilege     Type/status      Supernatural
+ *   U superuser   p player         m mortal
+ *   a admin       r room           G ghoul
+ *   W wizard      e exit           v vampire
+ *   w staff       c connected      f werewolf
+ *   T storyteller d dark           k kinfolk
+ *   b builder     s safe
+ *                 g guest
+ *                 z void
+ *                 l link_ok
+ *                 E enter_ok
+ *                 V visual
+ *                 O opaque
+ */
 export const flags: Tags = new Tags(
-  { name: "superuser", code: "su",  lvl: 10, lock: "superuser" },
-  { name: "admin",     code: "a",   lvl: 9,  lock: "superuser" },
-  { name: "wizard",    code: "wiz", lvl: 9,  lock: "superuser" },
-  { name: "storyteller", code: "st", lvl: 8, lock: "admin" },
-  { name: "builder",   code: "b",   lvl: 7,  lock: "admin" },
-  { name: "player",    code: "p",   lvl: 1,  lock: "superuser" },
-  { name: "safe",      code: "s" },
-  { name: "void",      code: "v",   lock: "superuser" },
-  { name: "dark",      code: "d" },
-  { name: "guest",     code: "g",   lock: "superuser" },
-  { name: "room",      code: "r",   lvl: 1,  lock: "superuser" },
-  { name: "exit",      code: "e",   lvl: 1,  lock: "superuser" },
-  { name: "connected", code: "c",   lock: "superuser" },
-  { name: "mortal",    code: "[m]", lock: "builder+" },
-  { name: "ghoul",     code: "[g]", lock: "builder+" },
-  { name: "vampire",   code: "[v]", lock: "builder+" },
-  { name: "werewolf",  code: "[w]", lock: "builder+" },
-  { name: "kinfolk",   code: "[k]", lock: "builder+" },
-  { name: "link_ok",   code: "l" },
-  { name: "enter_ok",  code: "E" },
-  { name: "visual",    code: "V" },
-  { name: "opaque",    code: "O" },
+  { name: "superuser",   code: "U", lvl: 10, lock: "superuser" },
+  { name: "admin",       code: "a", lvl: 9,  lock: "superuser" },
+  { name: "wizard",      code: "W", lvl: 9,  lock: "superuser" },
+  { name: "staff",       code: "w", lvl: 8,  lock: "admin" },
+  { name: "storyteller", code: "T", lvl: 8,  lock: "admin" },
+  { name: "builder",     code: "b", lvl: 7,  lock: "admin" },
+  { name: "player",      code: "p", lvl: 1,  lock: "superuser" },
+  { name: "safe",        code: "s" },
+  { name: "void",        code: "z", lock: "superuser" },
+  { name: "dark",        code: "d" },
+  { name: "guest",       code: "g", lock: "superuser" },
+  { name: "room",        code: "r", lvl: 1,  lock: "superuser" },
+  { name: "exit",        code: "e", lvl: 1,  lock: "superuser" },
+  { name: "connected",   code: "c", lock: "superuser" },
+  { name: "mortal",      code: "m", lock: "builder+" },
+  { name: "ghoul",       code: "G", lock: "builder+" },
+  { name: "vampire",     code: "v", lock: "builder+" },
+  { name: "werewolf",    code: "f", lock: "builder+" },
+  { name: "kinfolk",     code: "k", lock: "builder+" },
+  { name: "link_ok",     code: "l" },
+  { name: "enter_ok",    code: "E" },
+  { name: "visual",      code: "V" },
+  { name: "opaque",      code: "O" },
 );
+
+/**
+ * Short flag codes for a flag set/string (e.g. "exit dark" → "ed").
+ * Unknown flags are skipped. Codes keep defined case (wizard → W,
+ * staff → w) so upper/lower remain distinct in dbref displays.
+ */
+export function flagCodes(
+  flagSrc: Set<string> | string[] | string | undefined,
+): string {
+  if (!flagSrc) return "";
+  const names = typeof flagSrc === "string"
+    ? flagSrc.split(/\s+/).filter(Boolean)
+    : [...flagSrc].filter(Boolean);
+  const parts: string[] = [];
+  for (const name of names) {
+    const tag = flags.exists(name);
+    if (tag?.code) parts.push(tag.code);
+  }
+  return parts.join("");
+}
+
+/**
+ * Staff/editor dbref suffix: `#12ed` (id + flag codes).
+ * Used as `(#12ed)` after names on look when the viewer can edit.
+ */
+export function dbrefWithFlags(
+  id: string,
+  flagSrc?: Set<string> | string[] | string,
+): string {
+  return `#${id}${flagCodes(flagSrc)}`;
+}

--- a/packages/mush/tests/flag_codes.test.ts
+++ b/packages/mush/tests/flag_codes.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Flag short-codes on staff dbrefs: (#12ed) for exit+dark, etc.
+ */
+import { assertEquals } from "@std/assert";
+import { flagCodes, dbrefWithFlags } from "../src/world/flags.ts";
+import { execLook } from "../src/verbs/look.ts";
+import type { IDBObj, IUrsamuSDK } from "../src/commands/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("flagCodes maps known flags", OPTS, () => {
+  assertEquals(flagCodes("dark"), "d");
+  assertEquals(flagCodes("exit dark"), "ed");
+  assertEquals(flagCodes(new Set(["exit", "dark"])), "ed");
+  assertEquals(flagCodes("enter_ok"), "E");
+  assertEquals(flagCodes("builder dark"), "bd");
+});
+
+Deno.test("flagCodes are single-letter and case-distinct", OPTS, () => {
+  // wizard W vs staff w — upper/lower are different flags
+  assertEquals(flagCodes("wizard"), "W");
+  assertEquals(flagCodes("staff"), "w");
+  assertEquals(flagCodes("wizard staff"), "Ww");
+  assertEquals(flagCodes("superuser"), "U");
+  assertEquals(flagCodes("storyteller"), "T");
+  assertEquals(flagCodes("werewolf"), "f");
+  assertEquals(flagCodes("ghoul"), "G");
+  // every emitted code is exactly one character
+  const sample = flagCodes(
+    "superuser admin wizard staff storyteller builder " +
+      "player safe void dark guest room exit connected " +
+      "mortal ghoul vampire werewolf kinfolk " +
+      "link_ok enter_ok visual opaque",
+  );
+  assertEquals([...sample].every((ch) => ch.length === 1), true);
+  assertEquals(sample.includes("wiz"), false);
+  assertEquals(sample.includes("su"), false);
+  assertEquals(sample.includes("["), false);
+});
+
+Deno.test("flagCodes skips unknown flags", OPTS, () => {
+  assertEquals(flagCodes("dark not_a_flag"), "d");
+  assertEquals(flagCodes(""), "");
+  assertEquals(flagCodes(undefined), "");
+});
+
+Deno.test("dbrefWithFlags joins id and codes", OPTS, () => {
+  assertEquals(
+    dbrefWithFlags("12", new Set(["exit", "dark"])),
+    "#12ed",
+  );
+  assertEquals(dbrefWithFlags("5", "room"), "#5r");
+});
+
+function mockObj(
+  id: string,
+  flags: string[],
+  extra: Partial<IDBObj> = {},
+): IDBObj {
+  return {
+    id,
+    name: id,
+    flags: new Set(flags),
+    state: { name: id },
+    location: "room1",
+    contents: [],
+    ...extra,
+  };
+}
+
+function mockU(opts: {
+  meFlags?: string[];
+  here: IDBObj;
+  canEditIds?: string[];
+}): IUrsamuSDK & { _sent: string[] } {
+  const sent: string[] = [];
+  const me = mockObj("p1", opts.meFlags ?? ["player", "connected"]);
+  me.location = opts.here.id;
+  const canEditIds = new Set(opts.canEditIds ?? []);
+  return {
+    me,
+    here: opts.here,
+    cmd: { name: "look", original: "look", args: [], switches: [] },
+    send: (m: string) => {
+      sent.push(m);
+    },
+    broadcast: () => {},
+    canEdit: async (_a: IDBObj, t: IDBObj) => canEditIds.has(t.id),
+    db: {
+      modify: async () => {},
+      search: async () => [],
+      create: async () => mockObj("99", []),
+      destroy: async () => {},
+    },
+    attr: {
+      get: async () => null,
+      set: async () => {},
+      clear: async () => false,
+    },
+    util: {
+      target: async () => null,
+      displayName: (o: IDBObj) =>
+        (o.state?.name as string) || o.name || "?",
+      stripSubs: (s: string) => s,
+      center: (s: string) => s,
+      ljust: (s: string, w: number) => s.padEnd(w),
+      rjust: (s: string, w: number) => s.padStart(w),
+    },
+    _sent: sent,
+  } as unknown as IUrsamuSDK & { _sent: string[] };
+}
+
+Deno.test(
+  "staff look shows flag codes on dark exits",
+  OPTS,
+  async () => {
+    const dark = mockObj("12", ["exit", "dark"], {
+      state: { name: "Secret;s" },
+    });
+    const room = mockObj("1", ["room"], {
+      state: { name: "Hall", description: "A hall." },
+      contents: [dark],
+    });
+    const u = mockU({
+      meFlags: ["player", "connected", "wizard"],
+      here: room,
+      canEditIds: [],
+    });
+    await execLook(u);
+    const out = u._sent[0];
+    // Dark exit visible to staff with #12ed
+    assertEquals(out.includes("Secret"), true);
+    assertEquals(out.includes("(#12ed)"), true);
+  },
+);
+
+Deno.test(
+  "mortal look does not show dbref flag codes",
+  OPTS,
+  async () => {
+    const lit = mockObj("12", ["exit"], {
+      state: { name: "East;e" },
+    });
+    const room = mockObj("1", ["room"], {
+      state: { name: "Hall", description: "A hall." },
+      contents: [lit],
+    });
+    const u = mockU({
+      meFlags: ["player", "connected"],
+      here: room,
+      canEditIds: [],
+    });
+    await execLook(u);
+    const out = u._sent[0];
+    assertEquals(out.includes("East"), true);
+    assertEquals(out.includes("(#12"), false);
+  },
+);

--- a/packages/mush/tests/gradient.test.ts
+++ b/packages/mush/tests/gradient.test.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assertMatch } from "@std/assert";
+import {
+  parseColor,
+  sampleGradient,
+  gradientText,
+  splitColors,
+  type Rgb,
+} from "../src/verbs/gradient-colors.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("parseColor: hex forms", OPTS, () => {
+  assertEquals(parseColor("#ff0000"), [255, 0, 0]);
+  assertEquals(parseColor("00ff00"), [0, 255, 0]);
+  assertEquals(parseColor("#f0a"), [255, 0, 170]);
+  assertEquals(parseColor("#F00"), [255, 0, 0]);
+});
+
+Deno.test("parseColor: named and mush letters", OPTS, () => {
+  assertEquals(parseColor("red"), [255, 0, 0]);
+  assertEquals(parseColor("CYAN"), [0, 220, 255]);
+  assertEquals(parseColor("r"), [255, 0, 0]);
+  assertEquals(parseColor("gold"), [255, 200, 40]);
+});
+
+Deno.test("parseColor: rejects junk", OPTS, () => {
+  assertEquals(parseColor(""), null);
+  assertEquals(parseColor("nope"), null);
+  assertEquals(parseColor("#gg0000"), null);
+  assertEquals(parseColor("#12"), null);
+});
+
+Deno.test("sampleGradient: endpoints and mid", OPTS, () => {
+  const stops: Rgb[] = [[0, 0, 0], [255, 0, 0]];
+  assertEquals(sampleGradient(stops, 0), [0, 0, 0]);
+  assertEquals(sampleGradient(stops, 1), [255, 0, 0]);
+  assertEquals(sampleGradient(stops, 0.5), [128, 0, 0]);
+});
+
+Deno.test("sampleGradient: three stops", OPTS, () => {
+  const stops: Rgb[] = [[255, 0, 0], [0, 255, 0], [0, 0, 255]];
+  assertEquals(sampleGradient(stops, 0), [255, 0, 0]);
+  assertEquals(sampleGradient(stops, 0.5), [0, 255, 0]);
+  assertEquals(sampleGradient(stops, 1), [0, 0, 255]);
+});
+
+Deno.test("gradientText: wraps each char and resets", OPTS, () => {
+  const out = gradientText("AB", [[255, 0, 0], [0, 0, 255]]);
+  assertMatch(out, /^<#ff0000>A<#0000ff>B%cn$/);
+});
+
+Deno.test("gradientText: single char uses first stop", OPTS, () => {
+  const out = gradientText("X", [[10, 20, 30], [200, 200, 200]]);
+  assertEquals(out, "<#0a141e>X%cn");
+});
+
+Deno.test("splitColors: commas and trim", OPTS, () => {
+  assertEquals(splitColors("red, blue, #0f0"), [
+    "red",
+    "blue",
+    "#0f0",
+  ]);
+  assertEquals(splitColors("  a ,, b  "), ["a", "b"]);
+});

--- a/packages/mush/tests/look_dark_exits.test.ts
+++ b/packages/mush/tests/look_dark_exits.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Dark exits must not appear on look, and when every exit is dark the
+ * Exits section (and EXITFORMAT) must be omitted entirely.
+ */
+import { assertEquals } from "@std/assert";
+import { visibleExitsForLook, execLook } from "../src/verbs/look.ts";
+import type { IDBObj, IUrsamuSDK } from "../src/commands/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function mockObj(
+  id: string,
+  flags: string[],
+  extra: Partial<IDBObj> = {},
+): IDBObj {
+  return {
+    id,
+    name: id,
+    flags: new Set(flags),
+    state: { name: id },
+    location: "room1",
+    contents: [],
+    ...extra,
+  };
+}
+
+function mockU(opts: {
+  me?: Partial<IDBObj>;
+  here: IDBObj;
+  canEditIds?: string[];
+}): IUrsamuSDK & { _sent: string[] } {
+  const sent: string[] = [];
+  const me = mockObj("p1", ["player", "connected"], opts.me);
+  me.location = opts.here.id;
+  const canEditIds = new Set(opts.canEditIds ?? []);
+  return {
+    me,
+    here: opts.here,
+    cmd: { name: "look", original: "look", args: [], switches: [] },
+    send: (m: string) => {
+      sent.push(m);
+    },
+    broadcast: () => {},
+    canEdit: async (_a: IDBObj, t: IDBObj) => canEditIds.has(t.id),
+    db: {
+      modify: async () => {},
+      search: async () => [],
+      create: async () => mockObj("99", []),
+      destroy: async () => {},
+    },
+    attr: {
+      get: async () => null,
+      set: async () => {},
+      clear: async () => false,
+    },
+    util: {
+      target: async () => null,
+      displayName: (o: IDBObj) => o.name ?? "?",
+      stripSubs: (s: string) => s,
+      center: (s: string) => s,
+      ljust: (s: string, w: number) => s.padEnd(w),
+      rjust: (s: string, w: number) => s.padStart(w),
+    },
+    _sent: sent,
+  } as unknown as IUrsamuSDK & { _sent: string[] };
+}
+
+Deno.test(
+  "visibleExitsForLook hides dark exits from normal players",
+  OPTS,
+  async () => {
+    const actor = mockObj("p1", ["player", "connected"]);
+    const lit = mockObj("e1", ["exit"]);
+    const dark = mockObj("e2", ["exit", "dark"]);
+    const u = mockU({
+      here: mockObj("r1", ["room"], { contents: [lit, dark] }),
+      canEditIds: [],
+    });
+    const vis = await visibleExitsForLook(u, actor, [lit, dark]);
+    assertEquals(vis.map((e) => e.id), ["e1"]);
+  },
+);
+
+Deno.test(
+  "visibleExitsForLook shows dark exits to staff",
+  OPTS,
+  async () => {
+    const actor = mockObj("p1", ["player", "connected", "wizard"]);
+    const dark = mockObj("e2", ["exit", "dark"]);
+    const u = mockU({
+      here: mockObj("r1", ["room"], { contents: [dark] }),
+    });
+    const vis = await visibleExitsForLook(u, actor, [dark]);
+    assertEquals(vis.map((e) => e.id), ["e2"]);
+  },
+);
+
+Deno.test(
+  "visibleExitsForLook shows dark exits when canEdit",
+  OPTS,
+  async () => {
+    const actor = mockObj("p1", ["player", "connected"]);
+    const dark = mockObj("e2", ["exit", "dark"]);
+    const u = mockU({
+      here: mockObj("r1", ["room"], { contents: [dark] }),
+      canEditIds: ["e2"],
+    });
+    const vis = await visibleExitsForLook(u, actor, [dark]);
+    assertEquals(vis.map((e) => e.id), ["e2"]);
+  },
+);
+
+Deno.test(
+  "look omits Exits section when all exits are dark",
+  OPTS,
+  async () => {
+    const darkA = mockObj("e1", ["exit", "dark"], {
+      state: { name: "North;n" },
+    });
+    const darkB = mockObj("e2", ["exit", "dark"], {
+      state: { name: "South;s" },
+    });
+    const room = mockObj("r1", ["room"], {
+      state: { name: "Hidden Hall", description: "Quiet." },
+      contents: [darkA, darkB],
+    });
+    const u = mockU({ here: room, canEditIds: [] });
+    await execLook(u);
+    assertEquals(u._sent.length, 1);
+    const out = u._sent[0];
+    assertEquals(out.includes("Exits"), false);
+    assertEquals(out.includes("North"), false);
+    assertEquals(out.includes("South"), false);
+  },
+);
+
+Deno.test(
+  "look still lists non-dark exits",
+  OPTS,
+  async () => {
+    const lit = mockObj("e1", ["exit"], {
+      state: { name: "East;e" },
+    });
+    const dark = mockObj("e2", ["exit", "dark"], {
+      state: { name: "West;w" },
+    });
+    const room = mockObj("r1", ["room"], {
+      state: { name: "Hall", description: "A hall." },
+      contents: [lit, dark],
+    });
+    const u = mockU({ here: room, canEditIds: [] });
+    await execLook(u);
+    const out = u._sent[0];
+    assertEquals(out.includes("Exits"), true);
+    assertEquals(out.includes("East"), true);
+    assertEquals(out.includes("West"), false);
+  },
+);

--- a/packages/mush/tests/security_avatar.test.ts
+++ b/packages/mush/tests/security_avatar.test.ts
@@ -1,20 +1,49 @@
 import { assertEquals } from "@std/assert";
-import { isPrivateHost, execAvatar } from "../src/verbs/avatar.ts";
+import {
+  isPrivateHost,
+  execAvatar,
+  chooseFetchTarget,
+  buildPinnedFetchUrl,
+} from "../src/verbs/avatar.ts";
 import type { IUrsamuSDK } from "../src/commands/types.ts";
 import { dbojs, DBO } from "../mod.ts";
 
 const OPTS = { sanitizeResources: false, sanitizeOps: false };
 
 Deno.test("isPrivateHost detects IPv4-mapped IPv6 bypasses", OPTS, () => {
-  // EXPLOIT: IPv4-mapped IPv6 address is currently not blocked by isPrivateHost
   assertEquals(isPrivateHost("::ffff:127.0.0.1"), true);
 });
 
-Deno.test("execAvatar pins resolved IP to prevent DNS Rebinding", OPTS, async () => {
+Deno.test("chooseFetchTarget pins HTTP but not HTTPS", OPTS, () => {
+  const http = chooseFetchTarget(
+    new URL("http://attacker.com/pic.png"),
+    ["8.8.8.8"],
+  );
+  assertEquals(new URL(http.fetchUrl).hostname, "8.8.8.8");
+  assertEquals(http.hostHeader, "attacker.com");
+
+  const https = chooseFetchTarget(
+    new URL("https://cdn.example/pic.jpg"),
+    ["8.8.8.8"],
+  );
+  // HTTPS must keep hostname so TLS cert validation works.
+  assertEquals(new URL(https.fetchUrl).hostname, "cdn.example");
+  assertEquals(https.hostHeader, undefined);
+});
+
+Deno.test("buildPinnedFetchUrl swaps host for IP", OPTS, () => {
+  const u = buildPinnedFetchUrl(
+    "http://attacker.com/a.png",
+    "1.2.3.4",
+  );
+  assertEquals(new URL(u).hostname, "1.2.3.4");
+  assertEquals(new URL(u).pathname, "/a.png");
+});
+
+Deno.test("execAvatar pins resolved IP for HTTP fetch", OPTS, async () => {
   const sentMessages: string[] = [];
   const fetchedUrls: string[] = [];
 
-  // Mock player
   const player = {
     id: "avatar_test_player_001",
     flags: "player connected",
@@ -25,23 +54,52 @@ Deno.test("execAvatar pins resolved IP to prevent DNS Rebinding", OPTS, async ()
   await dbojs.create(player);
 
   const mockU: IUrsamuSDK = {
-    me: { id: player.id, name: "TestPlayer", flags: new Set(["player", "connected"]), state: player.state, contents: player.contents },
-    here: { id: "room1", name: "Room", flags: new Set(["room"]), state: {}, contents: [] },
+    me: {
+      id: player.id,
+      name: "TestPlayer",
+      flags: new Set(["player", "connected"]),
+      state: player.state,
+      contents: player.contents,
+    },
+    here: {
+      id: "room1",
+      name: "Room",
+      flags: new Set(["room"]),
+      state: {},
+      contents: [],
+    },
     socketId: "socket1",
-    cmd: { name: "@avatar", original: "@avatar http://attacker.com/pic.png", args: ["http://attacker.com/pic.png"], switches: [] },
-    send: (msg: string) => { sentMessages.push(msg); },
+    cmd: {
+      name: "@avatar",
+      original: "@avatar http://attacker.com/pic.png",
+      args: ["http://attacker.com/pic.png"],
+      switches: [],
+    },
+    send: (msg: string) => {
+      sentMessages.push(msg);
+    },
     broadcast: () => {},
     eval: () => Promise.resolve(""),
-    attr: { get: () => Promise.resolve(null), set: () => Promise.resolve() },
+    attr: {
+      get: () => Promise.resolve(null),
+      set: () => Promise.resolve(),
+    },
     db: {
       modify: () => Promise.resolve(),
       search: () => Promise.resolve([]),
-      create: (d: Record<string, unknown>) => Promise.resolve({ ...d, id: "99", flags: new Set(), contents: [] }),
+      create: (d: Record<string, unknown>) =>
+        Promise.resolve({
+          ...d,
+          id: "99",
+          flags: new Set(),
+          contents: [],
+        }),
       destroy: () => Promise.resolve(),
     },
     util: {
       target: () => Promise.resolve(null),
-      displayName: (o: Record<string, unknown>) => String(o.name ?? "Unknown"),
+      displayName: (o: Record<string, unknown>) =>
+        String(o.name ?? "Unknown"),
       stripSubs: (s: string) => s,
       parseDesc: (s: string) => s,
       center: (s: string) => s,
@@ -51,35 +109,42 @@ Deno.test("execAvatar pins resolved IP to prevent DNS Rebinding", OPTS, async ()
     canEdit: () => Promise.resolve(true),
   } as unknown as IUrsamuSDK;
 
-  // Mock resolveDns and fetch
   const originalResolveDns = Deno.resolveDns;
   const originalFetch = globalThis.fetch;
 
   // deno-lint-ignore no-explicit-any
-  (Deno as any).resolveDns = (hostname: string, recordType: any): Promise<any> => {
+  (Deno as any).resolveDns = (
+    hostname: string,
+    recordType: string,
+  ): Promise<string[]> => {
     if (hostname === "attacker.com") {
-      return Promise.resolve(["8.8.8.8"]); // return safe public IP
+      return Promise.resolve(["8.8.8.8"]);
     }
-    return originalResolveDns(hostname, recordType);
+    return originalResolveDns(
+      hostname,
+      recordType as "A",
+    ) as Promise<string[]>;
   };
 
-  globalThis.fetch = (input: string | Request | URL, _init?: RequestInit): Promise<Response> => {
-    const urlStr = input.toString();
-    fetchedUrls.push(urlStr);
-    return Promise.resolve(new Response(new Uint8Array([1, 2, 3]), {
-      status: 200,
-      headers: { "Content-Type": "image/png" },
-    }));
+  globalThis.fetch = (
+    input: string | Request | URL,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    fetchedUrls.push(input.toString());
+    return Promise.resolve(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
   };
 
   try {
     await execAvatar(mockU);
-    // EXPLOIT: In the vulnerable version, the fetched URL contains "attacker.com"
-    // instead of the pinned resolved IP "8.8.8.8".
-    // This assertion should fail in the Red phase because it fetch()es "attacker.com" directly.
     assertEquals(fetchedUrls.length, 1);
     const u = new URL(fetchedUrls[0]);
     assertEquals(u.hostname, "8.8.8.8");
+    assertEquals(sentMessages.at(-1), "Avatar saved.");
   } finally {
     Deno.resolveDns = originalResolveDns;
     globalThis.fetch = originalFetch;

--- a/tests/scripts_attrs.test.ts
+++ b/tests/scripts_attrs.test.ts
@@ -42,19 +42,19 @@ function makeU(contents: IDBObj[] = []): { u: IUrsamuSDK; sent: string[] } {
 // inventory tests
 // ---------------------------------------------------------------------------
 
-Deno.test("inventory — empty inventory reports nothing carried", OPTS, () => {
+Deno.test("inventory — empty inventory reports nothing carried", OPTS, async () => {
   const { u, sent } = makeU([]);
-  execInventory(u);
+  await execInventory(u);
   assertStringIncludes(sent.join(" "), "not carrying anything");
 });
 
-Deno.test("inventory — with items lists each item name", OPTS, () => {
+Deno.test("inventory — with items lists each item name", OPTS, async () => {
   const items: IDBObj[] = [
     { id: "item1", name: "Lantern", flags: new Set(["thing"]), state: {}, contents: [] },
     { id: "item2", name: "Rope",    flags: new Set(["thing"]), state: {}, contents: [] },
   ];
   const { u, sent } = makeU(items);
-  execInventory(u);
+  await execInventory(u);
   const combined = sent.join("\n");
   assertStringIncludes(combined, "Lantern");
   assertStringIncludes(combined, "Rope");

--- a/tests/scripts_object_attrs.test.ts
+++ b/tests/scripts_object_attrs.test.ts
@@ -167,6 +167,7 @@ Deno.test("look at object with ODESC — room broadcast fires", OPTS, async () =
     args: ["Painting"],
     roomContents: [painting],
     searchResult: [painting],
+    targetResult: painting,
     attrMap: { [`${THING_ID}/ODESC`]: "studies the painting with great interest." },
   });
   await execLook(u);

--- a/tests/security/avatar-ssrf.test.ts
+++ b/tests/security/avatar-ssrf.test.ts
@@ -7,7 +7,10 @@ import { assertEquals } from "jsr:@std/assert@^1";
 
 const OPTS = { sanitizeResources: false, sanitizeOps: false };
 
-const SRC = new URL("../../packages/mush/src/verbs/avatar.ts", import.meta.url);
+const SRC = new URL(
+  "../../packages/mush/src/verbs/avatar-fetch.ts",
+  import.meta.url,
+);
 
 Deno.test(
   "avatar fetch uses redirect:error to prevent redirect-based SSRF bypass",


### PR DESCRIPTION
## Summary
- **mush**: `+gradient` multi-stop name colors; SSRF-safe `@avatar` fetch; public `/avatars/:id` route
- **discord**: game↔Discord channel bridge; strip truecolor markup; local avatar files only for webhook `avatar_url` (no query strings / third-party hosts)
- **channels**: auto-join / defaults improvements
- **help**: dark-topic listing and file provider fixes
- Related package version bumps and court production fixes

## Test plan
- [x] Pre-commit security suite passed (235 tests)
- [x] Discord package unit tests
- [x] Live court: custom avatar on Public webhook posts
- [ ] CI green on this PR