### PR TITLE
fix(look): normalize %r before word-wrap on descriptions

### DIFF
--- a/packages/cofd/src/support/look_desc.ts
+++ b/packages/cofd/src/support/look_desc.ts
@@ -8,9 +8,20 @@ const visualLen = (s: string): number =>
     .replace(/%c[a-zA-Z]/g, "")
     .replace(/%[nrtbR]/g, "").length;
 
+/** Turn MUSH %r / %t into real whitespace before wrap. */
+function normalizeDescNewlines(text: string): string {
+  return text
+    .replace(/%r/gi, "\n")
+    .replace(/%t/gi, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
 function wordWrap(text: string, width: number): string {
   const out: string[] = [];
-  for (const paragraph of text.split("\n")) {
+  for (
+    const paragraph of normalizeDescNewlines(text).split("\n")
+  ) {
     if (paragraph.trim() === "") {
       out.push("");
       continue;
@@ -60,5 +71,6 @@ export const cofdDescformatHandler = (
     .split("\n")
     .map((line) => (line.trim() ? " " + line : ""))
     .join("\n");
-  return Promise.resolve(`${indented}%r`);
+  // Real newlines only — trailing %r re-breaks after wrap.
+  return Promise.resolve(indented);
 };

--- a/packages/mush/src/verbs/look.ts
+++ b/packages/mush/src/verbs/look.ts
@@ -45,9 +45,18 @@ function headerName(
 const visualLen = (s: string): number =>
   s.replace(/<#[0-9a-fA-F]{6}>/g, "").replace(/%c[a-zA-Z]/g, "").replace(/%[nrtbR]/g, "").length;
 
+/** Turn MUSH %r / %t into real whitespace before wrap. */
+function normalizeDescNewlines(text: string): string {
+  return text
+    .replace(/%r/gi, "\n")
+    .replace(/%t/gi, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
 function wordWrap(text: string, width: number): string {
   const out: string[] = [];
-  for (const paragraph of text.split("\n")) {
+  for (const paragraph of normalizeDescNewlines(text).split("\n")) {
     if (paragraph.trim() === "") { out.push(""); continue; }
     let i = 0;
     while (i < paragraph.length && (paragraph[i] === " " || paragraph[i] === "\t")) i++;


### PR DESCRIPTION
## Summary
Room descs store paragraph breaks as `%r`. Look/CoFD DESCFORMAT wrapped on real newlines only, so `gather.%r%rWelcome` was one wrap token and produced broken mid-line returns after `%r` expanded.

- Convert `%r`/`%t` to whitespace before wrap
- Stop appending trailing `%r` after CoFD DESCFORMAT wrap

## Test plan
- [x] Court Welcome Room look — clean paragraph wraps