### PR TITLE
fix(cofd): show flag codes on player dbrefs in CONFORMAT

### DIFF
--- a/packages/cofd/deno.json
+++ b/packages/cofd/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/cofd-plugin",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Chronicles of Darkness 2e plugin for UrsaMU \u2014 character sheets, guided chargen, and d10 dice with 10/9/8-again, rote, and Willpower spend.",
   "exports": "./index.ts",
   "tasks": {
@@ -36,9 +36,9 @@
     ]
   },
   "imports": {
-    "ursamu": "jsr:@ursamu/mush@^0.1.5",
-    "@ursamu/ursamu": "jsr:@ursamu/mush@^0.1.5",
-    "@ursamu/mush": "jsr:@ursamu/mush@^0.1.5",
+    "ursamu": "jsr:@ursamu/mush@^0.1.11",
+    "@ursamu/ursamu": "jsr:@ursamu/mush@^0.1.11",
+    "@ursamu/mush": "jsr:@ursamu/mush@^0.1.11",
     "@ursamu/combat": "jsr:@ursamu/combat@^0.8.0",
     "@ursamu/core": "jsr:@ursamu/core@^0.1.1",
     "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.3",
@@ -48,9 +48,9 @@
     "@ursamu/mail": "jsr:@ursamu/mail@^2.4.0",
     "@ursamu/mail-plugin": "jsr:@ursamu/mail@^2.4.0",
     "@ursamu/globals": "./tests/helpers/globals-shim.ts",
-    "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.7.0",
-    "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.7.0/eval",
-    "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.7.0/parse",
+    "@ursamu/mushcode": "jsr:@ursamu/mush@^0.1.11",
+    "@ursamu/mushcode/eval": "jsr:@ursamu/mush@^0.1.11",
+    "@ursamu/mushcode/parse": "jsr:@ursamu/mush@^0.1.11",
     "@ursamu/parser": "npm:@ursamu/parser@1.2.4",
     "@digibear/tags": "npm:@digibear/tags@1.0.0",
     "bcrypt": "npm:bcryptjs@2.4.3",

--- a/packages/cofd/index.ts
+++ b/packages/cofd/index.ts
@@ -158,7 +158,7 @@ async function onEngineReady(): Promise<void> {
 
 export const plugin: IPlugin = {
   name: "cofd",
-  version: "1.1.0",
+  version: "1.1.3",
   description: "Chronicles of Darkness 2e plugin: sheets, chargen, d10 dice with 10/9/8-again, rote, and Willpower spend.",
   dependencies: [
     { name: "help", version: ">=1.0.0" },

--- a/packages/cofd/src/support/look_format.ts
+++ b/packages/cofd/src/support/look_format.ts
@@ -2,7 +2,7 @@
 // Fae sight uses maskName via resolveItemLookName.
 
 import type { IUrsamuSDK, IDBObj } from "@ursamu/ursamu";
-import { divider, getConfig } from "@ursamu/mush";
+import { divider, getConfig, dbrefWithFlags } from "@ursamu/mush";
 import { formatContentItems } from "./look_format_items.ts";
 
 export { cofdDescformatHandler } from "./look_desc.ts";
@@ -16,6 +16,29 @@ const ROLE_TAGS = [
   { flag: "admin", display: "(Admin)" },
   { flag: "staff", display: "(Staff)" },
 ];
+
+/** Staff/builders see (#idFLAGS) on look names. */
+function showDbref(looker: IDBObj, canEdit: boolean): boolean {
+  if (canEdit) return true;
+  return (
+    looker.flags.has("wizard") ||
+    looker.flags.has("admin") ||
+    looker.flags.has("superuser") ||
+    looker.flags.has("staff") ||
+    looker.flags.has("storyteller") ||
+    looker.flags.has("builder")
+  );
+}
+
+function nameWithDbref(
+  display: string,
+  obj: IDBObj,
+  looker: IDBObj,
+  canEdit: boolean,
+): string {
+  if (!showDbref(looker, canEdit)) return display;
+  return `${display}(${dbrefWithFlags(obj.id, obj.flags)})`;
+}
 
 const visualLen = (s: string): number =>
   s.replace(/<#[0-9a-fA-F]{6}>/g, "")
@@ -190,9 +213,12 @@ export const cofdConformatHandler = async (
         : formatIdle(c.state?.lastCommand as number);
       const desc = getCharShortDesc(c) || SHORTDESC_PROMPT;
       const canEditChar = await u.canEdit(looker, c);
-      const nameWithRef = canEditChar
-        ? `${cName}(#${c.id})`
-        : cName;
+      const nameWithRef = nameWithDbref(
+        cName,
+        c,
+        looker,
+        canEditChar,
+      );
 
       const namePad = " ".repeat(
         Math.max(1, 21 - visualLen(nameWithRef)),

--- a/packages/cofd/src/support/look_format_items.ts
+++ b/packages/cofd/src/support/look_format_items.ts
@@ -1,6 +1,7 @@
 // Item row formatting for CoFD CONFORMAT.
 
 import type { IDBObj, IUrsamuSDK } from "@ursamu/ursamu";
+import { dbrefWithFlags } from "@ursamu/mush";
 import { itemData } from "../equipment/objects.ts";
 import { lookupItem } from "../equipment/catalog.ts";
 import { resolveItemLookName } from "./perception.ts";
@@ -105,7 +106,17 @@ export async function formatContentItems(
     slot += 1;
     const canEditObj = await u.canEdit(looker, obj);
     let label = resolveItemLookName(looker, obj);
-    if (canEditObj) label = `${label}(#${obj.id})`;
+    if (
+      canEditObj ||
+      looker.flags.has("wizard") ||
+      looker.flags.has("admin") ||
+      looker.flags.has("superuser") ||
+      looker.flags.has("staff") ||
+      looker.flags.has("builder")
+    ) {
+      label =
+        `${label}(${dbrefWithFlags(obj.id, obj.flags)})`;
+    }
     if (d?.kind === "ammo" || d?.kind === "goblin-fruit") {
       const count = d.count ?? 1;
       if (count > 1 || d.kind === "ammo") {

--- a/packages/discord/src/channel-bridge.ts
+++ b/packages/discord/src/channel-bridge.ts
@@ -4,7 +4,7 @@
  * Discord → game uses injectChannelMessage + source flag.
  */
 
-import { DBO, rooms, sessions, send } from "@ursamu/core";
+import { DBO, rooms, sessions, send } from "@ursamu/mush";
 import { clean, stripMushMarkup } from "./helpers.ts";
 import { getWebhookUrl } from "./config.ts";
 import { postWebhook } from "./webhook.ts";

--- a/packages/discord/src/scene-bridge.ts
+++ b/packages/discord/src/scene-bridge.ts
@@ -263,7 +263,7 @@ export async function handleDiscordSceneMessage(token: string, msg: any): Promis
       broadcastMsg = `%ch${charName}%cn says, "${content}"`;
     }
 
-    const { send: coreSend } = await import("@ursamu/core");
+    const { send: coreSend } = await import("@ursamu/mush");
     const inside = await dbojs.query({ location: instancedRoomId });
     const targetIds = inside.map((p) => p.id);
     if (targetIds.length > 0) {


### PR DESCRIPTION
## Summary
- CoFD CONFORMAT was still rendering players as `Name(#id)` without flag short-codes
- Use `dbrefWithFlags` so staff see e.g. `Diablerie(#2pUc)`
- Discord bridge imports from `@ursamu/mush` so vendor deploys resolve core APIs

## Test plan
- [x] cofd look_layout / perception tests
- [x] Deployed to court — look shows player flag codes