### PR TITLE
docs(locks): TinyMUX-style help and me/*name/carries/owner

### DIFF
--- a/help/building/@lock.md
+++ b/help/building/@lock.md
@@ -1,19 +1,28 @@
 ---
 hidden: true
 ---
-@LOCK
++@LOCK
 
-COMMAND: @lock[/<switch>] <object>=<key>
+Set or clear a **lock** (access key) on an object. TinyMUX-style keys.
 
-Sets a lock on <object> to restrict access or usage based on the <key>. The
-<key> is a boolean expression composed of objects, flags, and attributes.
+SYNTAX
+  @lock[/<type>] <target>=<key>
+  @unlock[/<type>] <target>
 
-Switches: /Basic (Default) - Basic lock (pickup/traverse). /Enter - Enter lock.
-/Use - Use lock. /Page - Page lock. /Tell - Tell lock. /Speech - Speech lock.
-/Drop - Drop lock. /Give - Give lock. /User - User-defined lock (requires
-specific checking code).
+TYPES (default: basic)
+  basic   Pickup / exit traverse
+  use     @use / USE
+  enter   Enter object or room
+  leave   Leave object or room
+  drop    Who may drop this
+  give    Who may give to this
+  page    Who may page you
+  link    Who may @link here
 
-Examples: @lock me=*friend @lock/enter home=+friend @lock/use lever = *admin |
-+wizard
+EXAMPLES
+  @lock north=me
+  @lock door=wizard | #2
+  @lock/use lever=flag(builder)
+  @unlock north
 
-Related Topics: @unlock, locks, @flags
+SEE ALSO: +help locks, +help locks/keys, +help locks/examples

--- a/help/building/locks/examples.md
+++ b/help/building/locks/examples.md
@@ -1,0 +1,32 @@
+---
+topic: "locks/examples"
+section: locks
+dark: true
+---
++LOCKS/EXAMPLES
+
+See also: +help locks (overview)
+
+EXITS
+  @lock north=me
+  @lock vault=wizard | #2
+  @lock portal=+member & !dark
+  @fail north=The way is barred.
+  @ofail north=rattles the gate.
+
+ITEMS
+  @lock sword=me
+  @lock/use wand=flag(wizard)
+  @lock gem=holds(#9) | me
+
+ROOMS / ENTER
+  @lock/enter club=+member
+  @lock/enter office=is(#2) | perm(admin)
+
+INDIRECT / EVAL-STYLE
+  @lock junior=@#10
+    (must pass #10's basic lock)
+  @lock shop=[gt(money(%#),50)]
+
+SEE ALSO: +help @lock, +help locks/keys,
++help action-attrs

--- a/help/building/locks/funcs.md
+++ b/help/building/locks/funcs.md
@@ -1,0 +1,30 @@
+---
+topic: "locks/funcs"
+section: locks
+dark: true
+---
++LOCKS/FUNCS
+
+See also: +help locks (overview)
+
+Built-in lock functions (fail-closed if unknown):
+
+  flag(name)           Enactor has flag
+  attr(name)           state has own property name
+  attr(name, val)      state.name === val
+  type(name)           Same as flag (player/room/…)
+  is(#id)              Enactor id is #id
+  holds(#id)           Enactor carries #id
+  carries(#id)         Alias for holds
+  owner()              Enactor owns locked object
+  perm(level)          Privilege (builder, admin, …)
+
+EXAMPLES
+  @lock box=holds(#42)
+  @lock gate=flag(wizard) | is(#2)
+  @lock/use tool=perm(builder)
+
+Softcode keys: `@lock here=[gt(money(%#),10)]`
+(requires lock evaluator).
+
+SEE ALSO: +help locks/keys, +help locks/examples

--- a/help/building/locks/keys.md
+++ b/help/building/locks/keys.md
@@ -1,0 +1,28 @@
+---
+topic: "locks/keys"
+section: locks
+dark: true
+---
++LOCKS/KEYS
+
+See also: +help locks (overview)
+
+ATOMS (TinyMUX-style)
+  me              Enactor owns the locked object
+  #12             Enactor is object #12
+  *Alice          Enactor is player named Alice
+  +wizard         Enactor has flag wizard
+  wizard          Same (bare flag / power word)
+  builder+        Flag or higher (via flag system)
+  tribe:red       state.tribe === "red"
+  power:>=3       Numeric compare on state field
+  @#5             Pass the basic lock on #5
+  [softcode]      Softcode expr (if evaluator set)
+
+OPS
+  a & b    AND          a | b    OR
+  !a       NOT          ( a )    group
+
+Adjacent atoms AND: `connected wizard` = both.
+
+SEE ALSO: +help locks/funcs, +help locks/examples

--- a/help/building/locks/types.md
+++ b/help/building/locks/types.md
@@ -1,0 +1,29 @@
+---
+topic: "locks/types"
+section: locks
+dark: true
+---
++LOCKS/TYPES
+
+See also: +help locks (overview)
+
+@lock/<type> stores a named key. Default type is **basic**.
+
+  basic   Get / take item; walk exit
+  use     @use / USE on the object
+  enter   Enter a container or room
+  leave   Leave a container or room
+  drop    Drop this object
+  give    Give something *to* this object
+  page    Page the locked player
+  link    @link / building link rights
+  speech  Speak in room (if enforced)
+  tell    Whisper / tell (if enforced)
+
+EXAMPLES
+  @lock chest=me
+  @lock/use crystal=flag(wizard)
+  @lock/enter club=+member
+  @unlock/use crystal
+
+SEE ALSO: +help @lock, +help locks/examples

--- a/packages/builder/help/lock.md
+++ b/packages/builder/help/lock.md
@@ -1,27 +1,31 @@
 ---
 topic: "@lock"
 section: building
-aliases: ["@unlock"]
+aliases: ["@unlock", "lock", "locks"]
 ---
-# @lock / @unlock
++@LOCK
 
-**@lock** sets a key expression on an object. Types: (none)=get,
-`use`, `enter`, `leave`, `link`.
+Set or clear a **lock** (access key) on an object. TinyMUX-style keys.
 
-## Syntax
-  `@lock <target>=<key>`
-  `@lock/<type> <target>=<key>`
-  `@unlock <target>`
-  `@unlock/<type> <target>`
+SYNTAX
+  @lock[/<type>] <target>=<key>
+  @unlock[/<type>] <target>
 
-## Notes
-- On lock failure: `FAIL`, `OFAIL`, `AFAIL` attributes fire.
+TYPES (default: basic)
+  basic   Pickup / exit traverse
+  use     @use / USE
+  enter   Enter object or room
+  leave   Leave object or room
+  drop    Who may drop this
+  give    Who may give to this
+  page    Who may page you
+  link    Who may @link here
 
-## Examples
-  `@lock sword=wizard`
-  `@lock/use lever=WIZARD`
-  `@lock/enter here=flag(admin)`
-  `@unlock sword`
+EXAMPLES
+  @lock north=me
+  @lock door=wizard | #2
+  @lock/use lever=flag(builder)
+  @unlock north
 
-## See Also
-  `action-attrs`, `@set`
+SEE ALSO: +help locks/keys, +help locks/examples,
++help locks/funcs, +help action-attrs

--- a/packages/builder/help/locks.md
+++ b/packages/builder/help/locks.md
@@ -1,5 +1,7 @@
 ---
-hidden: true
+topic: "locks"
+section: building
+aliases: ["lock-keys", "locking"]
 ---
 +LOCKS
 
@@ -16,6 +18,7 @@ TOPICS
 Operators: `&` / `&&` (and), `|` / `||` (or), `!` (not),
 `( )` grouping. Adjacent atoms imply AND.
 
-On fail: **FAIL** / **OFAIL** / **AFAIL** fire.
+On fail: **FAIL** / **OFAIL** / **AFAIL** fire (see
+action-attrs).
 
 SEE ALSO: +help @lock, +help locks/examples

--- a/packages/builder/help/locks/examples.md
+++ b/packages/builder/help/locks/examples.md
@@ -1,0 +1,32 @@
+---
+topic: "locks/examples"
+section: locks
+dark: true
+---
++LOCKS/EXAMPLES
+
+See also: +help locks (overview)
+
+EXITS
+  @lock north=me
+  @lock vault=wizard | #2
+  @lock portal=+member & !dark
+  @fail north=The way is barred.
+  @ofail north=rattles the gate.
+
+ITEMS
+  @lock sword=me
+  @lock/use wand=flag(wizard)
+  @lock gem=holds(#9) | me
+
+ROOMS / ENTER
+  @lock/enter club=+member
+  @lock/enter office=is(#2) | perm(admin)
+
+INDIRECT / EVAL-STYLE
+  @lock junior=@#10
+    (must pass #10's basic lock)
+  @lock shop=[gt(money(%#),50)]
+
+SEE ALSO: +help @lock, +help locks/keys,
++help action-attrs

--- a/packages/builder/help/locks/funcs.md
+++ b/packages/builder/help/locks/funcs.md
@@ -1,0 +1,30 @@
+---
+topic: "locks/funcs"
+section: locks
+dark: true
+---
++LOCKS/FUNCS
+
+See also: +help locks (overview)
+
+Built-in lock functions (fail-closed if unknown):
+
+  flag(name)           Enactor has flag
+  attr(name)           state has own property name
+  attr(name, val)      state.name === val
+  type(name)           Same as flag (player/room/…)
+  is(#id)              Enactor id is #id
+  holds(#id)           Enactor carries #id
+  carries(#id)         Alias for holds
+  owner()              Enactor owns locked object
+  perm(level)          Privilege (builder, admin, …)
+
+EXAMPLES
+  @lock box=holds(#42)
+  @lock gate=flag(wizard) | is(#2)
+  @lock/use tool=perm(builder)
+
+Softcode keys: `@lock here=[gt(money(%#),10)]`
+(requires lock evaluator).
+
+SEE ALSO: +help locks/keys, +help locks/examples

--- a/packages/builder/help/locks/keys.md
+++ b/packages/builder/help/locks/keys.md
@@ -1,0 +1,28 @@
+---
+topic: "locks/keys"
+section: locks
+dark: true
+---
++LOCKS/KEYS
+
+See also: +help locks (overview)
+
+ATOMS (TinyMUX-style)
+  me              Enactor owns the locked object
+  #12             Enactor is object #12
+  *Alice          Enactor is player named Alice
+  +wizard         Enactor has flag wizard
+  wizard          Same (bare flag / power word)
+  builder+        Flag or higher (via flag system)
+  tribe:red       state.tribe === "red"
+  power:>=3       Numeric compare on state field
+  @#5             Pass the basic lock on #5
+  [softcode]      Softcode expr (if evaluator set)
+
+OPS
+  a & b    AND          a | b    OR
+  !a       NOT          ( a )    group
+
+Adjacent atoms AND: `connected wizard` = both.
+
+SEE ALSO: +help locks/funcs, +help locks/examples

--- a/packages/builder/help/locks/types.md
+++ b/packages/builder/help/locks/types.md
@@ -1,0 +1,29 @@
+---
+topic: "locks/types"
+section: locks
+dark: true
+---
++LOCKS/TYPES
+
+See also: +help locks (overview)
+
+@lock/<type> stores a named key. Default type is **basic**.
+
+  basic   Get / take item; walk exit
+  use     @use / USE on the object
+  enter   Enter a container or room
+  leave   Leave a container or room
+  drop    Drop this object
+  give    Give something *to* this object
+  page    Page the locked player
+  link    @link / building link rights
+  speech  Speak in room (if enforced)
+  tell    Whisper / tell (if enforced)
+
+EXAMPLES
+  @lock chest=me
+  @lock/use crystal=flag(wizard)
+  @lock/enter club=+member
+  @unlock/use crystal
+
+SEE ALSO: +help @lock, +help locks/examples

--- a/packages/mush/src/world/locks.ts
+++ b/packages/mush/src/world/locks.ts
@@ -77,15 +77,26 @@ registerBuiltin("is", (enactor, _target, args) => {
   return enactor.id === dbref.replace(/^#/, "");
 });
 
-registerBuiltin("holds", (enactor, _target, args) => {
+const holdsImpl: LockFunc = (enactor, _target, args) => {
   const dbref = (args[0] ?? "").trim().replace(/^#/, "");
   return enactor.contents.some((c) => c.id === dbref);
-});
+};
+registerBuiltin("holds", holdsImpl);
+// TinyMUX alias
+registerBuiltin("carries", holdsImpl);
 
 registerBuiltin("perm", (enactor, _target, args) => {
   const permLevel = (args[0] ?? "").trim();
   const flagStr = Array.from(enactor.flags).join(" ");
   return flags.check(flagStr, permLevel);
+});
+
+/** TinyMUX owner() — enactor owns the locked object (target). */
+registerBuiltin("owner", (enactor, target, _args) => {
+  const owner = String(
+    (target.state?.owner as string | undefined) ?? target.id,
+  ).replace(/^#/, "");
+  return enactor.id === owner || enactor.id === target.id;
 });
 
 // --- Public API ---
@@ -281,35 +292,31 @@ const checkAtom = async (
     return callLockFunc(name, enactor, target, args);
   }
 
-  if (atom.startsWith("+") || atom.match(/^[a-zA-Z0-9_+]+$/)) {
-    const flagName = atom.startsWith("+") ? atom.slice(1) : atom;
-    return flags.check(Array.from(enactor.flags || []).join(" "), flagName);
+  // TinyMUX: me — enactor owns the locked object (or is it).
+  if (atom.toLowerCase() === "me") {
+    if (validationMode) return true;
+    const owner = String(
+      (target.state?.owner as string | undefined) ?? target.id,
+    ).replace(/^#/, "");
+    return enactor.id === owner || enactor.id === target.id;
+  }
+
+  // TinyMUX: *Name — enactor is that player (by name).
+  if (atom.startsWith("*")) {
+    if (validationMode) return true;
+    const want = atom.slice(1).trim().toLowerCase();
+    if (!want) return false;
+    const have = String(
+      enactor.state?.name ?? enactor.name ?? "",
+    ).toLowerCase();
+    return have === want;
   }
 
   if (atom.startsWith("#")) {
     return enactor.id === atom.slice(1);
   }
 
-  if (atom.includes(":")) {
-    const [attr, val] = atom.split(":");
-    const actualVal = enactor.state?.[attr.toLowerCase()];
-    if (actualVal === undefined) return false;
-
-    const cmpMatch = val.match(/^(>=|<=|>|<)(.+)$/);
-    if (cmpMatch) {
-      const [, op, numStr] = cmpMatch;
-      const numVal = parseFloat(numStr);
-      const actualNum = parseFloat(String(actualVal));
-      if (!isNaN(numVal) && !isNaN(actualNum)) {
-        if (op === ">=") return actualNum >= numVal;
-        if (op === "<=") return actualNum <= numVal;
-        if (op === ">") return actualNum > numVal;
-        if (op === "<") return actualNum < numVal;
-      }
-    }
-    return String(actualVal) === val;
-  }
-
+  // TinyMUX: @#dbref / @dbref — evaluate that object's basic lock.
   if (atom.startsWith("@#") || (atom.startsWith("@") && !atom.includes("/"))) {
     const id = atom.startsWith("@#") ? atom.slice(2) : atom.slice(1);
     const tarObj = await Obj.get(id);
@@ -328,6 +335,40 @@ const checkAtom = async (
       }
     }
     return false;
+  }
+
+  // TinyMUX: attr:value (and attr:>N etc.) on enactor state.
+  if (atom.includes(":")) {
+    const colon = atom.indexOf(":");
+    const attr = atom.slice(0, colon);
+    const val = atom.slice(colon + 1);
+    const actualVal =
+      enactor.state?.[attr] ??
+      enactor.state?.[attr.toLowerCase()];
+    if (actualVal === undefined) return false;
+
+    const cmpMatch = val.match(/^(>=|<=|>|<)(.+)$/);
+    if (cmpMatch) {
+      const [, op, numStr] = cmpMatch;
+      const numVal = parseFloat(numStr);
+      const actualNum = parseFloat(String(actualVal));
+      if (!isNaN(numVal) && !isNaN(actualNum)) {
+        if (op === ">=") return actualNum >= numVal;
+        if (op === "<=") return actualNum <= numVal;
+        if (op === ">") return actualNum > numVal;
+        if (op === "<") return actualNum < numVal;
+      }
+    }
+    return String(actualVal) === val;
+  }
+
+  // +FLAG or bare FLAG / power word (wizard, builder+, connected).
+  if (atom.startsWith("+") || atom.match(/^[a-zA-Z0-9_+]+$/)) {
+    const flagName = atom.startsWith("+") ? atom.slice(1) : atom;
+    return flags.check(
+      Array.from(enactor.flags || []).join(" "),
+      flagName,
+    );
   }
 
   return false;

--- a/packages/mush/tests/mush.test.ts
+++ b/packages/mush/tests/mush.test.ts
@@ -100,6 +100,72 @@ Deno.test("evaluateLock: OR — 'connected || wizard' passes when actor has conn
   assertEquals(await evaluateLock("connected || wizard", actor, actor), true);
 });
 
+Deno.test("evaluateLock: me passes when enactor owns target", OPTS, async () => {
+  const owner: IDBObj = {
+    id: "10",
+    name: "Owner",
+    flags: new Set(["player", "connected"]),
+    state: { name: "Owner" },
+    contents: [],
+  };
+  const thing: IDBObj = {
+    id: "20",
+    name: "Sword",
+    flags: new Set(["thing"]),
+    state: { owner: "10" },
+    contents: [],
+  };
+  const stranger: IDBObj = {
+    id: "11",
+    name: "Other",
+    flags: new Set(["player", "connected"]),
+    state: { name: "Other" },
+    contents: [],
+  };
+  assertEquals(await evaluateLock("me", owner, thing), true);
+  assertEquals(await evaluateLock("me", stranger, thing), false);
+});
+
+Deno.test("evaluateLock: *Name matches player name", OPTS, async () => {
+  const alice: IDBObj = {
+    id: "30",
+    name: "Alice",
+    flags: new Set(["player", "connected"]),
+    state: { name: "Alice" },
+    contents: [],
+  };
+  assertEquals(await evaluateLock("*Alice", alice, alice), true);
+  assertEquals(await evaluateLock("*Bob", alice, alice), false);
+});
+
+Deno.test("evaluateLock: carries/holds and owner()", OPTS, async () => {
+  const gem: IDBObj = {
+    id: "42",
+    name: "Gem",
+    flags: new Set(["thing"]),
+    state: {},
+    contents: [],
+  };
+  const holder: IDBObj = {
+    id: "31",
+    name: "Holder",
+    flags: new Set(["player", "connected"]),
+    state: { name: "Holder" },
+    contents: [gem],
+  };
+  const box: IDBObj = {
+    id: "50",
+    name: "Box",
+    flags: new Set(["thing"]),
+    state: { owner: "31" },
+    contents: [],
+  };
+  assertEquals(await evaluateLock("holds(#42)", holder, box), true);
+  assertEquals(await evaluateLock("carries(#42)", holder, box), true);
+  assertEquals(await evaluateLock("owner()", holder, box), true);
+  assertEquals(await evaluateLock("holds(#99)", holder, box), false);
+});
+
 // ─── Area 3: dbojs CRUD ───────────────────────────────────────────────────────
 
 Deno.test("dbojs: create, queryOne, modify, delete", OPTS, async () => {


### PR DESCRIPTION
## Summary
- Expand lock help: `@lock`, `locks`, `locks/keys`, `types`, `funcs`, `examples`
- TinyMUX atoms: `me`, `*Name`; funcs: `carries()`, `owner()`
- Defaults remain fail-closed; empty lock still passes

## In-game
\`+help locks\` · \`+help locks/examples\` · \`+help locks/keys\`