### PR TITLE
feat(mush): TinyMUX exit SUCC/OSUCC/ODROP/FAIL with defaults

### DIFF
--- a/help/building/@fail.md
+++ b/help/building/@fail.md
@@ -11,9 +11,11 @@ Sets the Fail message.
 
 ## Description
 
-Sets the message shown to the player when they fail to use an object (e.g.,
-locked exit, or look at something they can't see).
+Sets the message shown to the enactor when they fail to use an object
+(e.g. a locked exit).
+
+On exits, if unset, defaults to: `You can't go that way.`
 
 ## Example
 
-`@fail North= The door is locked.`
+`@fail North=The door is locked.`

--- a/help/building/@odrop.md
+++ b/help/building/@odrop.md
@@ -3,7 +3,7 @@ hidden: true
 ---
 # @ODROP
 
-Sets the Other Drop message.
+Others-drop / arrival message (TinyMUX-style).
 
 ## Syntax
 
@@ -11,9 +11,14 @@ Sets the Other Drop message.
 
 ## Description
 
-Sets the message shown to _others_ when a player drops an object. Note: For
-exits, see `@drop` (as it acts as the enter message).
+On **exits**: shown to others in the **destination** room when someone
+arrives through the exit. Actor name is prepended.
+
+If unset on an exit, defaults to: `has arrived.`
+
+On **things**: others see this when the object is dropped.
 
 ## Example
 
+`@odrop North=arrives from the south.`
 `@odrop ball=drops a shiny red ball.`

--- a/help/building/@ofail.md
+++ b/help/building/@ofail.md
@@ -3,7 +3,7 @@ hidden: true
 ---
 # @OFAIL
 
-Sets the Other Fail message.
+Others-fail message (TinyMUX-style).
 
 ## Syntax
 
@@ -11,9 +11,11 @@ Sets the Other Fail message.
 
 ## Description
 
-Sets the message shown to _others_ in the room when a player fails to use an
-object.
+Shown to others when someone fails a lock (exit or thing). Actor name
+is prepended.
+
+On exits, if unset, defaults to: `tries to leave, but can't.`
 
 ## Example
 
-`@ofail North=tries the door but finds it locked.`
+`@ofail North=rattles the locked door.`

--- a/help/building/@osucc.md
+++ b/help/building/@osucc.md
@@ -3,7 +3,7 @@ hidden: true
 ---
 # @OSUCC
 
-Sets the Other Success message.
+Sets the Other Success message (TinyMUX-style).
 
 ## Syntax
 
@@ -11,8 +11,11 @@ Sets the Other Success message.
 
 ## Description
 
-Sets the message shown to _others_ in the room when a player successfully uses
-an object/exit.
+Shown to others in the **origin** room when someone successfully uses
+an exit (or picks up a thing). The actor name is prepended:
+`Alice heads north.`
+
+On exits, if unset, defaults to: `has left.`
 
 ## Example
 

--- a/packages/mush/src/commands/exit-traverse.ts
+++ b/packages/mush/src/commands/exit-traverse.ts
@@ -1,0 +1,232 @@
+/**
+ * TinyMUX-style exit traversal (did_it attributes + defaults).
+ *
+ * Success: SUCC → OSUCC → ASUCC → move → DROP → ODROP → ADROP → look
+ * Fail (lock): FAIL → OFAIL → AFAIL
+ *
+ * Attributes are read via parent-walking getAttribute, with legacy
+ * data.osucc / data.odrop fallbacks. OSUCC/ODROP values are suffixes
+ * after the actor name (e.g. @osucc north=heads north.).
+ */
+import { dbojs, hydrate } from "../world/dbobjs.ts";
+import type { IDBOBJ } from "../world/types.ts";
+import { evaluateLock } from "../world/locks.ts";
+import { send } from "@ursamu/core";
+import { getAttribute } from "../events/hooks.ts";
+import { createNativeSDK } from "./sdk.ts";
+
+/** TinyMUX defaults when the attribute is unset. */
+export const EXIT_DEFAULTS = {
+  fail: "You can't go that way.",
+  ofail: "tries to leave, but can't.",
+  osucc: "has left.",
+  odrop: "has arrived.",
+} as const;
+
+function actorDisplayName(actor: IDBOBJ): string {
+  return (
+    (actor.data?.moniker as string) ||
+    (actor.data?.name as string) ||
+    actor.id ||
+    "Someone"
+  );
+}
+
+function exitLabel(exit: IDBOBJ): string {
+  const raw = (exit.data?.name as string) || exit.id;
+  return raw.split(";")[0]?.trim() || raw;
+}
+
+/**
+ * Resolve an exit message attribute (parent chain + legacy data.*).
+ */
+export async function resolveExitAttr(
+  exit: IDBOBJ,
+  name: string,
+): Promise<string> {
+  const attr = await getAttribute(exit, name);
+  if (attr?.value != null && String(attr.value).length > 0) {
+    return String(attr.value);
+  }
+  const legacy = exit.data?.[name.toLowerCase()];
+  if (typeof legacy === "string" && legacy.length > 0) return legacy;
+  return "";
+}
+
+function othersMsg(
+  actorName: string,
+  attr: string,
+  defaultSuffix: string,
+): string {
+  const body = (attr || defaultSuffix).trim();
+  // Full custom line if builder starts with the name or a quote.
+  if (
+    body.toLowerCase().startsWith(actorName.toLowerCase()) ||
+    body.startsWith('"') ||
+    body.startsWith("'")
+  ) {
+    return body;
+  }
+  return `${actorName} ${body}`;
+}
+
+async function sendToConnected(
+  locationId: string,
+  message: string,
+  excludeId?: string,
+): Promise<void> {
+  const here = await dbojs.query({ location: locationId });
+  for (const c of here) {
+    if (excludeId && c.id === excludeId) continue;
+    if (!String(c.flags || "").includes("connected")) continue;
+    if (!String(c.flags || "").includes("player")) continue;
+    send([c.id], message);
+  }
+}
+
+function basicLockKey(exit: IDBOBJ): string {
+  const named = (exit.data?.locks as Record<string, string> | undefined)
+    ?.basic;
+  if (named) return named;
+  const legacy = exit.data?.lock;
+  return typeof legacy === "string" ? legacy : "";
+}
+
+/**
+ * Attempt to take a matched exit. Returns true (always handled).
+ */
+export async function traverseExit(
+  socketId: string,
+  actor: IDBOBJ,
+  exit: IDBOBJ,
+  msg: string,
+): Promise<boolean> {
+  const actorId = actor.id;
+  const destination = exit.data?.destination as string | undefined;
+  if (!destination) {
+    send([socketId], "That exit leads nowhere.");
+    return true;
+  }
+
+  const destRoom = await dbojs.queryOne({ id: destination });
+  if (!destRoom) {
+    send([socketId], "That exit leads nowhere.");
+    return true;
+  }
+
+  const fromId = actor.location;
+  if (!fromId) {
+    send([socketId], "You are nowhere.");
+    return true;
+  }
+
+  const exitName = exitLabel(exit);
+  const actorName = actorDisplayName(actor);
+  const enactor = hydrate(actor);
+  const exitObj = hydrate(exit);
+
+  // ── Lock (basic) ──────────────────────────────────────────────────────
+  const lockKey = basicLockKey(exit);
+  if (lockKey) {
+    const allowed = await evaluateLock(lockKey, enactor, exitObj);
+    if (!allowed) {
+      const uFail = await createNativeSDK(socketId, actorId, {
+        name: exitName,
+        original: msg,
+        args: [],
+      });
+      const fail =
+        (await uFail.eval(exit.id, "FAIL").catch(() => "")) ||
+        (await resolveExitAttr(exit, "FAIL")) ||
+        EXIT_DEFAULTS.fail;
+      send([socketId], fail);
+
+      const ofail =
+        (await resolveExitAttr(exit, "OFAIL")) || EXIT_DEFAULTS.ofail;
+      await sendToConnected(
+        fromId,
+        othersMsg(actorName, ofail, EXIT_DEFAULTS.ofail),
+        actorId,
+      );
+
+      const afail = await resolveExitAttr(exit, "AFAIL");
+      if (afail) {
+        const owner = exit.data?.owner as string | undefined;
+        if (owner) send([owner], afail);
+      }
+      return true;
+    }
+  }
+
+  // ── Success messages (origin) ─────────────────────────────────────────
+  const u = await createNativeSDK(socketId, actorId, {
+    name: exitName,
+    original: msg,
+    args: [],
+  });
+
+  const succ =
+    (await u.eval(exit.id, "SUCC").catch(() => "")) ||
+    (await resolveExitAttr(exit, "SUCC"));
+  if (succ) send([socketId], succ);
+
+  const osucc = await resolveExitAttr(exit, "OSUCC");
+  await sendToConnected(
+    fromId,
+    othersMsg(actorName, osucc, EXIT_DEFAULTS.osucc),
+    actorId,
+  );
+
+  const asucc = await resolveExitAttr(exit, "ASUCC");
+  if (asucc) {
+    const owner = exit.data?.owner as string | undefined;
+    if (owner) send([owner], asucc);
+  }
+
+  // ── Move ──────────────────────────────────────────────────────────────
+  actor.data ||= {};
+  actor.data.lastCommand = Date.now();
+  await dbojs.modify({ id: actorId }, "$set", {
+    location: destination,
+    data: actor.data,
+  } as Partial<typeof actor>);
+
+  // ── Arrival messages (destination) ────────────────────────────────────
+  const drop =
+    (await u.eval(exit.id, "DROP").catch(() => "")) ||
+    (await resolveExitAttr(exit, "DROP"));
+  if (drop) send([socketId], drop);
+
+  const odrop = await resolveExitAttr(exit, "ODROP");
+  await sendToConnected(
+    destination,
+    othersMsg(actorName, odrop, EXIT_DEFAULTS.odrop),
+    actorId,
+  );
+
+  const adrop = await resolveExitAttr(exit, "ADROP");
+  if (adrop) {
+    const owner = exit.data?.owner as string | undefined;
+    if (owner) send([owner], adrop);
+  }
+
+  // ── Look + hook ───────────────────────────────────────────────────────
+  const { execLook } = await import("../verbs/look.ts");
+  await execLook(u);
+
+  const fromRoom = await dbojs.queryOne({ id: fromId });
+  const { gameHooks } = await import("@ursamu/core");
+  await (gameHooks as unknown as {
+    emit(e: string, p: unknown): Promise<void>;
+  }).emit("player:move", {
+    actorId,
+    actorName,
+    fromRoomId: fromId,
+    toRoomId: destination,
+    fromRoomName: (fromRoom?.data?.name as string) || fromId,
+    toRoomName: (destRoom.data?.name as string) || destination,
+    exitName,
+  });
+
+  return true;
+}

--- a/packages/mush/src/commands/pipeline-stages.ts
+++ b/packages/mush/src/commands/pipeline-stages.ts
@@ -267,7 +267,8 @@ export async function matchSoftcodePattern(
 
 /**
  * Match input against exit names in the actor's current room.
- * Returns true if an exit was taken.
+ * Returns true if an exit was taken (or lock-failed).
+ * Messaging: TinyMUX SUCC/OSUCC/ASUCC + DROP/ODROP/ADROP + FAIL/*.
  */
 export async function matchExits(
   socketId: string,
@@ -280,79 +281,22 @@ export async function matchExits(
   if (!actor?.location) return false;
 
   const trimmedMsg = msg.trim().toLowerCase();
-  const exits = await dbojs.query({ location: actor.location, flags: /exit/i });
+  const exits = await dbojs.query({
+    location: actor.location,
+    flags: /exit/i,
+  });
 
   for (const exit of exits) {
     const rawName = (exit.data?.name as string) || exit.id;
-    const aliases = rawName.split(";").map((p) => p.trim().toLowerCase());
-    if (!aliases.some((a) => a === trimmedMsg || trimmedMsg.startsWith(a))) continue;
+    const aliases = rawName
+      .split(";")
+      .map((p) => p.trim().toLowerCase())
+      .filter(Boolean);
+    // Exact alias match only (avoids "n" eating "nowhere").
+    if (!aliases.includes(trimmedMsg)) continue;
 
-    const destination = exit.data?.destination as string | undefined;
-    if (!destination) {
-      send([socketId], "That exit leads nowhere.");
-      return true;
-    }
-
-    const destRoom = await dbojs.queryOne({ id: destination });
-    if (!destRoom) {
-      send([socketId], "That exit leads nowhere.");
-      return true;
-    }
-
-    const fromId = actor.location;
-    const exitName = aliases[0] || rawName;
-
-    actor.data ||= {};
-    actor.data.lastCommand = Date.now();
-    await dbojs.modify({ id: actorId }, "$set", {
-      location: destination,
-      data: actor.data,
-    } as Partial<typeof actor>);
-
-    const actorName = (actor.data?.moniker as string) || (actor.data?.name as string) || "Someone";
-    const fromRoom = await dbojs.queryOne({ id: fromId });
-    const fromContents = await dbojs.query({ location: fromId });
-
-    // Announce departure
-    const odrop = exit.data?.odrop as string | undefined;
-    const departMsg = odrop || `${actorName} has left.`;
-    for (const c of fromContents) {
-      if (c.id !== actorId && c.flags.includes("connected")) {
-        send([c.id], departMsg);
-      }
-    }
-
-    // Announce arrival
-    const destContents = await dbojs.query({ location: destination });
-    const osucc = exit.data?.osucc as string | undefined;
-    const arriveMsg = osucc || `${actorName} has arrived.`;
-    for (const c of destContents) {
-      if (c.id !== actorId && c.flags.includes("connected")) {
-        send([c.id], arriveMsg);
-      }
-    }
-
-    const u = await createNativeSDK(socketId, actorId, {
-      name: exitName,
-      original: msg,
-      args: [],
-    });
-    // Trigger look
-    const { execLook } = await import("../verbs/look.ts");
-    await execLook(u);
-
-    const { gameHooks } = await import("@ursamu/core");
-    await (gameHooks as unknown as { emit(e: string, p: unknown): Promise<void> }).emit("player:move", {
-      actorId,
-      actorName,
-      fromRoomId: fromId,
-      toRoomId: destination,
-      fromRoomName: (fromRoom?.data?.name as string) || fromId,
-      toRoomName: (destRoom.data?.name as string) || destination,
-      exitName,
-    });
-
-    return true;
+    const { traverseExit } = await import("./exit-traverse.ts");
+    return await traverseExit(socketId, actor, exit, msg);
   }
   return false;
 }

--- a/packages/mush/tests/exit_traverse.test.ts
+++ b/packages/mush/tests/exit_traverse.test.ts
@@ -1,0 +1,71 @@
+/**
+ * TinyMUX-style exit message defaults and attr resolution.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  EXIT_DEFAULTS,
+  resolveExitAttr,
+} from "../src/commands/exit-traverse.ts";
+import type { IDBOBJ } from "../src/world/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("EXIT_DEFAULTS match TinyMUX-style leave/arrive", OPTS, () => {
+  assertEquals(EXIT_DEFAULTS.osucc, "has left.");
+  assertEquals(EXIT_DEFAULTS.odrop, "has arrived.");
+  assertEquals(EXIT_DEFAULTS.fail, "You can't go that way.");
+  assertEquals(EXIT_DEFAULTS.ofail, "tries to leave, but can't.");
+});
+
+Deno.test(
+  "resolveExitAttr prefers attributes over legacy data",
+  OPTS,
+  async () => {
+    const exit = {
+      id: "e1",
+      flags: "exit",
+      location: "r1",
+      data: {
+        name: "North;n",
+        destination: "r2",
+        osucc: "legacy osucc",
+        attributes: [
+          { name: "OSUCC", value: "heads north." },
+        ],
+      },
+    } as IDBOBJ;
+
+    const v = await resolveExitAttr(exit, "OSUCC");
+    assertEquals(v, "heads north.");
+  },
+);
+
+Deno.test(
+  "resolveExitAttr falls back to legacy data.osucc",
+  OPTS,
+  async () => {
+    const exit = {
+      id: "e1",
+      flags: "exit",
+      location: "r1",
+      data: {
+        name: "North;n",
+        osucc: "slips away north.",
+      },
+    } as IDBOBJ;
+
+    const v = await resolveExitAttr(exit, "OSUCC");
+    assertEquals(v, "slips away north.");
+  },
+);
+
+Deno.test("resolveExitAttr empty when unset", OPTS, async () => {
+  const exit = {
+    id: "e1",
+    flags: "exit",
+    location: "r1",
+    data: { name: "North;n" },
+  } as IDBOBJ;
+  assertEquals(await resolveExitAttr(exit, "OSUCC"), "");
+  assertEquals(await resolveExitAttr(exit, "FAIL"), "");
+});


### PR DESCRIPTION
## Summary
Exit traversal now follows TinyMUX did_it attributes with defaults when unset:

| When | Attr | Default |
|------|------|---------|
| Leave (others) | OSUCC | has left. |
| Arrive (others) | ODROP | has arrived. |
| Lock fail (you) | FAIL | You can't go that way. |
| Lock fail (others) | OFAIL | tries to leave, but can't. |

Also wires SUCC/ASUCC/DROP/ADROP, basic `@lock` checks, parent-chain attrs, and legacy `data.osucc`/`data.odrop` fallbacks. Fixes previously swapped leave/arrive fields.

## Test plan
- [x] exit_traverse unit tests
- [x] Deployed to court