### PR TITLE
ci: trigger JSR publish for help and discord

### DIFF
--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -1,6 +1,7 @@
 name: Packages CI
 
 on:
+  workflow_dispatch:
   push:
     paths: ["packages/**", "tools/**"]
     branches: [main, master, develop]

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -91,3 +91,4 @@ Bot credentials are **never** stored in the DB.
 ## License
 
 MIT
+

--- a/packages/help/README.md
+++ b/packages/help/README.md
@@ -95,3 +95,4 @@ deno task check      # type check
 deno task preflight  # JSR dry-run
 deno task publish    # publish to JSR (after preflight)
 ```
+


### PR DESCRIPTION
Path filter missed help/discord publish after CI workflow update. Touch package files to run packages-ci publish jobs.