### PR TITLE
ci: publish help and discord to JSR

### DIFF
--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -124,3 +124,39 @@ jobs:
         with: { deno-version: v2.x }
       - name: Publish
         run: deno publish --allow-slow-types --no-check --allow-dirty
+
+  publish-help:
+    name: Publish @ursamu/help to JSR
+    runs-on: ubuntu-latest
+    needs: [core, mush]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/help
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with: { deno-version: v2.x }
+      - name: Publish
+        run: deno publish --allow-slow-types --no-check --allow-dirty
+
+  publish-discord:
+    name: Publish @ursamu/discord to JSR
+    runs-on: ubuntu-latest
+    needs: [core, mush]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/discord
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with: { deno-version: v2.x }
+      - name: Publish
+        run: deno publish --allow-slow-types --no-check --allow-dirty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,4 +16,6 @@ jobs:
       - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: v2.x
-      - run: deno publish
+      # Root meta-package depends on workspace JSR packages; those publish
+      # first via packages-ci.yml. Allow slow types and skip full check.
+      - run: deno publish --allow-slow-types --no-check --allow-dirty


### PR DESCRIPTION
## Summary
- Add packages-ci publish jobs for `@ursamu/help` and `@ursamu/discord`
- Root Publish to JSR uses `--allow-slow-types --no-check --allow-dirty` so it can succeed after workspace packages publish

## Test plan
- [ ] packages-ci publish jobs succeed on merge to main
- [ ] JSR shows help 0.1.8 and discord 0.2.2