### PR TITLE
fix(mush): rebuild SDK after exit move so look shows destination

### DIFF
--- a/packages/mush/src/commands/exit-traverse.ts
+++ b/packages/mush/src/commands/exit-traverse.ts
@@ -191,9 +191,16 @@ export async function traverseExit(
     data: actor.data,
   } as Partial<typeof actor>);
 
+  // Rebuild SDK after move so me/here (and look) use the destination.
+  const uDest = await createNativeSDK(socketId, actorId, {
+    name: exitName,
+    original: msg,
+    args: [],
+  });
+
   // ── Arrival messages (destination) ────────────────────────────────────
   const drop =
-    (await u.eval(exit.id, "DROP").catch(() => "")) ||
+    (await uDest.eval(exit.id, "DROP").catch(() => "")) ||
     (await resolveExitAttr(exit, "DROP"));
   if (drop) send([socketId], drop);
 
@@ -212,7 +219,7 @@ export async function traverseExit(
 
   // ── Look + hook ───────────────────────────────────────────────────────
   const { execLook } = await import("../verbs/look.ts");
-  await execLook(u);
+  await execLook(uDest);
 
   const fromRoom = await dbojs.queryOne({ id: fromId });
   const { gameHooks } = await import("@ursamu/core");


### PR DESCRIPTION
## Summary
Taking an exit moved the player in the DB but auto-look still used an SDK built in the origin room, so the first look after `cg` (etc.) showed the old room. Rebuild the SDK after the location update.

## Test plan
- [x] Deployed to court
- [ ] Walk an exit — look should show destination immediately