### PR TITLE
docs: align README and info site with portal install + design.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 
 ![ursamu header](https://raw.githubusercontent.com/ursamu/ursamu/main/ursamu_github_banner.png)
 
-[![JSR](https://jsr.io/badges/@ursamu/ursamu)](https://jsr.io/@ursamu/ursamu)
-[![Version](https://img.shields.io/badge/version-2.7.0-blue)](https://github.com/UrsaMU/ursamu/releases)
+[![JSR](https://jsr.io/badges/@ursamu/mush)](https://jsr.io/@ursamu/mush)
+[![Version](https://img.shields.io/badge/mush-1.0.30-blue)](https://jsr.io/@ursamu/mush)
+[![CLI](https://img.shields.io/badge/cli-0.1.2-blue)](https://jsr.io/@ursamu/cli)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Deno](https://img.shields.io/badge/deno-2.x-black)](https://deno.land)
 
-A modern MUSH-like server in TypeScript/Deno. Full TinyMUX 2.x softcode
-versioned REST API, and zero external database dependencies — uses TypeGraph
-with PGlite (PostgreSQL running locally or in-memory) as the default database system,
-with Deno KV as a fallback option.
+A modern MUSH-like server in TypeScript/Deno. Full TinyMUX 2.x softcode,
+versioned REST API, public portal (`@ursamu/site`) and staff console
+(`@ursamu/web`), and zero external database dependencies — TypeGraph with
+PGlite (local/in-memory PostgreSQL) by default, Deno KV as a fallback.
 
 ---
 
@@ -40,31 +41,40 @@ with Deno KV as a fallback option.
 Prerequisite: [Deno](https://deno.land) 2.x.
 
 ```bash
-# Scaffold a new game project from JSR
-deno run -A jsr:@ursamu/ursamu/cli create my-game
+# Scaffold a new game (engine + portal stack) from JSR
+deno run -A jsr:@ursamu/cli@0.1.2/create my-game
 cd my-game
 
-# Start the supervised server (first run prompts for a superuser)
+# Start the supervised server
 deno task start
 ```
 
-Default listeners:
+Default listeners (scaffolded games):
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | `4201` | Telnet | Legacy MU* clients |
-| `4202` | WebSocket | Raw WS clients |
-| `4203` | HTTP / WS | REST API + JWT WebSocket |
+| `4202` | WebSocket | Game WS hub |
+| `4203` | HTTP | REST API + static portal |
 
-Connect with `telnet localhost 4201`, or point a web client at
-`ws://localhost:4203?token=<jwt>&client=web`.
+Open the public site at `http://localhost:4203/` (when `@ursamu/site` is
+installed with `plugins.site.serveRoot: true`). Staff console:
+`http://localhost:4203/admin/`. Play client: `/play`. Telnet:
+`telnet localhost 4201`.
 
-### From source
+**First staff account:** with an empty database, register via the web
+UI (`/register` or site login). The first web registrant receives
+`superuser`. Telnet `create <name> <password>` still works for the
+first player when no accounts exist.
+
+### From source (engine monorepo)
 
 ```bash
 git clone https://github.com/UrsaMU/ursamu.git
 cd ursamu
-deno task start
+# Prefer scaffolding a child game with --local for engine work:
+deno run -A packages/cli/src/create.ts my-game --local
+cd my-game && deno task start
 ```
 
 ---
@@ -154,56 +164,42 @@ deno task start
 
 ### Packages (monorepo)
 
-The engine is split into two first-class packages:
-
 | Package | JSR | Purpose |
 |---------|-----|---------|
-| `@ursamu/core` | `jsr:@ursamu/core` | Generic server infrastructure — transport, DB (TypeGraph/PGlite or Deno KV), plugin lifecycle, events |
-| `@ursamu/mush` | `jsr:@ursamu/mush` | MUSH world layer — `IDBObj`, flags, locks, softcode evaluator, `addCmd`, `IUrsamuSDK` |
-| `@ursamu/ursamu` | `jsr:@ursamu/ursamu` | Backwards-compat shim that re-exports everything from `@ursamu/mush` |
+| `@ursamu/core` | `jsr:@ursamu/core` | Transport, DB (TypeGraph/PGlite or Deno KV), plugin lifecycle, events |
+| `@ursamu/mush` | `jsr:@ursamu/mush` | MUSH world — `IDBObj`, flags, locks, softcode, `addCmd`, `IUrsamuSDK` |
+| `@ursamu/cli` | `jsr:@ursamu/cli` | Project/plugin scaffold, update, package picker |
+| `@ursamu/site` | `jsr:@ursamu/site` | Public portal shell — nav, skins, `/play` client |
+| `@ursamu/web` | `jsr:@ursamu/web` | Staff console SPA at `/admin/` |
+| `@ursamu/ursamu` | `jsr:@ursamu/ursamu` | Back-compat shim re-exporting `@ursamu/mush` |
 
-**New projects** should import from `jsr:@ursamu/mush`. Existing plugins using
-`jsr:@ursamu/ursamu` continue to work without changes.
+**New projects** import from `jsr:@ursamu/mush`. Plugins still on
+`jsr:@ursamu/ursamu` keep working.
 
 ```
 packages/
-├── core/    @ursamu/core — transport, DB, plugin loader, event bus
-└── mush/    @ursamu/mush — MUSH engine (world layer built on core)
+├── core/     @ursamu/core
+├── mush/     @ursamu/mush   (engine)
+├── cli/      @ursamu/cli
+├── site/     @ursamu/site   (public FE)
+├── web/      @ursamu/web    (staff FE)
+├── help/ bbs/ mail/ wiki/ …
+└── …
 ```
 
-### Source layout
+Scaffolded games pin `@ursamu/mush` and declare plugins under
+`config/config.json` → `server.plugins`. Default portal stack:
+builder, channels, help, bbs, mail, wiki, web, site.
 
-```
-src/
-├── @types/          TypeScript interfaces (IDBObj, IUrsamuSDK, IPlugin, …)
-├── cli/             CLI entry points (create, plugin, update, scripts, …)
-├── commands/        102 built-in addCmd registrations
-├── middleware/      HTTP middleware (auth, CORS, rate limiting)
-├── plugins/         Official plugins + plugins.manifest.json
-├── routes/          REST routers (auth, dbobj, scenes, players, config)
-├── services/
-│   ├── broadcast/   send() / room broadcast
-│   ├── commands/    cmdParser — parse and dispatch
-│   ├── Config/      Config loader + cache
-│   ├── Database/    TypeGraph & Deno KV adapters (DBO, dbojs, events)
-│   ├── DBObjs/      Object CRUD (createObj, hydrate, Obj)
-│   ├── GameClock/   In-game calendar
-│   ├── Hooks/       gameHooks (player:login, say, move, …)
-│   ├── Intents/     Interceptors (AOP)
-│   ├── jwt/         Token sign/verify
-│   ├── parser/      MUSH color + substitution parser
-│   ├── Queue/       Async task queue
-│   ├── Sandbox/     Web Worker script execution
-│   ├── SDK/         IUrsamuSDK factory
-│   ├── Softcode/    TinyMUX 2.x evaluator + stdlib
-│   ├── StatSystem/  Pluggable stat systems
-│   ├── telnet/      Telnet sidecar
-│   └── WebSocket/   WS hub (rooms, rate limit)
-├── utils/           target resolution, flags, format handlers
-├── app.ts           HTTP/WS dispatcher
-├── main.ts          Engine init (mu)
-└── telnet.ts        Telnet sidecar entry
-```
+### Design contracts (FE)
+
+| Surface | Contract |
+|---------|----------|
+| Public site + `/play` | [`packages/site/design.md`](packages/site/design.md) |
+| Staff console `/admin` | [`packages/web/design.md`](packages/web/design.md) |
+
+Both share the **UrsaMU violet night** token family
+(`tokens.css` / `staff-theme.css`). Skins remap site tokens only.
 
 ### Request lifecycle
 
@@ -292,9 +288,16 @@ Run with `deno task <name>`.
 | `install-cli` | Install `ursamu` as a global command. |
 | `docker:build` / `:up` / `:down` / `:logs` | Docker Compose lifecycle. |
 
-CLI subcommands (`deno run -A jsr:@ursamu/ursamu/cli <subcommand>`):
-`create` / `init`, `plugin list|install|update|remove|search|info`,
-`update [<branch>]`, `scripts list`, `help`.
+CLI (from JSR):
+
+```bash
+deno run -A jsr:@ursamu/cli@0.1.2/create my-game
+deno run -A jsr:@ursamu/cli@0.1.2/create plugin my-feature
+deno run -A jsr:@ursamu/cli@0.1.2/ursamu   # interactive menu
+```
+
+Subcommands: `create`, `plugin list|install|update|remove|search|info`,
+`update`, `scripts list`, package picker.
 
 ---
 
@@ -352,7 +355,7 @@ in `src/plugins/.registry.json`.
 Scaffold a plugin inside any project:
 
 ```bash
-deno run -A jsr:@ursamu/ursamu/cli create plugin my-feature
+deno run -A jsr:@ursamu/cli@0.1.2/create plugin my-feature
 ```
 
 Generated layout:
@@ -555,19 +558,14 @@ deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
 | Topic | Link |
 |-------|------|
 | Installation | [docs/guides/installation.md](docs/guides/installation.md) |
+| CLI reference | [docs/guides/cli.md](docs/guides/cli.md) |
 | User guide | [docs/guides/user-guide.md](docs/guides/user-guide.md) |
 | Admin guide | [docs/guides/admin-guide.md](docs/guides/admin-guide.md) |
-| In-game commands | [docs/guides/commands.md](docs/guides/commands.md) |
-| Scripting guide | [docs/guides/scripting.md](docs/guides/scripting.md) |
-| Writing help files | [docs/guides/help-authoring.md](docs/guides/help-authoring.md) |
-| CLI reference | [docs/guides/cli.md](docs/guides/cli.md) |
-| Docker | [docs/guides/docker.md](docs/guides/docker.md) |
 | Deployment | [docs/guides/deployment.md](docs/guides/deployment.md) |
 | Plugin development | [docs/plugins/index.md](docs/plugins/index.md) |
-| Official plugins | [docs/plugins/official-plugins.md](docs/plugins/official-plugins.md) |
-| REST API reference | [docs/api/rest.md](docs/api/rest.md) |
-| Core API | [docs/api/core.md](docs/api/core.md) |
-| Testing | [docs/development/testing.md](docs/development/testing.md) |
+| REST API | [docs/api/rest.md](docs/api/rest.md) |
+| Public site design | [packages/site/design.md](packages/site/design.md) |
+| Staff console design | [packages/web/design.md](packages/web/design.md) |
 | Architecture | [docs/about.md](docs/about.md) |
 
 ---
@@ -581,7 +579,7 @@ to discuss your plan.
 git clone https://github.com/YOUR-USERNAME/ursamu.git
 cd ursamu
 deno task test
-deno task create plugin my-test-feature
+deno run -A packages/cli/src/create.ts plugin my-test-feature
 ```
 
 See [docs/development/contributing.md](docs/development/contributing.md)

--- a/deno.json
+++ b/deno.json
@@ -86,7 +86,9 @@
     "packages:test": "deno test packages/*/tests/ --allow-all --unstable-kv --no-check",
     "packages:check": "deno check packages/core/mod.ts packages/mush/mod.ts --unstable-kv",
     "packages:lint": "deno lint packages/",
-    "publish:all": "deno run -A scripts/publish-all.ts"
+    "publish:all": "deno run -A scripts/publish-all.ts",
+    "docs": "cd docs && deno task lume -s --port 3001",
+    "docs:build": "cd docs && deno task build"
   },
   "compilerOptions": {
     "lib": [
@@ -170,6 +172,10 @@
   },
   "allowScripts": {
     "allow": [],
-    "deny": ["npm:bcrypt@6.0.0", "npm:canvas@2.11.2", "npm:fsevents@2.3.3"]
+    "deny": [
+      "npm:bcrypt@6.0.0",
+      "npm:canvas@2.11.2",
+      "npm:fsevents@2.3.3"
+    ]
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,35 @@
-# UrsaMU Documentation (v2.6.0)
+# UrsaMU Documentation
 
 Welcome to the UrsaMU documentation. All pages are written in Markdown and
 rendered by the Lume static-site generator — they also read cleanly directly
 on GitHub.
+
+**Current pins (docs):** engine `@ursamu/mush@1.0.30`, CLI
+`@ursamu/cli@0.1.2`, public FE `@ursamu/site`, staff FE `@ursamu/web`.
+
+Visual system matches the product FE contracts:
+
+- [`packages/site/design.md`](../packages/site/design.md) — public portal
+- [`packages/web/design.md`](../packages/web/design.md) — staff console
 
 ## Navigation
 
 - [Home](./index.md) — landing page, features, quick install
 - [About](./about.md) — what UrsaMU is and how it compares to other MU* servers
 - [MUSH Compatibility](./mush_compatibility.md) — TinyMUX 2.x parity matrix
-- [Guides](./guides/) — installation, player, and admin guides
+- [Guides](./guides/) — installation, CLI, player, and admin guides
 - [API Reference](./api/) — core, database, hooks, commands, formats
 - [Configuration](./configuration/) — `config.json` shape and `JWT_SECRET`
-- [Plugins](./plugins/) — plugin authoring and the v2.6.0 manifest format
+- [Plugins](./plugins/) — plugin authoring and JSR packages
 - [Development](./development/) — pre-commit gauntlet, testing, contributing
 - [LLM Reference](./llms.md) — machine-optimized API summary
 
 ## Building the Site Locally
 
 ```bash
+# from repo root
 deno task docs
 ```
 
-This serves the site at `http://localhost:3000` with hot reload.
+Serves at `http://localhost:3001/` (port 3000 is often taken).
+Build only: `deno task docs:build` → `docs/_site/`.

--- a/docs/_config.ts
+++ b/docs/_config.ts
@@ -37,9 +37,11 @@ site
         extend: {
           colors: {
             ursamu: {
-              bg: "#1a0b2e",
-              primary: "#4c1d95",
-              accent: "#8b5cf6",
+              bg: "#0b0a12",
+              surface: "#161422",
+              primary: "#a78bfa",
+              accent: "#6d28d9",
+              border: "#3a3554",
             },
           },
         },

--- a/docs/_includes/layout.vto
+++ b/docs/_includes/layout.vto
@@ -41,7 +41,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="{{ it.site.repository }}" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">

--- a/docs/_site/about/index.html
+++ b/docs/_site/about/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -293,37 +293,43 @@
 <tbody>
 <tr>
 <td>Written in C</td>
-<td>Written in TypeScript</td>
+<td>Written in TypeScript / Deno</td>
 </tr>
 <tr>
 <td>No standard package system</td>
-<td>Deno native (JSR, npm imports)</td>
+<td>JSR packages (<code>@ursamu/mush</code>, plugins)</td>
 </tr>
 <tr>
 <td>Telnet-only</td>
-<td>WebSocket primary, Telnet sidecar</td>
+<td>WS hub + HTTP portal + Telnet sidecar</td>
+</tr>
+<tr>
+<td>No first-class web UI</td>
+<td><code>@ursamu/site</code> (public) + <code>@ursamu/web</code> (staff)</td>
 </tr>
 <tr>
 <td>Embedded scripting in MUSHcode</td>
-<td>Scripts run in sandboxed Web Workers</td>
+<td>Softcode + sandboxed TS Web Workers</td>
 </tr>
 <tr>
 <td>Modify core to extend</td>
-<td>Plugin architecture</td>
+<td>Plugin architecture (<code>addCmd</code>, hooks, routes)</td>
 </tr>
 <tr>
 <td>Manual compile &amp; deploy</td>
-<td><code>deno task start</code></td>
+<td><code>jsr:@ursamu/cli</code> scaffold → <code>deno task start</code></td>
 </tr>
 </tbody>
 </table>
 <h2>Core Features</h2>
-<h3>WebSocket-Native Protocol</h3>
-<p>The primary interface to UrsaMU is <strong>WebSocket</strong>, not Telnet. This means:</p>
+<h3>Portal + WebSocket-native protocol</h3>
+<p>Scaffolded games ship a <strong>public site</strong> (<code>@ursamu/site</code>) and <strong>staff<br>
+console</strong> (<code>@ursamu/web</code>) on the HTTP port, plus a WebSocket game hub:</p>
 <ul>
-<li>Native browser connectivity — build web clients without proxies</li>
-<li>Structured JSON messages for clean client/server contracts</li>
-<li>A Telnet sidecar is still available for classic MU* clients</li>
+<li>Browser play client at <code>/play</code> (sign-in required)</li>
+<li>Staff tools at <code>/admin/</code> (wiki, DB, settings, plugin pages)</li>
+<li>Structured JSON over WS for custom clients</li>
+<li>Telnet sidecar for classic MU* clients</li>
 </ul>
 <pre class="language-javascript" tabindex="0"><code class="language-javascript"><span class="token keyword">const</span> socket <span class="token operator">=</span> <span class="token keyword">new</span> <span class="token class-name">WebSocket</span><span class="token punctuation">(</span><span class="token string">"ws://yourgame.example.com:4202"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 
@@ -345,8 +351,8 @@ u.emit.broadcast(here.id, `${en.name} waves hello!`);
 </code></pre>
 <h3>Plugin Architecture</h3>
 <p>Everything in UrsaMU is extensible via plugins:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IPlugin, IUrsamuSDK } from "jsr:@ursamu/ursamu";
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/mush";
+import type { IPlugin, IUrsamuSDK } from "jsr:@ursamu/mush";
 
 const myPlugin: IPlugin = {
   name: "my-game-plugin",
@@ -445,7 +451,7 @@ GET /api/v1/scenes/:id/export?format=json
 </tr>
 <tr>
 <td>Testing</td>
-<td><code>deno test</code> — 296 tests, 0 failures</td>
+<td><code>deno test</code> — 1464 tests, 0 failures</td>
 </tr>
 <tr>
 <td>Docs</td>
@@ -502,7 +508,7 @@ GET /api/v1/scenes/:id/export?format=json
 <td>No</td>
 <td>No</td>
 <td>No</td>
-<td><strong>Native</strong></td>
+<td><strong>Via plugins</strong></td>
 </tr>
 <tr>
 <td>Discord</td>
@@ -519,11 +525,11 @@ GET /api/v1/scenes/:id/export?format=json
 <td><strong>Deno/JSR</strong></td>
 </tr>
 <tr>
-<td>Docker support</td>
+<td>Containerization</td>
 <td>Manual</td>
 <td>Manual</td>
 <td>Manual</td>
-<td><strong>Yes</strong></td>
+<td><strong>Game-level</strong></td>
 </tr>
 <tr>
 <td>License</td>
@@ -535,13 +541,34 @@ GET /api/v1/scenes/:id/export?format=json
 </tbody>
 </table>
 <h2>Project Status</h2>
-<p>UrsaMU is at <strong>v1.0</strong>. Current version is <code>1.0.0</code>.</p>
+<p>UrsaMU is at <strong>v2.6.0</strong> — production-ready since v2.0.0.</p>
 <ul>
-<li><strong>Test suite</strong>: 296 passing, 0 failing</li>
-<li><strong>Core systems</strong>: complete (commands, sandbox, WebSocket, Discord, scenes, channels)</li>
-<li><strong>Status</strong>: v1.0.0 released</li>
+<li><strong>Test suite</strong>: 1464 passing, 0 failing across 480 lint-clean files</li>
+<li><strong>Core systems</strong>: complete — 102 native commands, full TinyMUX 2.x softcode (250+ functions), sandbox, WebSocket, Telnet sidecar, Discord bridge, scenes, channels, zone system, format-handler pipeline, security hardening</li>
+<li><strong>Plugin system</strong>: atomic fail-fast installs with semver constraints and rollback (v2.6.0); typed <code>IPlugin</code> lifecycle and <code>gameHooks</code> declaration merging</li>
+<li><strong>Stdlib (v2.5.1+)</strong>: Noise, PRNG, physics, spatial, interpolation, vector primitives re-exported from <code>mod.ts</code></li>
+<li><strong>Status</strong>: actively maintained, published on JSR as <code>@ursamu/ursamu</code></li>
 </ul>
-<p>The project is open-source under the MIT License. Contributions are welcome!</p>
+<h2>The project is open-source under the MIT License. Contributions are welcome!</h2>
+<h2>Architecture</h2>
+<p>UrsaMU uses independent processes so each component can restart without affecting the others:</p>
+<ul>
+<li><strong>Hub</strong> — game logic, Deno KV persistence, HTTP REST API, and WebSocket connections (single port, default <code>4203</code>)</li>
+<li><strong>Telnet Sidecar</strong> — proxies classic Telnet connections to the Hub via WebSockets (<code>4201</code>)</li>
+</ul>
+<p>The hub handles everything through a single port: WebSocket upgrades for browser/telnet clients, REST API calls for frontends and integrations, and static file serving for the optional web client.</p>
+<h3>Storage</h3>
+<p>All persistence uses <strong>Deno KV</strong> — a built-in key-value store with ACID transactions, no external database required. Collections are namespaced by plugin (e.g. <code>server.chans</code>, <code>mail.messages</code>, <code>jobs.tickets</code>).</p>
+<h3>Plugin system</h3>
+<p>Plugins are auto-discovered at startup: any <code>src/plugins/*/index.ts</code> file is loaded. The exported <code>plugin</code> object handles lifecycle (<code>init</code>/<code>remove</code>), while commands and scripts register as module-load side effects. Plugins can extend the engine via:</p>
+<ul>
+<li><code>addCmd</code> — register command patterns</li>
+<li><code>registerScript</code> — provide or override system scripts</li>
+<li><code>registerCmdMiddleware</code> — inject command pipeline steps</li>
+<li><code>registerPluginRoute</code> — add REST endpoints</li>
+<li><code>gameHooks</code> — subscribe to engine lifecycle events</li>
+<li><code>DBO&lt;T&gt;</code> — private namespaced storage</li>
+</ul>
 
       </article>
 
@@ -559,6 +586,40 @@ GET /api/v1/scenes/:id/export?format=json
       
         
           
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         

--- a/docs/_site/api/core/index.html
+++ b/docs/_site/api/core/index.html
@@ -2,8 +2,8 @@
 <html lang="en"><head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Core API reference for UrsaMU">
+  <title>Core API Reference | UrsaMU Documentation</title>
+  <meta name="description" content="Complete type and function reference for UrsaMU plugin and script authors — exports of jsr:@ursamu/mush.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -261,630 +261,751 @@
       <nav class="breadcrumbs" aria-label="Breadcrumb">
         <a href="/ursamu/">Home</a>
         <span class="breadcrumbs-sep">›</span>
-        <span class="breadcrumbs-current"></span>
+        <span class="breadcrumbs-current">Core API Reference</span>
       </nav>
       
 
       <!-- Page content -->
       <article class="prose">
-        <h1>UrsaMU Core API Reference</h1>
-<p>This document provides a reference for the core UrsaMU API classes and interfaces.</p>
-<h2>App</h2>
-<p>The <code>App</code> class is the central hub of UrsaMU. It provides access to all the major subsystems and services.</p>
-<h3>Properties</h3>
+        <h1>Core API Reference</h1>
+<p>Everything documented here is exported from <code>jsr:@ursamu/mush</code>.</p>
+<h2>Package Structure</h2>
+<p>UrsaMU ships three packages on JSR:</p>
 <table>
 <thead>
 <tr>
-<th>Property</th>
-<th>Type</th>
-<th>Description</th>
+<th>Package</th>
+<th>Purpose</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>config</code></td>
-<td><code>Config</code></td>
-<td>The application configuration</td>
+<td><code>jsr:@ursamu/mush</code></td>
+<td>Full MUSH engine API — the preferred import for plugins and game projects</td>
 </tr>
 <tr>
-<td><code>db</code></td>
-<td><code>Database</code></td>
-<td>The database manager</td>
+<td><code>jsr:@ursamu/core</code></td>
+<td>Raw server infrastructure only (transports, pipeline, sessions) — no MUSH concepts; use this when building a custom game engine on top of the same infrastructure</td>
 </tr>
 <tr>
-<td><code>commands</code></td>
-<td><code>CommandManager</code></td>
-<td>The command manager</td>
-</tr>
-<tr>
-<td><code>hooks</code></td>
-<td><code>HookManager</code></td>
-<td>The hook manager</td>
-</tr>
-<tr>
-<td><code>plugins</code></td>
-<td><code>PluginManager</code></td>
-<td>The plugin manager</td>
-</tr>
-<tr>
-<td><code>players</code></td>
-<td><code>PlayerManager</code></td>
-<td>The player manager</td>
-</tr>
-<tr>
-<td><code>objects</code></td>
-<td><code>ObjectManager</code></td>
-<td>The game object manager</td>
-</tr>
-<tr>
-<td><code>flags</code></td>
-<td><code>FlagManager</code></td>
-<td>The flag manager</td>
-</tr>
-<tr>
-<td><code>channels</code></td>
-<td><code>ChannelManager</code></td>
-<td>The channel manager</td>
-</tr>
-<tr>
-<td><code>mail</code></td>
-<td><code>MailManager</code></td>
-<td>The mail manager</td>
-</tr>
-<tr>
-<td><code>bboard</code></td>
-<td><code>BulletinBoardManager</code></td>
-<td>The bulletin board manager</td>
+<td><code>jsr:@ursamu/mush</code></td>
+<td>Backwards-compatibility shim — re-exports everything from <code>@ursamu/mush</code>; existing plugins using this import continue to work unchanged</td>
 </tr>
 </tbody>
 </table>
-<h3>Methods</h3>
-<h4><code>start()</code></h4>
-<p>Starts the UrsaMU server.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.start();
+<h3><code>@ursamu/core</code> exports</h3>
+<p><code>@ursamu/core</code> provides the low-level primitives that <code>@ursamu/mush</code> builds on:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import {
+  createServer,
+  websocketTransport, telnetTransport, httpTransport,
+  registerFallback, addHandler, runPipeline,
+  sessions, registerSender,
+} from "jsr:@ursamu/core";
 </code></pre>
-<h4><code>stop()</code></h4>
-<p>Stops the UrsaMU server.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.stop();
-</code></pre>
-<h4><code>reload()</code></h4>
-<p>Reloads the UrsaMU server configuration and plugins.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.reload();
-</code></pre>
-<h4><code>broadcast(message: string)</code></h4>
-<p>Broadcasts a message to all connected players.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.broadcast("Server is restarting in 5 minutes!");
-</code></pre>
-<h2>Player</h2>
-<p>The <code>Player</code> class represents a connected player in the game.</p>
-<h3>Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Property</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>dbref</code></td>
-<td><code>string</code></td>
-<td>The database reference ID</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td><code>string</code></td>
-<td>The player’s name</td>
-</tr>
-<tr>
-<td><code>password</code></td>
-<td><code>string</code></td>
-<td>The hashed password</td>
-</tr>
-<tr>
-<td><code>connected</code></td>
-<td><code>boolean</code></td>
-<td>Whether the player is currently connected</td>
-</tr>
-<tr>
-<td><code>location</code></td>
-<td><code>string</code></td>
-<td>The dbref of the player’s current location</td>
-</tr>
-<tr>
-<td><code>flags</code></td>
-<td><code>string[]</code></td>
-<td>The flags set on the player</td>
-</tr>
-<tr>
-<td><code>attributes</code></td>
-<td><code>Record&lt;string, any&gt;</code></td>
-<td>Custom attributes stored on the player</td>
-</tr>
-</tbody>
-</table>
-<h3>Methods</h3>
-<h4><code>send(message: string)</code></h4>
-<p>Sends a message to the player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">player.send("Welcome to UrsaMU!");
-</code></pre>
-<h4><code>move(destination: string | GameObject)</code></h4>
-<p>Moves the player to a new location.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Move by dbref
-player.move("#123");
+<p>Use <code>@ursamu/core</code> directly only when you are building a non-MUSH server<br>
+(custom protocol, alternative command syntax, etc.) on the UrsaMU<br>
+infrastructure. For standard MUSH game development import from<br>
+<code>jsr:@ursamu/mush</code>.</p>
+<h2>Contents</h2>
+<ul>
+<li><a href="#imports">Imports</a></li>
+<li><a href="#engine-entry-points">Engine entry points</a> — <code>mu</code>, <code>startTelnetServer</code>, <code>createObj</code>, <code>checkAndCreateSuperuser</code></li>
+<li><a href="#commands">Commands</a> — <code>addCmd</code>, <code>cmds</code>, <code>registerScript</code>, <code>registerCmdMiddleware</code></li>
+<li><a href="#plugin-sdk-iursamusdk">Plugin SDK (IUrsamuSDK)</a> — the <code>u</code> object</li>
+<li><a href="#database">Database</a> — <code>DBO</code>, <code>dbojs</code></li>
+<li><a href="#locks--permissions">Locks &amp; permissions</a> — <code>registerLockFunc</code>, <code>evaluateLock</code>, <code>validateLock</code></li>
+<li><a href="#format-handlers">Format handlers</a> — <code>registerFormatHandler</code>, <code>registerFormatTemplate</code>, <code>resolveFormat</code>, <code>resolveGlobalFormat</code>, <code>header</code>/<code>divider</code>/<code>footer</code></li>
+<li><a href="#softcode-extension">Softcode extension</a> — <code>registerSoftcodeFunc</code>, <code>registerSoftcodeSub</code>, <code>softcodeService</code></li>
+<li><a href="#hooks--events">Hooks &amp; events</a> — <code>gameHooks</code>, <code>GameHookMap</code></li>
+<li><a href="#rest--ui">REST &amp; UI</a> — <code>registerPluginRoute</code>, <code>registerUIComponent</code></li>
+<li><a href="#stat-systems">Stat systems</a> — <code>registerStatSystem</code></li>
+<li><a href="#websocket">WebSocket</a> — <code>wsService</code>, <code>joinSocketToRoom</code>, <code>send</code></li>
+<li><a href="#engine-context">Engine context</a> — <code>buildContext</code>, <code>GameContext</code></li>
+<li><a href="#plugin-config">Plugin config</a> — <code>PluginConfigManager</code></li>
+<li><a href="#stdlib-ts">Stdlib (TS)</a> — Noise, Rng, physics, spatial, interpolation, vectors</li>
+<li><a href="#types">Types</a></li>
+<li><a href="#internal-plugin-install-errors">Internal: plugin install errors</a></li>
+</ul>
+<hr>
+<h2>Imports</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import {
+  mu, startTelnetServer, createObj, checkAndCreateSuperuser,
+  addCmd, cmds, registerScript, registerCmdMiddleware,
+  DBO, dbojs, send, joinSocketToRoom, wsService,
+  gameHooks,
+  registerLockFunc, evaluateLock, validateLock,
+  registerFormatHandler, registerFormatTemplate, unregisterFormatHandler,
+  resolveFormat, resolveFormatOr, resolveGlobalFormat, resolveGlobalFormatOr,
+  header, divider, footer,
+  registerSoftcodeFunc, registerSoftcodeSub, softcodeService,
+  registerPluginRoute, registerUIComponent, unregisterUIComponent, getRegisteredUIComponents,
+  registerStatSystem, getStatSystem, getDefaultStatSystem, getStatSystemNames,
+  buildContext, PluginConfigManager,
+} from "jsr:@ursamu/mush";
 
-// Move by object reference
-const room = app.objects.get("#123");
-player.move(room);
+import type {
+  IUrsamuSDK, IDBObj, IDBOBJ, ICmd, IPlugin, IPluginDependency,
+  IContext, IMiddlewareFunction, IStatSystem, IUIComponent,
+  GameHookMap, SessionEvent, SayEvent, PoseEvent, PageEvent, MoveEvent,
+  ChannelMessageEvent, ObjectCreatedEvent, ObjectDestroyedEvent, ObjectModifiedEvent,
+  SceneCreatedEvent, ScenePoseEvent, SceneSetEvent, SceneTitleEvent, SceneClearEvent,
+  MailReceivedEvent, FormatHandler, FormatSlot, GameContext, UserSocket,
+  LockFunc, SoftcodeFn, SoftcodeSubHandler, SoftcodeContext,
+} from "jsr:@ursamu/mush";
 </code></pre>
-<h4><code>disconnect(reason?: string)</code></h4>
-<p>Disconnects the player from the server.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">player.disconnect("Idle timeout");
+<hr>
+<h2>Engine entry points</h2>
+<h3><code>mu(config?)</code></h3>
+<p>Boots the engine. Call once from <code>src/main.ts</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { mu } from "jsr:@ursamu/mush";
+await mu();
 </code></pre>
-<h4><code>hasFlag(flag: string)</code></h4>
-<p>Checks if the player has a specific flag.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (player.hasFlag("WIZARD")) {
-  // Player is a wizard
-}
+<h3><code>startTelnetServer(port?)</code></h3>
+<p>Spawn a standalone Telnet listener that talks to the same hub.</p>
+<h3><code>createObj(template)</code></h3>
+<p>Create a DB object outside of a command handler (migrations, seeders).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const room = await createObj({
+  name: "The Void",
+  flags: new Set(["room"]),
+  state: { desc: "An empty room." },
+  contents: [],
+});
 </code></pre>
-<h4><code>setFlag(flag: string)</code></h4>
-<p>Sets a flag on the player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">player.setFlag("BUILDER");
-</code></pre>
-<h4><code>clearFlag(flag: string)</code></h4>
-<p>Removes a flag from the player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">player.clearFlag("GUEST");
-</code></pre>
-<h4><code>get(attribute: string, defaultValue?: any)</code></h4>
-<p>Gets an attribute value from the player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const description = player.get("description", "No description set.");
-</code></pre>
-<h4><code>set(attribute: string, value: any)</code></h4>
-<p>Sets an attribute value on the player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">player.set("description", "A tall figure with a mysterious aura.");
-</code></pre>
-<h2>GameObject</h2>
-<p>The <code>GameObject</code> class is the base class for all game objects (rooms, exits, things).</p>
-<h3>Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Property</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>dbref</code></td>
-<td><code>string</code></td>
-<td>The database reference ID</td>
-</tr>
-<tr>
-<td><code>name</code></td>
-<td><code>string</code></td>
-<td>The object’s name</td>
-</tr>
-<tr>
-<td><code>type</code></td>
-<td><code>"ROOM" | "EXIT" | "THING" | "PLAYER"</code></td>
-<td>The object type</td>
-</tr>
-<tr>
-<td><code>owner</code></td>
-<td><code>string</code></td>
-<td>The dbref of the object’s owner</td>
-</tr>
-<tr>
-<td><code>location</code></td>
-<td><code>string</code></td>
-<td>The dbref of the object’s location</td>
-</tr>
-<tr>
-<td><code>flags</code></td>
-<td><code>string[]</code></td>
-<td>The flags set on the object</td>
-</tr>
-<tr>
-<td><code>attributes</code></td>
-<td><code>Record&lt;string, any&gt;</code></td>
-<td>Custom attributes stored on the object</td>
-</tr>
-</tbody>
-</table>
-<h3>Methods</h3>
-<h4><code>hasFlag(flag: string)</code></h4>
-<p>Checks if the object has a specific flag.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (obj.hasFlag("DARK")) {
-  // Object is dark
-}
-</code></pre>
-<h4><code>setFlag(flag: string)</code></h4>
-<p>Sets a flag on the object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">obj.setFlag("LOCKED");
-</code></pre>
-<h4><code>clearFlag(flag: string)</code></h4>
-<p>Removes a flag from the object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">obj.clearFlag("LOCKED");
-</code></pre>
-<h4><code>get(attribute: string, defaultValue?: any)</code></h4>
-<p>Gets an attribute value from the object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const description = obj.get("description", "Nothing special.");
-</code></pre>
-<h4><code>set(attribute: string, value: any)</code></h4>
-<p>Sets an attribute value on the object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">obj.set("description", "A rusty old key.");
-</code></pre>
-<h4><code>save()</code></h4>
-<p>Saves the object to the database.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">obj.set("description", "A new description");
-obj.save();
-</code></pre>
-<h2>Command</h2>
-<p>The <code>ICmd</code> interface defines the structure of a command in UrsaMU.</p>
-<h3>Properties</h3>
-<table>
-<thead>
-<tr>
-<th>Property</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>name</code></td>
-<td><code>string</code></td>
-<td>The name of the command</td>
-</tr>
-<tr>
-<td><code>pattern</code></td>
-<td><code>string | RegExp</code></td>
-<td>Regex pattern to match; capture groups become <code>u.cmd.args</code></td>
-</tr>
-<tr>
-<td><code>lock</code></td>
-<td><code>string</code></td>
-<td>Lock expression required to run this command</td>
-</tr>
-<tr>
-<td><code>exec</code></td>
-<td><code>(u: IUrsamuSDK) =&gt; void | Promise&lt;void&gt;</code></td>
-<td>The function to execute when the command is run</td>
-</tr>
-<tr>
-<td><code>help</code></td>
-<td><code>string</code></td>
-<td>The help text for the command</td>
-</tr>
-<tr>
-<td><code>hidden</code></td>
-<td><code>boolean</code></td>
-<td>If true, omit from help listings</td>
-</tr>
-</tbody>
-</table>
-<h3>IUrsamuSDK</h3>
-<p>The SDK object received by every command’s <code>exec</code> function. Plugin commands and sandbox scripts receive the same interface.</p>
-<table>
-<thead>
-<tr>
-<th>Property</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>me</code></td>
-<td><code>IDBObj</code></td>
-<td>The actor who executed the command</td>
-</tr>
-<tr>
-<td><code>here</code></td>
-<td><code>IDBObj | null</code></td>
-<td>The room the actor is currently in</td>
-</tr>
-<tr>
-<td><code>cmd.args</code></td>
-<td><code>string[]</code></td>
-<td>Regex capture groups from the matched pattern</td>
-</tr>
-<tr>
-<td><code>cmd.switches</code></td>
-<td><code>string[]</code></td>
-<td>Switches supplied (e.g. <code>["verbose"]</code>)</td>
-</tr>
-<tr>
-<td><code>socketId</code></td>
-<td><code>string</code></td>
-<td>The WebSocket socket ID of the actor</td>
-</tr>
-</tbody>
-</table>
-<h4><code>u.send(message: string)</code></h4>
-<p>Sends a message to the actor who executed the command.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.send("Command executed successfully!");
-</code></pre>
-<h4><code>u.broadcast(roomId: string, message: string)</code></h4>
-<p>Broadcasts a message to all players in a room.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.broadcast(u.here?.id ?? "", "Something happens here.");
-</code></pre>
-<h3>Example</h3>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-// Define and register a command
-addCmd({
-  name: "look",
-  pattern: /^(?:look|l)\s*(.*)/i,
+<h3><code>checkAndCreateSuperuser()</code></h3>
+<p>Idempotent — ensures <code>#1</code> exists with the <code>superuser</code> flag.</p>
+<hr>
+<h2>Commands</h2>
+<h3><code>addCmd(...cmds)</code></h3>
+<p>Registers one or more <code>ICmd</code> objects. Safe at module load.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">addCmd({
+  name: "+greet",
+  pattern: /^\+greet\s+(.+)/i,
   lock: "connected",
-  exec: async (u: IUrsamuSDK) =&gt; {
-    const targetName = u.cmd.args[0]?.trim();
-    const target = targetName
-      ? await u.util.target(u.me, targetName)
-      : u.here;
-    if (!target) return u.send("I don't see that here.");
-    u.send(`You look at ${String(target.state.name ?? target.id)}.`);
-  },
-  help: "look [&lt;object&gt;]\nLooks at an object or the current room."
+  category: "Social",
+  help: "+greet &lt;name&gt; — Say hello.",
+  exec: (u) =&gt; u.send(`Hello, ${u.cmd.args[0]}!`),
 });
 </code></pre>
-<h2>Hook</h2>
-<p>The <code>HookManager</code> class manages event hooks in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>on(event: string, callback: Function, priority?: number)</code></h4>
-<p>Registers a callback for an event.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.hooks.on("player:connect", (player) =&gt; {
-  console.log(`Player ${player.name} connected`);
-}, 50);
+<p><code>ICmd</code> shape:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface ICmd {
+  name: string;
+  pattern: string | RegExp;
+  lock?: string;
+  category?: string;
+  help?: string;
+  hidden?: boolean;
+  exec: (u: IUrsamuSDK) =&gt; void | Promise&lt;void&gt;;
+}
 </code></pre>
-<h4><code>off(event: string, callback: Function)</code></h4>
-<p>Removes a callback for an event.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.hooks.off("player:connect", myCallback);
+<p>Capture groups in <code>pattern</code> populate <code>u.cmd.args[0]</code>, <code>[1]</code>, etc.</p>
+<h3><code>cmds</code></h3>
+<p>The registered command map. Use to introspect or override an existing<br>
+command:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { cmds } from "jsr:@ursamu/mush";
+const existing = cmds.get("look");
 </code></pre>
-<h4><code>emit(event: string, ...args: any[])</code></h4>
-<p>Emits an event with arguments.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.hooks.emit("custom:event", { data: "some data" });
+<h3><code>registerScript(name, content)</code></h3>
+<p>Register a softcode/system script. Lookup order: local file override →<br>
+plugin registry → engine bundled.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerScript("custom-look", "say You ran the custom look script.");
 </code></pre>
-<h4><code>once(event: string, callback: Function, priority?: number)</code></h4>
-<p>Registers a one-time callback for an event.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.hooks.once("system:startup", () =&gt; {
-  console.log("Server started");
+<h3><code>registerCmdMiddleware(fn)</code></h3>
+<p>Insert middleware into the command pipeline. Runs before <code>exec</code>. Return<br>
+<code>false</code> to abort dispatch.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerCmdMiddleware(async (u) =&gt; {
+  if (u.me.flags.has("frozen")) { u.send("You're frozen."); return false; }
 });
 </code></pre>
+<hr>
+<h2>Plugin SDK (<code>IUrsamuSDK</code>)</h2>
+<p>The <code>u</code> object passed to every <code>addCmd</code> <code>exec</code> and every sandbox script.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface IUrsamuSDK {
+  state: Record&lt;string, unknown&gt;;
+  socketId?: string;
+  me: IDBObj;
+  here: IDBObj &amp; { broadcast(msg: string): void };
+  target?: IDBObj &amp; { broadcast(msg: string): void };
+  cmd: { name: string; original?: string; args: string[]; switches?: string[] };
+
+  send(message: string, target?: string): void;
+  broadcast(message: string): void;
+  execute(command: string): Promise&lt;void&gt;;
+  force(command: string): Promise&lt;void&gt;;
+  forceAs(targetId: string, command: string): Promise&lt;void&gt;;
+  canEdit(actor: IDBObj, target: IDBObj): Promise&lt;boolean&gt;;
+  checkLock(target: IDBObj, lock: string): Promise&lt;boolean&gt;;
+  setFlags(targetId: string, flags: string): Promise&lt;void&gt;;
+  trigger(targetId: string, attr: string, args?: string[]): Promise&lt;void&gt;;
+  eval(targetId: string, attr: string, args?: string[]): Promise&lt;string&gt;;
+  evalString(source: string): Promise&lt;string&gt;;
+  intercept?: (input: string) =&gt; Promise&lt;boolean&gt;;
+
+  db:    { search, create, modify, destroy };
+  util:  { target, displayName, stripSubs, center, ljust, rjust, sprintf,
+           template, parseDesc, resolveFormat, resolveFormatOr,
+           resolveGlobalFormat, resolveGlobalFormatOr };
+  auth:  { verify, login, hash, setPassword };
+  sys:   { setConfig, disconnect, reboot, shutdown, uptime, update,
+           gameTime, setGameTime };
+  chan:  { join, leave, list, create, destroy, set, history };
+  attr:  { get, set, clear };
+  events:{ emit, on };
+  ui:    { panel, render, layout };
+}
+</code></pre>
+<h3><code>u.db</code></h3>
+<p>All async. <code>op</code> must be <code>"$set"</code>, <code>"$inc"</code>, <code>"$unset"</code>, or <code>"$push"</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const list = await u.db.search({ flags: ["room"] });
+const sword = await u.db.create({ name: "Sword", flags: new Set(["thing"]),
+  location: u.me.id, state: {}, contents: [] });
+await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
+await u.db.modify(u.me.id, "$inc", { "data.deaths": 1 });
+await u.db.modify(u.me.id, "$unset", { "data.tempFlag": "" });
+await u.db.modify(u.here.id, "$push", { "data.log": "Alice arrived." });
+await u.db.destroy(sword.id);
+</code></pre>
+<h3><code>u.util</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const obj = await u.util.target(u.me, u.cmd.args[0], true);
+const name = u.util.displayName(target, u.me);
+const plain = u.util.stripSubs("%chBold%cn");
+u.send(u.util.center("TITLE", 78, "="));
+u.send(u.util.ljust("Name", 20) + u.util.rjust("100", 10));
+u.send(u.util.sprintf("%-20s %5d gp", player.name!, gold));
+const text = await u.util.resolveFormat(u.me, "NAMEFORMAT", defaultName);
+</code></pre>
+<h3><code>u.auth</code> / <code>u.sys</code> / <code>u.chan</code> / <code>u.attr</code> / <code>u.events</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.auth.verify(u.me.name!, "pw");
+await u.auth.setPassword(u.me.id, "newpw");
+
+await u.sys.setConfig("server.name", "My Game");
+const t = await u.sys.gameTime();
+
+await u.chan.join("Public", "pub");
+await u.chan.create("Staff", { header: "%ch[STAFF]%cn", hidden: true });
+
+const bio = await u.attr.get(u.me.id, "FINGER-INFO");
+await u.attr.set(u.me.id, "BIO", "Tall and lanky.");
+
+await u.events.emit("game:levelup", { id: u.me.id, lvl: 5 });
+</code></pre>
+<h3><code>u.eval</code> / <code>u.evalString</code> / <code>u.trigger</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const score = await u.eval(u.me.id, "SCORE-FORMULA");
+const rendered = await u.evalString("[name(me)] is here.");
+await u.trigger(u.here.id, "ONENTER", [u.me.id]);
+</code></pre>
+<h3><code>u.force</code> / <code>u.forceAs</code> / <code>u.execute</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.force("look");
+await u.forceAs(npcId, "say Welcome.");
+await u.execute("@pemit #3=Server message.");
+</code></pre>
+<p><code>u.forceAs</code> is privileged — guard with <code>u.me.flags.has("wizard")</code> etc.</p>
+<hr>
 <h2>Database</h2>
-<p>The <code>Database</code> class provides access to the UrsaMU database.</p>
-<h3>Methods</h3>
-<h4><code>get(key: string)</code></h4>
-<p>Gets a value from the database.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const value = await app.db.get("players:#123");
-</code></pre>
-<h4><code>set(key: string, value: any)</code></h4>
-<p>Sets a value in the database.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.db.set("players:#123", playerData);
-</code></pre>
-<h4><code>delete(key: string)</code></h4>
-<p>Deletes a value from the database.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.db.delete("players:#123");
-</code></pre>
-<h4><code>list(prefix: string)</code></h4>
-<p>Lists all keys with a specific prefix.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const playerKeys = await app.db.list("players:");
-</code></pre>
-<h4><code>transaction(callback: (tx: Transaction) =&gt; Promise&lt;void&gt;)</code></h4>
-<p>Performs a transaction.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.db.transaction(async (tx) =&gt; {
-  const player = await tx.get("players:#123");
-  player.money += 100;
-  await tx.set("players:#123", player);
-});
-</code></pre>
-<h2>CommandManager</h2>
-<p>The <code>CommandManager</code> class manages commands in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>register(plugin: string, command: ICmd)</code></h4>
-<p>Registers a command. Prefer using <code>addCmd()</code> directly from the SDK package.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/ursamu";
+<h3><code>DBO&lt;T&gt;</code></h3>
+<p>Generic database collection. Use for plugin-scoped storage. Always prefix<br>
+the namespace with your plugin name.</p>
+<p>By default, UrsaMU uses <strong>TypeGraph (built on Postgres/PGlite)</strong> to store document records inside a local or in-memory PostgreSQL database, with a fallback <code>DenoKvAdapter</code> available.</p>
+<ul>
+<li><strong>Environment Variable</strong>: <code>URSAMU_TYPEGRAPH_DB</code> can be set to customize the database storage file/directory (defaults to <code>${Deno.cwd()}/data/typegraph.db</code> for production/development, and <code>memory://</code> during test runs).</li>
+<li><strong>Methods</strong>: Supports standard query and modification operators.</li>
+</ul>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { DBO } from "jsr:@ursamu/mush";
 
-addCmd({
-  name: "hello",
-  pattern: /^hello$/i,
-  lock: "connected",
-  exec: (u) =&gt; {
-    u.send("Hello, world!");
-  }
+const scores = new DBO&lt;{ player: string; score: number }&gt;("myplugin.scores");
+await scores.create({ player: "Alice", score: 100 });
+const all = await scores.all();
+const top = await scores.queryOne({ player: "Alice" });
+await scores.modify({ player: "Alice" }, "$inc", { score: 1 });
+await scores.modify({ player: "Alice" }, "$push", { history: Date.now() });
+</code></pre>
+<p>Ops: <code>$set</code>, <code>$inc</code>, <code>$unset</code>, <code>$push</code> (atomic CAS append).</p>
+<h3><code>dbojs</code></h3>
+<p>The shared game-object collection (<code>IDBOBJ</code>).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { dbojs } from "jsr:@ursamu/mush";
+
+const players = await dbojs.find({ flags: { $in: ["player"] } });
+const room = await dbojs.queryOne({ id: "1" });
+</code></pre>
+<hr>
+<h2>Locks &amp; permissions</h2>
+<p>Lock strings combine <strong>lockfuncs</strong> with the operators <code>&amp;&amp;</code>, <code>||</code>, <code>!</code>, and<br>
+<code>()</code>. Legacy <code>&amp;</code> / <code>|</code> still work. Max length 4096 chars / 256 tokens.</p>
+<p>Built-in lockfuncs:</p>
+<table>
+<thead>
+<tr>
+<th>Func</th>
+<th>Example</th>
+<th>Passes when</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>flag(name)</code></td>
+<td><code>flag(wizard)</code></td>
+<td>enactor has the flag</td>
+</tr>
+<tr>
+<td><code>attr(name)</code></td>
+<td><code>attr(tribe)</code></td>
+<td>enactor.state has own property <code>name</code></td>
+</tr>
+<tr>
+<td><code>attr(name, val)</code></td>
+<td><code>attr(tribe, glasswalker)</code></td>
+<td><code>state[name] === val</code></td>
+</tr>
+<tr>
+<td><code>type(name)</code></td>
+<td><code>type(player)</code></td>
+<td>enactor has the type flag</td>
+</tr>
+<tr>
+<td><code>is(#id)</code></td>
+<td><code>is(#5)</code></td>
+<td><code>enactor.id === "5"</code></td>
+</tr>
+<tr>
+<td><code>holds(#id)</code></td>
+<td><code>holds(#12)</code></td>
+<td>enactor.contents includes <code>#12</code></td>
+</tr>
+<tr>
+<td><code>perm(level)</code></td>
+<td><code>perm(admin)</code></td>
+<td>passes privilege ladder check</td>
+</tr>
+</tbody>
+</table>
+<h3><code>registerLockFunc(name, fn)</code></h3>
+<p>Register a custom lockfunc. Built-in names are protected.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerLockFunc } from "jsr:@ursamu/mush";
+
+registerLockFunc("tribe", (enactor, _target, args) =&gt;
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// lock: "tribe(glasswalker) || perm(admin)"
+</code></pre>
+<h3><code>evaluateLock(lock, enactor, target?)</code></h3>
+<p>Returns <code>Promise&lt;boolean&gt;</code>. Fail-closed on unknown funcs or parse errors.</p>
+<h3><code>validateLock(lock)</code></h3>
+<p>Throws on syntax error. Use to validate user-supplied lock strings.</p>
+<hr>
+<h2>Format handlers</h2>
+<p>Pluggable display formatters for engine and plugin output. Resolution<br>
+priority: per-object softcode attribute → registered TS handler →<br>
+registered MUSH template → built-in default.</p>
+<p><code>FormatSlot</code> is an <strong>open union</strong> (v2.3.4+). The eight engine-known slots<br>
+get IDE autocomplete:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">NAMEFORMAT  DESCFORMAT  CONFORMAT   EXITFORMAT
+WHOFORMAT   WHOROWFORMAT  PSFORMAT  PSROWFORMAT
+</code></pre>
+<p>Plugins may register any <code>UPPERCASE</code> slot (e.g. <code>"MAILFORMAT"</code>,<br>
+<code>"BBROWFORMAT"</code>) without casts.</p>
+<h3><code>registerFormatHandler(slot, fn)</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerFormatHandler("NAMEFORMAT", (u, target, defaultName) =&gt; {
+  if (!target.flags.has("room")) return null;
+  return `%ch%cy[${defaultName}]%cn\n`;
 });
 </code></pre>
-<h4><code>unregister(plugin: string, commandName: string)</code></h4>
-<p>Unregisters a command.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.commands.unregister("myplugin", "hello");
+<p>Return <code>null</code> to fall through. First non-null handler wins. Returns the<br>
+registered function so <code>unregisterFormatHandler</code> can remove it.</p>
+<h3><code>registerFormatTemplate(slot, mushSource)</code> <em>(v2.4.0)</em></h3>
+<p>Install a MUSH-softcode template. <code>%0</code> binds to the default rendering.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const fn = registerFormatTemplate(
+  "NAMEFORMAT",
+  "[center(strcat(%cy[ ,%0, ]%cn),78,=)]",
+);
+// remove() ...
+unregisterFormatHandler("NAMEFORMAT", fn);
 </code></pre>
-<h4><code>get(commandName: string)</code></h4>
-<p>Gets a command by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const command = app.commands.get("look");
+<h3><code>unregisterFormatHandler(slot, fn)</code></h3>
+<p>Remove a handler by reference identity.</p>
+<h3><code>resolveFormat(target, slot, defaultArg)</code></h3>
+<p>Two-step lookup for target-bound formats: softcode attr on <code>target</code> →<br>
+registered handler. Returns <code>string | null</code>.</p>
+<h3><code>resolveFormatOr(target, slot, defaultArg, fallback)</code></h3>
+<p>As above, but always returns a string.</p>
+<h3><code>resolveGlobalFormat(enactor, slot, defaultArg)</code> <em>(v2.3.3)</em></h3>
+<p>Two-tier lookup for global-list formats (WHO, @ps, +mail, +bb): <code>#0</code> →<br>
+enactor. Returns <code>string | null</code>.</p>
+<h3><code>resolveGlobalFormatOr(enactor, slot, defaultArg, fallback)</code></h3>
+<p>Always returns a string.</p>
+<h3><code>header(title, width?)</code> / <code>divider(width?)</code> / <code>footer(width?)</code></h3>
+<p>Native TS layout helpers for block-style section rules. Distinct from the<br>
+softcode helpers of the same name.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.send(header("Stats", 78));
+u.send(divider(78));
+u.send(footer(78));
 </code></pre>
-<h4><code>match(input: string)</code></h4>
-<p>Finds a command that matches the input.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const match = app.commands.match("look at sword");
-if (match) {
-  // Commands are executed by the command parser via createNativeSDK
-  // Direct invocation is not typical — let the parser route commands
+<h3>Types</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">type FormatHandler = (
+  u: IUrsamuSDK,
+  target: IDBObj,
+  defaultArg: string,
+) =&gt; Promise&lt;string | null&gt; | string | null;
+
+type FormatSlot = "NAMEFORMAT" | "DESCFORMAT" | "CONFORMAT" | "EXITFORMAT"
+  | "WHOFORMAT" | "WHOROWFORMAT" | "PSFORMAT" | "PSROWFORMAT"
+  | (string &amp; {});
+</code></pre>
+<hr>
+<h2>Softcode extension</h2>
+<h3><code>registerSoftcodeFunc(name, fn)</code></h3>
+<p>Register a custom stdlib function callable from softcode as <code>name(args)</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerSoftcodeFunc } from "jsr:@ursamu/mush";
+
+registerSoftcodeFunc("double", (_ctx, args) =&gt;
+  String(Number(args[0]) * 2)
+);
+</code></pre>
+<h3><code>registerSoftcodeSub(char, handler)</code></h3>
+<p>Register a custom <code>%X</code> substitution.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerSoftcodeSub("$", (ctx) =&gt; `[$${ctx.enactor.id}]`);
+</code></pre>
+<h3><code>softcodeService</code></h3>
+<p>The evaluator instance. Exposed for plugin integration tests.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { softcodeService } from "jsr:@ursamu/mush";
+const out = await softcodeService.eval({ enactor, executor, source: "[add(2,3)]" });
+</code></pre>
+<hr>
+<h2>Hooks &amp; events</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+import type { SessionEvent, SayEvent } from "jsr:@ursamu/mush";
+
+const onLogin = (e: SessionEvent) =&gt; console.log(`${e.player.name} logged in`);
+gameHooks.on("player:login", onLogin);
+
+// In plugin remove() — same function reference required:
+gameHooks.off("player:login", onLogin);
+</code></pre>
+<p><code>GameHookMap</code> event names:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">player:login      player:logout
+say               pose             page             move
+channel:message
+object:created    object:destroyed object:modified  object:moved
+scene:created     scene:pose       scene:set
+scene:title       scene:clear
+mail:received
+</code></pre>
+<p>Each has a typed payload (<code>SessionEvent</code>, <code>SayEvent</code>, <code>PoseEvent</code>,<br>
+<code>PageEvent</code>, <code>MoveEvent</code>, <code>ChannelMessageEvent</code>, <code>ObjectCreatedEvent</code>,<br>
+<code>ObjectDestroyedEvent</code>, <code>ObjectModifiedEvent</code>, <code>ObjectMovedEvent</code>, <code>SceneCreatedEvent</code>,<br>
+<code>ScenePoseEvent</code>, <code>SceneSetEvent</code>, <code>SceneTitleEvent</code>, <code>SceneClearEvent</code>,<br>
+<code>MailReceivedEvent</code>).</p>
+<hr>
+<h2>REST &amp; UI</h2>
+<h3><code>registerPluginRoute(prefix, handler)</code></h3>
+<p>Attach a REST handler. Always return 401 before doing work when <code>userId</code><br>
+is null on a protected route.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerPluginRoute("/api/v1/my-plugin", async (req, userId) =&gt; {
+  if (!userId) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  return Response.json({ ok: true, userId });
+});
+</code></pre>
+<p>Handler signature: <code>(req: Request, userId: string | null) =&gt; Promise&lt;Response&gt;</code>.</p>
+<h3><code>registerUIComponent(component)</code> / <code>unregisterUIComponent(id)</code> / <code>getRegisteredUIComponents()</code></h3>
+<p>Expose a UI element via <code>GET /api/v1/ui-manifest</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import type { IUIComponent } from "jsr:@ursamu/mush";
+
+const comp: IUIComponent = {
+  id: "myplugin.panel",
+  type: "panel",
+  title: "My Panel",
+  url: "/plugins/myplugin/panel.html",
+  requires: { flag: "builder" },
+};
+registerUIComponent(comp);
+</code></pre>
+<hr>
+<h2>Stat systems</h2>
+<p>Plugins can register a pluggable stat/skill system, queryable by name.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerStatSystem, getDefaultStatSystem } from "jsr:@ursamu/mush";
+import type { IStatSystem } from "jsr:@ursamu/mush";
+
+const system: IStatSystem = { name: "wod5", /* ...impl */ };
+registerStatSystem(system, { default: true });
+
+const def = getDefaultStatSystem();
+</code></pre>
+<p>Also: <code>getStatSystem(name)</code>, <code>getStatSystemNames(): string[]</code>.</p>
+<hr>
+<h2>WebSocket</h2>
+<h3><code>wsService</code></h3>
+<p>Direct access to the WebSocket hub. Used by channel/notification plugins.</p>
+<h3><code>joinSocketToRoom(socketId, room)</code></h3>
+<p>Subscribe a connected socket to a broadcast room.</p>
+<h3><code>send(message, target?, options?)</code></h3>
+<p>Module-level broadcast — sends to a socket ID, room ID, or DB object ID.<br>
+Same semantics as <code>u.send</code> but importable from anywhere.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { send } from "jsr:@ursamu/mush";
+send("Server reboot in 5 minutes.", "#all");
+</code></pre>
+<h3><code>notify(actorId, message, options?)</code></h3>
+<p>Deliver a message to a single online actor by id. Available as both<br>
+<code>u.notify(actorId, msg)</code> (Promise<boolean>) on the SDK and a standalone<br>
+<code>notify</code> import for <code>gameHooks</code> handlers that don’t have a <code>u</code>. Returns<br>
+<code>true</code> if at least one live socket was found for the actor, <code>false</code> if the<br>
+actor is offline — callers can branch on the result to queue or drop.</boolean></p>
+<p>Use this when you need to message a third party. <code>u.send</code> addresses the<br>
+caller (<code>u.me</code>); <code>here.broadcast</code> is room-scoped; <code>notify</code> is the right<br>
+tool when a plugin command boots another player from a seat, or a hook<br>
+handler wants to tell the moved actor <em>why</em> something just happened.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In a plugin command:
+const delivered = await u.notify(target.id, "You have been booted from your post.");
+if (!delivered) {
+  // queue a job / mark unread / fall back to email
 }
-</code></pre>
-<h2>PluginManager</h2>
-<p>The <code>PluginManager</code> class manages plugins in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>register(plugin: IPlugin)</code></h4>
-<p>Registers a plugin.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.plugins.register(new MyPlugin());
-</code></pre>
-<h4><code>unregister(pluginName: string)</code></h4>
-<p>Unregisters a plugin.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.plugins.unregister("myplugin");
-</code></pre>
-<h4><code>get(pluginName: string)</code></h4>
-<p>Gets a plugin by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const plugin = app.plugins.get("myplugin");
-</code></pre>
-<h4><code>loadAll()</code></h4>
-<p>Loads all registered plugins.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.plugins.loadAll();
-</code></pre>
-<h4><code>unloadAll()</code></h4>
-<p>Unloads all registered plugins.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.plugins.unloadAll();
-</code></pre>
-<h2>PlayerManager</h2>
-<p>The <code>PlayerManager</code> class manages players in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>create(name: string, password: string)</code></h4>
-<p>Creates a new player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const player = await app.players.create("NewPlayer", "password123");
-</code></pre>
-<h4><code>authenticate(name: string, password: string)</code></h4>
-<p>Authenticates a player.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const player = await app.players.authenticate("PlayerName", "password123");
-if (player) {
-  // Authentication successful
-}
-</code></pre>
-<h4><code>get(dbref: string)</code></h4>
-<p>Gets a player by dbref.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const player = app.players.get("#123");
-</code></pre>
-<h4><code>getByName(name: string)</code></h4>
-<p>Gets a player by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const player = app.players.getByName("PlayerName");
-</code></pre>
-<h4><code>getConnected()</code></h4>
-<p>Gets all connected players.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const connectedPlayers = app.players.getConnected();
-</code></pre>
-<h4><code>broadcast(message: string)</code></h4>
-<p>Broadcasts a message to all connected players.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.players.broadcast("Server announcement: We will be upgrading soon!");
-</code></pre>
-<h2>ObjectManager</h2>
-<p>The <code>ObjectManager</code> class manages game objects in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>create(type: string, name: string, owner: string)</code></h4>
-<p>Creates a new game object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const room = await app.objects.create("ROOM", "Town Square", "#1");
-</code></pre>
-<h4><code>get(dbref: string)</code></h4>
-<p>Gets an object by dbref.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const obj = app.objects.get("#123");
-</code></pre>
-<h4><code>search(query: ObjectQuery)</code></h4>
-<p>Searches for objects matching a query.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const results = await app.objects.search({
-  type: "ROOM",
-  flags: ["DARK"],
-  owner: "#1"
+
+// In a gameHooks handler (no `u` in scope):
+import { notify, gameHooks } from "jsr:@ursamu/mush";
+gameHooks.on("player:move", (e) =&gt; {
+  notify(e.actorId, "Station unmanned — you left the post.");
 });
+
+// In a system script (sandboxed) — same shape, also returns a Promise&lt;boolean&gt;:
+export default async (u) =&gt; {
+  await u.notify(targetId, "Heads up.");
+};
 </code></pre>
-<h4><code>delete(dbref: string)</code></h4>
-<p>Deletes an object.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.objects.delete("#123");
+<p><code>UserSocket</code> is the typed socket metadata exported for plugin authors.</p>
+<hr>
+<h2>Engine context</h2>
+<p><code>GameContext</code> is the substrate every command runs on (actor, location,<br>
+helpers). Most plugin code uses <code>IUrsamuSDK</code> instead — <code>GameContext</code> is<br>
+exposed for low-level integrations.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { buildContext } from "jsr:@ursamu/mush";
+const ctx = await buildContext({ socketId, actorId });
 </code></pre>
-<h2>FlagManager</h2>
-<p>The <code>FlagManager</code> class manages flags in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>register(flag: Flag)</code></h4>
-<p>Registers a new flag.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.flags.register({
-  name: "INVISIBLE",
-  letter: "I",
-  type: ["PLAYER", "THING"],
-  permission: "wizard"
-});
+<hr>
+<h2>Plugin config</h2>
+<p><code>PluginConfigManager</code> reads per-plugin scoped values from <code>config.json</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { PluginConfigManager } from "jsr:@ursamu/mush";
+
+const cfg = new PluginConfigManager("myplugin");
+const apiKey = cfg.get&lt;string&gt;("apiKey");
+await cfg.set("lastRun", Date.now());
 </code></pre>
-<h4><code>unregister(flagName: string)</code></h4>
-<p>Unregisters a flag.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">app.flags.unregister("INVISIBLE");
+<hr>
+<h2>Stdlib (TS)</h2>
+<p>All functions are pure and deterministic. v2.5.1 promoted these from<br>
+softcode-only to TS-importable. v2.5.2 added per-instance <code>Noise</code>.</p>
+<h3>Noise</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import {
+  seedNoise, perlin1, perlin2, perlin3,
+  simplex2, worley2, fbm2, ridged2, noiseGrid,
+  Noise, createNoise, buildPerm,
+} from "jsr:@ursamu/mush";
+
+seedNoise(42);
+const v = perlin2(0.5, 1.7);
+
+const n = createNoise(123);
+const v2 = n.perlin2(0.5, 1.7);
 </code></pre>
-<h4><code>get(flagName: string)</code></h4>
-<p>Gets a flag by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const flag = app.flags.get("WIZARD");
+<table>
+<thead>
+<tr>
+<th>Function</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>seedNoise(seed)</code></td>
+<td>Reseed the singleton noise stream</td>
+</tr>
+<tr>
+<td><code>perlin1/2/3</code></td>
+<td>Classic Perlin noise (1D/2D/3D), range ~[-1, 1]</td>
+</tr>
+<tr>
+<td><code>simplex2</code></td>
+<td>2D simplex noise</td>
+</tr>
+<tr>
+<td><code>worley2</code></td>
+<td>2D Worley/cellular noise, returns distance to nearest feature</td>
+</tr>
+<tr>
+<td><code>fbm2</code></td>
+<td>Fractional Brownian Motion (octave-summed Perlin)</td>
+</tr>
+<tr>
+<td><code>ridged2</code></td>
+<td>Ridged multifractal noise</td>
+</tr>
+<tr>
+<td><code>noiseGrid(w,h,fn)</code></td>
+<td>Sample a function over a grid → <code>number[][]</code></td>
+</tr>
+<tr>
+<td><code>buildPerm(seed)</code></td>
+<td>Build a permutation table for a custom noise impl</td>
+</tr>
+<tr>
+<td><code>Noise</code> class</td>
+<td>Per-instance independent noise stream</td>
+</tr>
+<tr>
+<td><code>createNoise(seed)</code></td>
+<td>Construct a <code>Noise</code></td>
+</tr>
+</tbody>
+</table>
+<h3>PRNG (<code>Rng</code>)</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { Rng, createRng } from "jsr:@ursamu/mush";
+
+const r = createRng(123);
+r.next();        // [0, 1)
+r.int(1, 6);     // dice roll
+r.pick(["a", "b", "c"]);
 </code></pre>
-<h4><code>check(obj: GameObject, flagName: string)</code></h4>
-<p>Checks if an object has a flag.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const hasFlag = app.flags.check(player, "WIZARD");
+<p>Per-instance mulberry32 — independent of the softcode RNG.</p>
+<h3>Physics</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { vreflect, pointInAabb, rayAabb } from "jsr:@ursamu/mush";
+import type { Vec3 } from "jsr:@ursamu/mush";
+
+const reflected = vreflect([1, 0, 0], [0, 1, 0]);
+const inside = pointInAabb([5, 5, 5], [0, 0, 0], [10, 10, 10]);
+const hit = rayAabb(origin, dir, min, max);
 </code></pre>
-<h2>ChannelManager</h2>
-<p>The <code>ChannelManager</code> class manages communication channels in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>create(name: string, owner: string, options?: ChannelOptions)</code></h4>
-<p>Creates a new channel.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const channel = await app.channels.create("Public", "#1", {
-  header: "Public Channel",
-  joinable: true,
-  leavable: true
-});
+<h3>Spatial scalars</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import {
+  dist2d, dist3d, distSq2d, distSq3d,
+  manhattan, chebyshev, angle2d, bearing,
+} from "jsr:@ursamu/mush";
+
+dist2d(0, 0, 3, 4);     // 5
+manhattan(0, 0, 3, 4);  // 7
+bearing(0, 0, 1, 1);    // radians
 </code></pre>
-<h4><code>get(name: string)</code></h4>
-<p>Gets a channel by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const channel = app.channels.get("Public");
+<h3>Interpolation</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { lerp, inverseLerp, remap, smoothstep, smootherstep, clamp }
+  from "jsr:@ursamu/mush";
+
+lerp(0, 100, 0.5);          // 50
+inverseLerp(0, 100, 75);    // 0.75
+remap(0, 100, 0, 1, 50);    // 0.5
+smoothstep(0, 1, 0.5);      // 0.5 (Hermite curve)
+clamp(150, 0, 100);         // 100
 </code></pre>
-<h4><code>join(channelName: string, player: Player)</code></h4>
-<p>Adds a player to a channel.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.channels.join("Public", player);
+<h3>Vector ops</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { vsize, vsizeSq, vdistance, vdistanceSq, vlerp, vclamp }
+  from "jsr:@ursamu/mush";
+import type { Vec } from "jsr:@ursamu/mush";
+
+const a: Vec = [3, 4];
+vsize(a);              // 5
+vdistance([0, 0], a);  // 5
+vlerp([0, 0], a, 0.5); // [1.5, 2]
 </code></pre>
-<h4><code>leave(channelName: string, player: Player)</code></h4>
-<p>Removes a player from a channel.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.channels.leave("Public", player);
+<hr>
+<h2>Types</h2>
+<table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>IUrsamuSDK</code></td>
+<td>The <code>u</code> object — full surface</td>
+</tr>
+<tr>
+<td><code>IDBObj</code></td>
+<td>Hydrated game object (Set flags, populated contents)</td>
+</tr>
+<tr>
+<td><code>IDBOBJ</code></td>
+<td>Raw DB record shape</td>
+</tr>
+<tr>
+<td><code>ICmd</code></td>
+<td>Command registration</td>
+</tr>
+<tr>
+<td><code>IPlugin</code></td>
+<td>Plugin module export</td>
+</tr>
+<tr>
+<td><code>IPluginDependency</code></td>
+<td>Entry in <code>ursamu.plugin.json</code> deps</td>
+</tr>
+<tr>
+<td><code>IContext</code></td>
+<td>Low-level command context (legacy)</td>
+</tr>
+<tr>
+<td><code>IMiddlewareFunction</code></td>
+<td><code>(u: IUrsamuSDK) =&gt; boolean | Promise&lt;boolean&gt;</code></td>
+</tr>
+<tr>
+<td><code>IStatSystem</code></td>
+<td>Pluggable stat system</td>
+</tr>
+<tr>
+<td><code>IUIComponent</code></td>
+<td>UI manifest entry</td>
+</tr>
+<tr>
+<td><code>GameHookMap</code></td>
+<td>Event-name → payload mapping</td>
+</tr>
+<tr>
+<td><code>FormatHandler</code></td>
+<td>TS format-handler signature</td>
+</tr>
+<tr>
+<td><code>FormatSlot</code></td>
+<td>Open uppercase-string union</td>
+</tr>
+<tr>
+<td><code>GameContext</code></td>
+<td>Engine substrate</td>
+</tr>
+<tr>
+<td><code>UserSocket</code></td>
+<td>WebSocket metadata</td>
+</tr>
+<tr>
+<td><code>LockFunc</code></td>
+<td>Custom lockfunc signature</td>
+</tr>
+<tr>
+<td><code>SoftcodeFn</code></td>
+<td>Custom stdlib function signature</td>
+</tr>
+<tr>
+<td><code>SoftcodeSubHandler</code></td>
+<td>Custom <code>%X</code> handler signature</td>
+</tr>
+<tr>
+<td><code>SoftcodeContext</code></td>
+<td>Evaluator context</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Internal: plugin install errors</h2>
+<p>The v2.6.0 plugin installer throws typed errors on failure. They live in<br>
+<code>src/utils/pluginErrors.ts</code> and are <strong>not currently exported from<br>
+<code>mod.ts</code></strong> — they are used internally by the <code>ursamu plugin install</code><br>
+flow. Listed here for diagnostic visibility.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">PluginInstallError              base class
+├─ PluginDepNameError           invalid/missing name in deps entry
+├─ PluginDepUrlError            invalid/missing url
+├─ PluginCloneError             git clone failed
+├─ PluginRenameError            move into plugins/ failed
+├─ PluginVersionError           installed plugin missing version manifest
+├─ PluginSemverError            installed version doesn't satisfy dep range
+└─ PluginConflictError          two deps disagree on resolved version
 </code></pre>
-<h4><code>send(channelName: string, sender: Player, message: string)</code></h4>
-<p>Sends a message to a channel.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.channels.send("Public", player, "Hello, everyone!");
-</code></pre>
-<h2>MailManager</h2>
-<p>The <code>MailManager</code> class manages the mail system in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>send(sender: string, recipient: string, subject: string, body: string)</code></h4>
-<p>Sends a mail message.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.mail.send("#1", "#2", "Hello", "This is a test message.");
-</code></pre>
-<h4><code>get(mailId: string)</code></h4>
-<p>Gets a mail message by ID.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const message = await app.mail.get("mail:123");
-</code></pre>
-<h4><code>getInbox(player: string)</code></h4>
-<p>Gets a player’s inbox.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const inbox = await app.mail.getInbox("#1");
-</code></pre>
-<h4><code>delete(mailId: string)</code></h4>
-<p>Deletes a mail message.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.mail.delete("mail:123");
-</code></pre>
-<h2>BulletinBoardManager</h2>
-<p>The <code>BulletinBoardManager</code> class manages bulletin boards in UrsaMU.</p>
-<h3>Methods</h3>
-<h4><code>createBoard(name: string, owner: string, options?: BoardOptions)</code></h4>
-<p>Creates a new bulletin board.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const board = await app.bboard.createBoard("Announcements", "#1", {
-  readPermission: "connected",
-  writePermission: "wizard"
-});
-</code></pre>
-<h4><code>getBoard(name: string)</code></h4>
-<p>Gets a board by name.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const board = await app.bboard.getBoard("Announcements");
-</code></pre>
-<h4><code>post(boardName: string, author: string, subject: string, body: string)</code></h4>
-<p>Posts a message to a board.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.bboard.post("Announcements", "#1", "Server Update", "We will be updating the server tomorrow.");
-</code></pre>
-<h4><code>getPost(postId: string)</code></h4>
-<p>Gets a post by ID.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const post = await app.bboard.getPost("post:123");
-</code></pre>
-<h4><code>deletePost(postId: string)</code></h4>
-<p>Deletes a post.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await app.bboard.deletePost("post:123");
-</code></pre>
+<p>On any throw the installer’s <code>InstallTxn</code> rolls back every directory and<br>
+registry mutation made during the run.</p>
 
       </article>
 
@@ -956,6 +1077,40 @@ if (player) {
       
         
       
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
 
       
       <nav class="page-nav" aria-label="Page navigation">
@@ -967,9 +1122,9 @@ if (player) {
         
 
         
-          <a href="/ursamu/child-games/" class="page-nav-btn next">
+          <a href="/ursamu/api/rest/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">REST API Reference</span>
           </a>
         
       </nav>

--- a/docs/_site/api/index.html
+++ b/docs/_site/api/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>API Reference | UrsaMU Documentation</title>
-  <meta name="description" content="Comprehensive API reference for UrsaMU">
+  <meta name="description" content="Quick-reference index for all public UrsaMU APIs — imports, types, commands, database, hooks, and REST endpoints.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -267,247 +267,296 @@
 
       <!-- Page content -->
       <article class="prose">
-        <h1>UrsaMU API Reference</h1>
-<p>This document provides a comprehensive reference for the UrsaMU API.</p>
-<h2>Core API</h2>
-<h3>mu(options)</h3>
-<p>The main function to initialize and start the UrsaMU engine.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>options</code> (Object): Configuration options for the UrsaMU engine
-<ul>
-<li><code>config</code> (Object): Configuration object</li>
-<li><code>plugins</code> (Array): Array of plugins to load</li>
-</ul>
-</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<void>: Resolves when the engine has started</void></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { mu } from "ursamu";
+        <h1>API Reference</h1>
+<h2>Quick-reference index for all public UrsaMU APIs. For full documentation of<br>
+each section, see <a href="/ursamu/api/core/">Core API Reference</a>.</h2>
+<h2>Imports</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// All public APIs
+import {
+  addCmd, registerPluginRoute, mu, createObj, DBO, dbojs, gameHooks
+} from "jsr:@ursamu/mush";
 
-await mu({
-  config: {
-    server: {
-      port: 4201,
-      host: "0.0.0.0",
-    },
-    game: {
-      name: "My Game",
-    },
-  },
-  plugins: [myPlugin],
-});
+// Types (zero runtime cost)
+import type {
+  ICmd, IPlugin, IDBObj, IUrsamuSDK,
+  SayEvent, PoseEvent, PageEvent, MoveEvent, SessionEvent,
+  ChannelMessageEvent, SceneCreatedEvent, ScenePoseEvent,
+  SceneSetEvent, SceneTitleEvent, SceneClearEvent,
+} from "jsr:@ursamu/mush";
 </code></pre>
-<h3>app</h3>
-<p>The global application object that provides access to various services and<br>
-utilities.</p>
-<p><strong>Properties:</strong></p>
-<ul>
-<li><code>config</code>: The configuration manager</li>
-<li><code>db</code>: The database manager</li>
-<li><code>commands</code>: The command manager</li>
-<li><code>flags</code>: The flag manager</li>
-<li><code>functions</code>: The function manager</li>
-<li><code>hooks</code>: The hook manager</li>
-<li><code>router</code>: The web router (if web interface is enabled)</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { app } from "ursamu";
-
-// Access the configuration
-const gameName = app.config.get("game.name");
-
-// Access the database
-const player = await app.db.get("player:123");
+<p>Internal plugins may use direct paths:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "../../services/commands/cmdParser.ts";
+import type { IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
 </code></pre>
-<h2>Database API</h2>
-<h3>dbojs</h3>
-<p>The main database service for game objects.</p>
-<p><strong>Methods:</strong></p>
-<h4>create(data)</h4>
-<p>Creates a new object in the database.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>data</code> (Object): The object data to create</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<object>: The created object
-
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { dbojs } from "../../services/Database/index.ts";
-
-const newObject = await dbojs.create({
-  flags: "thing",
-  data: {
-    name: "My Object",
-    description: "A custom object",
-  },
-});
-</code></pre>
-<h4>get(id)</h4>
-<p>Retrieves an object from the database by ID.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>id</code> (string): The ID of the object to retrieve</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise&lt;Object|null&gt;: The retrieved object, or null if not found</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const object = await dbojs.get("123");
-</code></pre>
-<h4>update(object)</h4>
-<p>Updates an object in the database.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>object</code> (Object): The object to update</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<object>: The updated object
-
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">object.data.description = "Updated description";
-await dbojs.update(object);
-</code></pre>
-<h4>delete(id)</h4>
-<p>Deletes an object from the database.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>id</code> (string): The ID of the object to delete</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<void></void></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await dbojs.delete("123");
-</code></pre>
-<h4>query(criteria)</h4>
-<p>Queries the database for objects matching the given criteria.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>criteria</code> (Object): Query criteria</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise&lt;Array<object>&gt;: Array of matching objects
-
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Find all rooms
-const rooms = await dbojs.query({ flags: /room/i });
-
-// Find objects owned by a player
-const objects = await dbojs.query({ owner: "123" });
-
-// Find a player by name
-const players = await dbojs.query({
-  "data.name": new RegExp("^PlayerName$", "i"),
-  flags: /player/i,
-});
-</code></pre>
-<h4>all()</h4>
-<p>Retrieves all objects from the database.</p>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise&lt;Array<object>&gt;: Array of all objects
-
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const allObjects = await dbojs.all();
-</code></pre>
-<h3>counters</h3>
-<p>The database service for counters.</p>
-<p><strong>Methods:</strong></p>
-<p>Similar to <code>dbojs</code>, with the same method signatures.</p>
-<h3>chans</h3>
-<p>The database service for communication channels.</p>
-<p><strong>Methods:</strong></p>
-<p>Similar to <code>dbojs</code>, with the same method signatures.</p>
-<h3>mail</h3>
-<p>The database service for the mail system.</p>
-<p><strong>Methods:</strong></p>
-<p>Similar to <code>dbojs</code>, with the same method signatures.</p>
-<h3>bboard</h3>
-<p>The database service for bulletin boards.</p>
-<p><strong>Methods:</strong></p>
-<p>Similar to <code>dbojs</code>, with the same method signatures.</p>
-<h2>Command API</h2>
-<h3>addCmd(command)</h3>
-<p>Registers a new command.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>command</code> (ICmd): The command to register
-<ul>
-<li><code>name</code> (string): Unique identifier for the command</li>
-<li><code>pattern</code> (string | RegExp): Regex pattern to match user input; capture groups become <code>u.cmd.args</code></li>
-<li><code>lock</code> (string): Lock expression required to use the command (e.g. <code>"connected"</code>, <code>"wizard"</code>)</li>
-<li><code>exec</code> (Function): Function to execute — receives <code>IUrsamuSDK</code></li>
-</ul>
-</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>void</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "hello",
-  pattern: /^hello\s*(.*)/i,
-  lock: "connected",
-  exec: (u: IUrsamuSDK) =&gt; {
-    const target = u.cmd.args[0]?.trim() || "World";
-    u.send(`Hello, ${target}!`);
-  },
-});
-</code></pre>
-<h3>IUrsamuSDK</h3>
-<p>The unified SDK object passed to every command’s <code>exec</code> function. The same object is available in sandbox scripts.</p>
-<p><strong>Key properties:</strong></p>
+<hr>
+<h2>Types</h2>
 <table>
 <thead>
 <tr>
-<th>Property</th>
 <th>Type</th>
 <th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>u.me</code></td>
 <td><code>IDBObj</code></td>
-<td>The actor who executed the command</td>
+<td>Every game object — room, player, exit, item</td>
 </tr>
 <tr>
-<td><code>u.here</code></td>
-<td><code>IDBObj | null</code></td>
-<td>The room the actor is in</td>
+<td><code>IUrsamuSDK</code></td>
+<td>The <code>u</code> object injected into commands and scripts</td>
 </tr>
 <tr>
-<td><code>u.cmd.args</code></td>
-<td><code>string[]</code></td>
-<td>Regex capture groups from the matched pattern</td>
+<td><code>ICmd</code></td>
+<td>Command registration descriptor passed to <code>addCmd()</code></td>
 </tr>
 <tr>
-<td><code>u.cmd.switches</code></td>
-<td><code>string[]</code></td>
-<td>Switches supplied to the command</td>
+<td><code>IPlugin</code></td>
+<td>Plugin lifecycle interface</td>
 </tr>
 <tr>
-<td><code>u.socketId</code></td>
-<td><code>string</code></td>
-<td>The WebSocket socket ID</td>
+<td><code>IGameTime</code></td>
+<td>In-game calendar: <code>{ year, month, day, hour, minute }</code></td>
 </tr>
 </tbody>
 </table>
-<p><strong>Key methods:</strong></p>
+<h2>See <a href="/ursamu/api/core/">Core API Reference</a> for full type definitions.</h2>
+<h2>addCmd</h2>
+<p>Registers one or more in-game commands at module-load time.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/mush";
+import type { IUrsamuSDK } from "jsr:@ursamu/mush";
+
+addCmd({
+  name:    "+greet",
+  pattern: /^\+greet\s+(.*)/i,   // capture groups → u.cmd.args[0], args[1], …
+  lock:    "connected",
+  exec: async (u: IUrsamuSDK) =&gt; {
+    const target = await u.util.target(u.me, u.cmd.args[0]);
+    if (!target) { u.send("Who?"); return; }
+    u.send(`You wave to ${u.util.displayName(target, u.me)}.`);
+  },
+  help:     "+greet &lt;name&gt;\nWave at someone.",
+  category: "Social",
+});
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td><code>string</code></td>
+<td>Unique label; appears in help listings</td>
+</tr>
+<tr>
+<td><code>pattern</code></td>
+<td><code>RegExp</code></td>
+<td>Matched against raw player input</td>
+</tr>
+<tr>
+<td><code>lock</code></td>
+<td><code>string?</code></td>
+<td>Lock expression. Fails silently.</td>
+</tr>
+<tr>
+<td><code>exec</code></td>
+<td><code>(u) =&gt; void|Promise&lt;void&gt;</code></td>
+<td>Command body</td>
+</tr>
+<tr>
+<td><code>help</code></td>
+<td><code>string?</code></td>
+<td>Shown by <code>help &lt;name&gt;</code></td>
+</tr>
+<tr>
+<td><code>hidden</code></td>
+<td><code>boolean?</code></td>
+<td>Hide from help/command listings</td>
+</tr>
+<tr>
+<td><code>category</code></td>
+<td><code>string?</code></td>
+<td>Groups commands in listings</td>
+</tr>
+</tbody>
+</table>
+<h3>Lock expression quick reference</h3>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>""</code></td>
+<td>No restriction (login-screen commands)</td>
+</tr>
+<tr>
+<td><code>"connected"</code></td>
+<td>Player must be logged in</td>
+</tr>
+<tr>
+<td><code>"connected builder+"</code></td>
+<td>Logged in + builder flag or higher</td>
+</tr>
+<tr>
+<td><code>"connected admin+"</code></td>
+<td>Logged in + admin or higher</td>
+</tr>
+<tr>
+<td><code>"connected wizard"</code></td>
+<td>Logged in + wizard (level 9, superuser-only grant)</td>
+</tr>
+<tr>
+<td><code>"#42"</code></td>
+<td>Must be exactly object #42</td>
+</tr>
+<tr>
+<td><code>"!dark"</code></td>
+<td>Must NOT have the dark flag</td>
+</tr>
+<tr>
+<td><code>"wizard|admin"</code></td>
+<td>wizard OR admin</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>u.db</h2>
+<p>Database operations. All methods are <code>async</code>. Available in both <code>addCmd</code> handlers<br>
+and sandbox scripts.</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Signature</th>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>search</code></td>
+<td><code>(query: string | object) =&gt; Promise&lt;IDBObj[]&gt;</code></td>
+<td>Array of matching objects</td>
+</tr>
+<tr>
+<td><code>create</code></td>
+<td><code>(template: Partial&lt;IDBObj&gt;) =&gt; Promise&lt;IDBObj&gt;</code></td>
+<td>Newly created object</td>
+</tr>
+<tr>
+<td><code>modify</code></td>
+<td><code>(id, op, data) =&gt; Promise&lt;void&gt;</code></td>
+<td>—</td>
+</tr>
+<tr>
+<td><code>destroy</code></td>
+<td><code>(id: string) =&gt; Promise&lt;void&gt;</code></td>
+<td>—</td>
+</tr>
+</tbody>
+</table>
+<p><strong><code>modify</code> ops:</strong> <code>"$set"</code> (merge), <code>"$unset"</code> (remove field), <code>"$inc"</code> (increment number).<br>
+Do not pass any other string — it is rejected.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Merge a field
+await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
+
+// Full state replace (always spread to preserve other fields)
+await u.db.modify(u.me.id, "$set", { data: { ...u.me.state, gold: 100 } });
+
+// Increment
+await u.db.modify(u.me.id, "$inc", { "data.deaths": 1 });
+
+// Remove a field
+await u.db.modify(u.me.id, "$unset", { "data.tempAttr": "" });
+</code></pre>
+<p><strong>Search examples:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const online  = await u.db.search({ flags: /connected/i });
+const rooms   = await u.db.search({ flags: /room/i });
+const here    = await u.db.search({ location: u.here.id });
+const byName  = await u.db.search({ "data.name": /alice/i });
+const found   = await u.db.search({ $or: [
+  { "data.name": /alice/i }, { "data.alias": /alice/i }
+]});
+</code></pre>
+<hr>
+<h2>u.* Quick Reference</h2>
+<p>All namespaces on the <code>u</code> SDK object. Every method is <code>async</code> (returns a Promise).</p>
+<h3>Top-level methods</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Signature</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>send</code></td>
+<td><code>(msg, target?, opts?) =&gt; void</code></td>
+<td>Send to actor or target ID</td>
+</tr>
+<tr>
+<td><code>broadcast</code></td>
+<td><code>(msg, opts?) =&gt; void</code></td>
+<td>Send to all connected players</td>
+</tr>
+<tr>
+<td><code>teleport</code></td>
+<td><code>(target, dest) =&gt; void</code></td>
+<td>Move target to dest</td>
+</tr>
+<tr>
+<td><code>execute</code></td>
+<td><code>(cmd) =&gt; void</code></td>
+<td>Run command as actor</td>
+</tr>
+<tr>
+<td><code>force</code></td>
+<td><code>(cmd) =&gt; void</code></td>
+<td>Force command as actor</td>
+</tr>
+<tr>
+<td><code>forceAs</code></td>
+<td><code>(targetId, cmd) =&gt; Promise&lt;void&gt;</code></td>
+<td>Force command as another object</td>
+</tr>
+<tr>
+<td><code>canEdit</code></td>
+<td><code>(actor, target) =&gt; Promise&lt;boolean&gt;</code></td>
+<td>Owner / admin check</td>
+</tr>
+<tr>
+<td><code>checkLock</code></td>
+<td><code>(target, lock) =&gt; Promise&lt;boolean&gt;</code></td>
+<td>Evaluate lock expression</td>
+</tr>
+<tr>
+<td><code>setFlags</code></td>
+<td><code>(target, flags) =&gt; Promise&lt;void&gt;</code></td>
+<td>Add / remove flags</td>
+</tr>
+<tr>
+<td><code>trigger</code></td>
+<td><code>(target, attr, args?) =&gt; Promise&lt;void&gt;</code></td>
+<td>Fire a stored &amp;ATTR</td>
+</tr>
+<tr>
+<td><code>eval</code></td>
+<td><code>(targetId, attr, args?) =&gt; Promise&lt;string&gt;</code></td>
+<td>Evaluate &amp;ATTR, return output</td>
+</tr>
+</tbody>
+</table>
+<h3>u.util</h3>
 <table>
 <thead>
 <tr>
@@ -517,416 +566,515 @@ addCmd({
 </thead>
 <tbody>
 <tr>
-<td><code>u.send(msg)</code></td>
-<td>Send output to the actor</td>
+<td><code>target(actor, query, global?)</code></td>
+<td>Resolve name/ID to IDBObj</td>
 </tr>
 <tr>
-<td><code>u.broadcast(roomId, msg)</code></td>
-<td>Broadcast to everyone in a room</td>
+<td><code>displayName(obj, actor)</code></td>
+<td>Name with moniker applied</td>
 </tr>
 <tr>
-<td><code>u.force(cmd)</code></td>
-<td>Execute a command string as the actor</td>
+<td><code>stripSubs(str)</code></td>
+<td>Strip MUSH codes and ANSI escapes</td>
 </tr>
 <tr>
-<td><code>u.setFlags(id, flags)</code></td>
-<td>Add/remove flags (<code>"+wizard"</code>, <code>"-dark"</code>)</td>
+<td><code>ljust(str, len, fill?)</code></td>
+<td>Left-align to width</td>
 </tr>
 <tr>
-<td><code>u.teleport(id, destination)</code></td>
-<td>Move an object to a destination</td>
+<td><code>rjust(str, len, fill?)</code></td>
+<td>Right-align to width</td>
 </tr>
 <tr>
-<td><code>u.canEdit(actor, target)</code></td>
-<td>Check if actor can edit target (async)</td>
+<td><code>center(str, len, fill?)</code></td>
+<td>Center in width</td>
 </tr>
 <tr>
-<td><code>u.db.search(query)</code></td>
-<td>Search the database</td>
+<td><code>sprintf(fmt, ...args)</code></td>
+<td>Printf-style formatting</td>
 </tr>
 <tr>
-<td><code>u.db.create(data)</code></td>
-<td>Create a new object</td>
-</tr>
-<tr>
-<td><code>u.db.modify(id, data)</code></td>
-<td>Update an object</td>
-</tr>
-<tr>
-<td><code>u.db.destroy(id)</code></td>
-<td>Delete an object</td>
-</tr>
-<tr>
-<td><code>u.util.target(actor, name)</code></td>
-<td>Find a named object (async)</td>
-</tr>
-<tr>
-<td><code>u.util.stripSubs(str)</code></td>
-<td>Strip MUSH color/substitution codes</td>
-</tr>
-<tr>
-<td><code>u.auth.hash(password)</code></td>
-<td>Hash a password</td>
-</tr>
-<tr>
-<td><code>u.sys.disconnect(socketId)</code></td>
-<td>Disconnect a socket</td>
-</tr>
-<tr>
-<td><code>u.sys.reboot()</code></td>
-<td>Reboot the server</td>
+<td><code>template(pattern, data)</code></td>
+<td>Column-format template</td>
 </tr>
 </tbody>
 </table>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">exec: async (u: IUrsamuSDK) =&gt; {
-  // Access the actor
-  const actorName = String(u.me.state.name ?? u.me.id);
+<h3>u.auth</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>verify(name, password)</code></td>
+<td>Returns <code>boolean</code></td>
+</tr>
+<tr>
+<td><code>login(id)</code></td>
+<td>Connect player to session</td>
+</tr>
+<tr>
+<td><code>hash(password)</code></td>
+<td>bcrypt hash</td>
+</tr>
+<tr>
+<td><code>setPassword(id, password)</code></td>
+<td>Change password</td>
+</tr>
+</tbody>
+</table>
+<h3>u.sys</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>setConfig(key, value)</code></td>
+<td>Set runtime config</td>
+</tr>
+<tr>
+<td><code>disconnect(socketId)</code></td>
+<td>Kick a connection</td>
+</tr>
+<tr>
+<td><code>uptime()</code></td>
+<td>Milliseconds since start</td>
+</tr>
+<tr>
+<td><code>reboot()</code></td>
+<td>Exit 75 — daemon restarts</td>
+</tr>
+<tr>
+<td><code>shutdown()</code></td>
+<td>Exit 0 — clean stop</td>
+</tr>
+<tr>
+<td><code>update(branch?)</code></td>
+<td>git pull + reboot</td>
+</tr>
+<tr>
+<td><code>gameTime()</code></td>
+<td>Returns <code>IGameTime</code></td>
+</tr>
+<tr>
+<td><code>setGameTime(t)</code></td>
+<td>Set in-game calendar</td>
+</tr>
+</tbody>
+</table>
+<h3>u.chan</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>join(channel, alias)</code></td>
+<td>Join channel with alias</td>
+</tr>
+<tr>
+<td><code>leave(alias)</code></td>
+<td>Leave by alias</td>
+</tr>
+<tr>
+<td><code>list()</code></td>
+<td>List memberships</td>
+</tr>
+<tr>
+<td><code>create(name, opts?)</code></td>
+<td>Admin: create channel</td>
+</tr>
+<tr>
+<td><code>destroy(name)</code></td>
+<td>Admin: delete channel</td>
+</tr>
+<tr>
+<td><code>set(name, opts)</code></td>
+<td>Admin: update channel</td>
+</tr>
+<tr>
+<td><code>history(name, limit?)</code></td>
+<td>Recent messages (default 20)</td>
+</tr>
+</tbody>
+</table>
+<h3>u.bb</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>listBoards()</code></td>
+<td>All boards with unread counts</td>
+</tr>
+<tr>
+<td><code>listPosts(boardId)</code></td>
+<td>Posts on a board</td>
+</tr>
+<tr>
+<td><code>readPost(boardId, num)</code></td>
+<td>Read one post</td>
+</tr>
+<tr>
+<td><code>post(boardId, subj, body)</code></td>
+<td>Create a post</td>
+</tr>
+<tr>
+<td><code>editPost(boardId, num, body)</code></td>
+<td>Edit a post</td>
+</tr>
+<tr>
+<td><code>deletePost(boardId, num)</code></td>
+<td>Delete a post</td>
+</tr>
+<tr>
+<td><code>createBoard(name, opts?)</code></td>
+<td>Admin: create board</td>
+</tr>
+<tr>
+<td><code>destroyBoard(boardId)</code></td>
+<td>Admin: delete board</td>
+</tr>
+<tr>
+<td><code>markRead(boardId)</code></td>
+<td>Mark board as read</td>
+</tr>
+<tr>
+<td><code>newPostCount(boardId)</code></td>
+<td>Unread count for one board</td>
+</tr>
+<tr>
+<td><code>totalNewCount()</code></td>
+<td>Total unread across all boards</td>
+</tr>
+</tbody>
+</table>
+<h3>u.text</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>read(id)</code></td>
+<td>Read named text blob</td>
+</tr>
+<tr>
+<td><code>set(id, content)</code></td>
+<td>Write named text blob</td>
+</tr>
+</tbody>
+</table>
+<h3>u.attr</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>get(id, name)</code></td>
+<td>Read a soft-coded &amp;ATTR value. Returns <code>string | null</code>. Case-insensitive.</td>
+</tr>
+</tbody>
+</table>
+<h3>u.mail <em>(sandbox scripts only)</em></h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>send(mail)</code></td>
+<td>Send a message</td>
+</tr>
+<tr>
+<td><code>read(query)</code></td>
+<td>Query inbox</td>
+</tr>
+<tr>
+<td><code>delete(id)</code></td>
+<td>Delete by ID</td>
+</tr>
+<tr>
+<td><code>modify(query, op, update)</code></td>
+<td>Update (e.g. mark read)</td>
+</tr>
+</tbody>
+</table>
+<h3>u.events</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>emit(event, data, ctx?)</code></td>
+<td>Fire server-wide event</td>
+</tr>
+<tr>
+<td><code>on(event, handlerAttr)</code></td>
+<td>Subscribe &amp;ATTR handler</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>dbojs</h2>
+<p>Direct game-object database access (for plugins and startup code, not scripts).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { dbojs } from "jsr:@ursamu/mush";
 
-  // Access command arguments
-  const target = u.cmd.args[0]?.trim() ?? "";
-
-  // Check switches
-  const isVerbose = u.cmd.switches?.includes("verbose");
-
-  // Send output to the actor
-  u.send(`Hello, ${actorName}!`);
-};
+const players = await dbojs.queryAll((o) =&gt; o.flags.has("player"));
+const room    = await dbojs.queryOne((o) =&gt; o.id === "1");
+// queryOne returns IDBOBJ | undefined | false
 </code></pre>
-<h2>Flag API</h2>
-<h3>registerFlag(flag)</h3>
-<p>Registers a new flag.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>flag</code> (Object): The flag to register
-<ul>
-<li><code>name</code> (string): Name of the flag</li>
-<li><code>description</code> (string): Description of what the flag does</li>
-<li><code>default</code> (boolean): Default value for new objects</li>
-</ul>
-</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>void</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFlag } from "../../services/Flags/mod.ts";
+<hr>
+<h2>DBO&lt;T&gt;</h2>
+<p>Typed plugin-specific database collections backed by TypeGraph / Postgres (PGlite) or Deno KV.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { DBO } from "jsr:@ursamu/mush";
 
-registerFlag({
-  name: "vip",
-  description: "VIP player with special privileges",
-  default: false,
-});
+interface INote { id: string; playerId: string; text: string; date: number; }
+const notes = new DBO&lt;INote&gt;("myplugin.notes");
+
+await notes.create({ id: crypto.randomUUID(), playerId: u.me.id, text: "hi", date: Date.now() });
+const all  = await notes.find({ playerId: u.me.id });
+const one  = await notes.findOne({ id: noteId });
+await notes.update({ id: noteId }, { text: "updated" });
+await notes.delete({ id: noteId });
 </code></pre>
-<h3>hasFlag(object, flag)</h3>
-<p>Checks if an object has a flag.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>object</code> (Object): The object to check</li>
-<li><code>flag</code> (string): The flag to check for</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>boolean: True if the object has the flag, false otherwise</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { hasFlag } from "../../services/Flags/mod.ts";
+<hr>
+<h2>GameHooks</h2>
+<p>Typed event bus for the 12 built-in engine events.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
 
-if (hasFlag(player, "wizard")) {
-  // Player is a wizard
-}
+const handler = ({ actorId, actorName }: SessionEvent) =&gt; { /* ... */ };
+gameHooks.on("player:login", handler);
+gameHooks.off("player:login", handler);    // call in plugin remove()
 </code></pre>
-<h3>setFlag(object, flag, value)</h3>
-<p>Sets a flag on an object.</p>
-<p><strong>Parameters:</strong></p>
+<h3>Event catalog</h3>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Key payload fields</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>player:say</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>roomId</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>player:pose</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>roomId</code>, <code>content</code>, <code>isSemipose</code></td>
+</tr>
+<tr>
+<td><code>player:page</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>targetId</code>, <code>targetName</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>player:move</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>fromRoomId</code>, <code>toRoomId</code>, <code>fromRoomName</code>, <code>toRoomName</code>, <code>exitName</code></td>
+</tr>
+<tr>
+<td><code>player:login</code></td>
+<td><code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>player:logout</code></td>
+<td><code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>channel:message</code></td>
+<td><code>channelName</code>, <code>senderId</code>, <code>senderName</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>scene:created</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>sceneType</code></td>
+</tr>
+<tr>
+<td><code>scene:pose</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>msg</code>, <code>type</code></td>
+</tr>
+<tr>
+<td><code>scene:set</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>description</code></td>
+</tr>
+<tr>
+<td><code>scene:title</code></td>
+<td><code>sceneId</code>, <code>oldName</code>, <code>newName</code>, <code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>scene:clear</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>actorId</code>, <code>actorName</code>, <code>status</code></td>
+</tr>
+</tbody>
+</table>
+<p>Other hook buses (from specific plugins):</p>
 <ul>
-<li><code>object</code> (Object): The object to modify</li>
-<li><code>flag</code> (string): The flag to set</li>
-<li><code>value</code> (boolean): The value to set (true to add, false to remove)</li>
+<li><code>wikiHooks</code> — <code>wiki:created</code>, <code>wiki:edited</code>, <code>wiki:deleted</code></li>
+<li><code>eventHooks</code> — <code>event:created</code>, <code>event:updated</code>, <code>event:deleted</code>, <code>event:started</code>, <code>event:ended</code>, <code>event:rsvp</code>, <code>event:cancelled</code></li>
 </ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<object>: The updated object
+<hr>
+<h2>REST API</h2>
+<p>Authentication: <code>Authorization: Bearer &lt;jwt&gt;</code> header on all protected routes.</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Path</th>
+<th>Auth</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/login</code></td>
+<td>No</td>
+<td>Login — returns JWT</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/who</code></td>
+<td>Yes</td>
+<td>Online players</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/players/:id</code></td>
+<td>Yes</td>
+<td>Player info</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Yes</td>
+<td>Scene list</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Yes</td>
+<td>Open scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Yes</td>
+<td>Scene detail</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Yes</td>
+<td>Update scene</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/pose</code></td>
+<td>Yes</td>
+<td>Post to scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id/export</code></td>
+<td>Yes</td>
+<td>Export (<code>?format=markdown|json</code>)</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/mail</code></td>
+<td>Yes</td>
+<td>Inbox</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/mail</code></td>
+<td>Yes</td>
+<td>Send mail</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/mail/:id</code></td>
+<td>Yes</td>
+<td>Read message</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/mail/:id</code></td>
+<td>Yes</td>
+<td>Delete message</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Yes</td>
+<td>List / search wiki</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Yes</td>
+<td>Read wiki page</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Staff</td>
+<td>Create page</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Staff</td>
+<td>Update page</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Staff</td>
+<td>Delete page</td>
+</tr>
+<tr>
+<td><code>PUT</code></td>
+<td><code>/api/v1/wiki/:path.ext</code></td>
+<td>Staff</td>
+<td>Upload static asset</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>For AI Tools</h2>
+<p>For a single dense reference optimized for AI code generation, see:</p>
+<p><strong><a href="/ursamu/llms/"><code>/docs/llms.md</code></a></strong> — complete type signatures, all method signatures,<br>
+common patterns, and MUSH color codes in one flat document.</p>
 
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { setFlag } from "../../services/Flags/mod.ts";
-
-// Add the "vip" flag to a player
-await setFlag(player, "vip", true);
-
-// Remove the "vip" flag from a player
-await setFlag(player, "vip", false);
-</code></pre>
-<h2>Function API</h2>
-<h3>registerFunction(func)</h3>
-<p>Registers a new function for use in expressions.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>func</code> (Object): The function to register
-<ul>
-<li><code>name</code> (string): Name of the function</li>
-<li><code>description</code> (string): Description of what the function does</li>
-<li><code>args</code> (Array<string>): Array of argument names</string></li>
-<li><code>exec</code> (Function): Function to execute</li>
-</ul>
-</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>void</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFunction } from "../../services/Functions/mod.ts";
-
-registerFunction({
-  name: "add",
-  description: "Adds two numbers",
-  args: ["num1", "num2"],
-  exec: (args) =&gt; {
-    const [num1, num2] = args.map(Number);
-    return (num1 + num2).toString();
-  },
-});
-</code></pre>
-<h2>Hook API</h2>
-<h3>registerHook(hookName, callback)</h3>
-<p>Registers a hook to be called at a specific point in the system’s execution.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>hookName</code> (string): The name of the hook point</li>
-<li><code>callback</code> (Function): The function to call when the hook is triggered</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>void</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerHook } from "../../services/Hooks/mod.ts";
-
-registerHook("playerConnect", async (player) =&gt; {
-  console.log(`Player ${player.data.name} connected`);
-});
-</code></pre>
-<h3>registerHookPoint(hookName)</h3>
-<p>Registers a new hook point.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>hookName</code> (string): The name of the hook point to register</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>void</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerHookPoint } from "../../services/Hooks/mod.ts";
-
-registerHookPoint("myCustomHook");
-</code></pre>
-<h3>triggerHook(hookName, …args)</h3>
-<p>Triggers a hook, calling all registered callbacks.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>hookName</code> (string): The name of the hook point to trigger</li>
-<li><code>...args</code> (any): Arguments to pass to the hook callbacks</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<void></void></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { triggerHook } from "../../services/Hooks/mod.ts";
-
-await triggerHook("myCustomHook", { data: "some data" });
-</code></pre>
-<h2>Utility API</h2>
-<h3>parseFlags(flags)</h3>
-<p>Parses a flag string into an array of flags.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>flags</code> (string): The flag string to parse</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Array<string>: Array of parsed flags</string></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { parseFlags } from "../../utils/flags.ts";
-
-const flags = parseFlags("wizard builder connected");
-// Returns: ["wizard", "builder", "connected"]
-</code></pre>
-<h3>formatText(text, data)</h3>
-<p>Formats text with substitutions.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to format</li>
-<li><code>data</code> (Object): Data for substitutions</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>string: The formatted text</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { formatText } from "../../utils/text.ts";
-
-const formatted = formatText("Hello, %{name}!", { name: "World" });
-// Returns: "Hello, World!"
-</code></pre>
-<h3>parseArgs(input)</h3>
-<p>Parses command input into command, arguments, and switches.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>input</code> (string): The input to parse</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Object: The parsed input
-<ul>
-<li><code>cmd</code> (string): The command</li>
-<li><code>args</code> (string): The arguments</li>
-<li><code>switches</code> (Object): The switches</li>
-</ul>
-</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { parseArgs } from "../../utils/args.ts";
-
-const parsed = parseArgs("look/verbose at box");
-// Returns: { cmd: "look", args: "at box", switches: { verbose: true } }
-</code></pre>
-<h3>match(pattern, input)</h3>
-<p>Checks if input matches a command pattern.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>pattern</code> (string): The pattern to match against</li>
-<li><code>input</code> (string): The input to check</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>boolean: True if the input matches the pattern, false otherwise</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { match } from "../../utils/match.ts";
-
-const isMatch = match("look *", "look at box");
-// Returns: true
-</code></pre>
-<h3>evaluateExpression(expression, context)</h3>
-<p>Evaluates an expression.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>expression</code> (string): The expression to evaluate</li>
-<li><code>context</code> (Object): The context for evaluation</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<string>: The result of the evaluation</string></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { evaluateExpression } from "../../utils/expressions.ts";
-
-const result = await evaluateExpression("add(5, 3)", { player });
-// Returns: "8"
-</code></pre>
-<h3>sanitize(text)</h3>
-<p>Sanitizes text for safe display.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to sanitize</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>string: The sanitized text</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { sanitize } from "../../utils/text.ts";
-
-const safe = sanitize("&lt;script&gt;alert('XSS')&lt;/script&gt;");
-// Returns: "&amp;lt;script&amp;gt;alert('XSS')&amp;lt;/script&amp;gt;"
-</code></pre>
-<h3>colorize(text)</h3>
-<p>Converts color codes in text to ANSI color codes.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to colorize</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>string: The colorized text</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { colorize } from "../../utils/colors.ts";
-
-const colored = colorize("%chHello, %cgWorld!%cn");
-// Returns text with ANSI color codes
-</code></pre>
-<h3>stripColors(text)</h3>
-<p>Removes color codes from text.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to strip colors from</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>string: The text without color codes</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { stripColors } from "../../utils/colors.ts";
-
-const plain = stripColors("%chHello, %cgWorld!%cn");
-// Returns: "Hello, World!"
-</code></pre>
-<h3>generateId()</h3>
-<p>Generates a unique ID.</p>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>string: A unique ID</li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { generateId } from "../../utils/id.ts";
-
-const id = generateId();
-// Returns something like: "a1b2c3d4"
-</code></pre>
-<h3>hash(text)</h3>
-<p>Creates a hash of the given text.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to hash</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<string>: The hashed text</string></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { hash } from "../../utils/hash.ts";
-
-const hashed = await hash("password");
-// Returns a bcrypt hash
-</code></pre>
-<h3>compareHash(text, hash)</h3>
-<p>Compares text with a hash.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><code>text</code> (string): The text to compare</li>
-<li><code>hash</code> (string): The hash to compare against</li>
-</ul>
-<p><strong>Returns:</strong></p>
-<ul>
-<li>Promise<boolean>: True if the text matches the hash, false otherwise</boolean></li>
-</ul>
-<p><strong>Example:</strong></p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { compareHash } from "../../utils/hash.ts";
-
-const isMatch = await compareHash("password", hashedPassword);
-// Returns: true or false
-</code></pre>
-<p>This API reference covers the main functionality of UrsaMU. For more detailed<br>
-information on specific functions or classes, refer to the source code or the<br>
-relevant documentation sections.</p>
-
-      
+      </article>
 
       <!-- Prev / Next navigation -->
       
@@ -994,6 +1142,40 @@ relevant documentation sections.</p>
       
         
       
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
 
       
       <nav class="page-nav" aria-label="Page navigation">
@@ -1007,13 +1189,13 @@ relevant documentation sections.</p>
         
           <a href="/ursamu/api/core/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Core API Reference</span>
           </a>
         
       </nav>
       
 
-    
+    </main>
 
     <!-- FOOTER -->
     <footer class="site-footer">
@@ -1028,7 +1210,7 @@ relevant documentation sections.</p>
         <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
       </div>
     </footer>
-  
+  </div>
 
   <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
   <aside class="docs-toc" id="docsToc" aria-label="On this page">
@@ -1036,7 +1218,7 @@ relevant documentation sections.</p>
     <ul class="toc-list" id="tocList"></ul>
   </aside>
 
-<!-- /docs-layout -->
+</div><!-- /docs-layout -->
 
 
 <!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
@@ -1157,4 +1339,4 @@ relevant documentation sections.</p>
 
 
 
-</object></li></ul></object></li></ul></object></li></ul></object></li></ul></object></li></ul></article></main></div></div></body></html>
+</body></html>

--- a/docs/_site/api/rest/index.html
+++ b/docs/_site/api/rest/index.html
@@ -1,0 +1,853 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>REST API Reference | UrsaMU Documentation</title>
+  <meta name="description" content="Complete reference for UrsaMU's built-in HTTP endpoints — auth, players, channels, DB objects, scenes, config, and UI manifest.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/api/rest/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link active">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">REST API Reference</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>REST API Reference</h1>
+<p>The UrsaMU HTTP API runs on the same port as the WebSocket hub (default<br>
+<code>4203</code>). This document covers only the <strong>engine-built-in</strong> endpoints —<br>
+plugins (mail, jobs, bbs, help, wiki, builder, events) register their own<br>
+routes via <code>registerPluginRoute()</code> and document them in their own repos.</p>
+<p>Verified against <code>src/routes/</code> and <code>src/app.ts</code> for v2.6.0.</p>
+<h2>Contents</h2>
+<ul>
+<li><a href="#auth-model">Auth model</a></li>
+<li><a href="#error-responses">Error responses</a></li>
+<li><a href="#websocket-connection">WebSocket connection</a></li>
+<li><a href="#auth-router">Auth router</a> — <code>/api/v1/auth/*</code></li>
+<li><a href="#players--channels">Players &amp; channels</a> — <code>/api/v1/me</code>, <code>/api/v1/players/*</code>, <code>/api/v1/channels/*</code></li>
+<li><a href="#db-objects">DB Objects</a> — <code>/api/v1/dbos</code>, <code>/api/v1/dbobj/:id</code></li>
+<li><a href="#scenes">Scenes</a> — <code>/api/v1/scenes/*</code></li>
+<li><a href="#config--text">Config &amp; text</a> — <code>/api/v1/config</code>, <code>/api/v1/connect</code>, <code>/api/v1/welcome</code></li>
+<li><a href="#ui-manifest">UI manifest</a> — <code>/api/v1/ui-manifest</code></li>
+<li><a href="#avatars">Avatars</a> — <code>/avatars/:id</code></li>
+<li><a href="#health">Health</a> — <code>/health</code></li>
+<li><a href="#plugin-endpoints">Plugin endpoints</a></li>
+</ul>
+<hr>
+<h2>Auth model</h2>
+<p>All protected endpoints require a JWT in the <code>Authorization</code> header:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">Authorization: Bearer &lt;token&gt;
+</code></pre>
+<p>Obtain a token via <code>POST /api/v1/auth</code> or <code>POST /api/v1/auth/register</code>.<br>
+Tokens are signed with <code>JWT_SECRET</code> (set in <code>.env</code>). If <code>JWT_SECRET</code> is<br>
+unset in production the engine exits at boot. In dev a random per-process<br>
+secret is used and tokens are invalidated on every restart.</p>
+<p>A global API rate limit applies per IP (<code>apiRateLimits</code> map in<br>
+<code>src/app.ts</code>). Auth endpoints have an additional per-IP brute-force<br>
+guard.</p>
+<h2>Error responses</h2>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>400</td>
+<td>Bad request — missing or invalid body</td>
+</tr>
+<tr>
+<td>401</td>
+<td>Missing or invalid token</td>
+</tr>
+<tr>
+<td>403</td>
+<td>Valid token, insufficient permissions</td>
+</tr>
+<tr>
+<td>404</td>
+<td>Resource not found</td>
+</tr>
+<tr>
+<td>405</td>
+<td>Method not allowed</td>
+</tr>
+<tr>
+<td>429</td>
+<td>Rate limited (<code>Retry-After</code> header set)</td>
+</tr>
+<tr>
+<td>500</td>
+<td>Internal server error</td>
+</tr>
+</tbody>
+</table>
+<p>Error body shape:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "error": "Human-readable message" }
+</code></pre>
+<hr>
+<h2>WebSocket connection</h2>
+<p>The hub shares the HTTP port. Two connection modes:</p>
+<h3>JWT pre-auth (web clients)</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">ws://localhost:4203?token=&lt;jwt&gt;&amp;client=web
+</code></pre>
+<p>The player is authenticated immediately. On JWT reauth the engine<br>
+re-applies the <code>connected</code> flag and re-joins the player’s <code>#cid</code> and<br>
+<code>#location</code> rooms (v2.4.0 fix).</p>
+<h3>Classic connect (Telnet-style)</h3>
+<p>Connect without a token, then send <code>connect &lt;name&gt; &lt;password&gt;</code>.</p>
+<h3>Rate limiting</h3>
+<p>Each WebSocket is limited to <strong>10 commands/sec</strong>. Excess commands are<br>
+silently dropped (warning logged server-side).</p>
+<hr>
+<h2>Auth router</h2>
+<p>Defined in <code>src/routes/authRouter.ts</code>. All endpoints accept <code>POST</code> only.<br>
+Path is matched by suffix on <code>/api/v1/auth*</code>.</p>
+<h3>POST /api/v1/auth</h3>
+<p>Login. Returns a JWT.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "username": "Alice", "password": "hunter2" }
+</code></pre>
+<p>Response 200:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "token": "&lt;jwt&gt;", "id": "5", "name": "Alice" }
+</code></pre>
+<p>Errors: 401 invalid credentials, 429 rate-limited.</p>
+<h3>POST /api/v1/auth/register</h3>
+<p>Create a new character. Returns a JWT.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "username": "Alice", "email": "alice@example.com", "password": "hunter2" }
+</code></pre>
+<p>Response 201:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "token": "&lt;jwt&gt;", "id": "5", "name": "Alice" }
+</code></pre>
+<h3>POST /api/v1/auth/reset-password</h3>
+<p>Consume a one-time reset token and set a new password. Token comparison<br>
+is constant-time (v2.0.0 hardening). Expired tokens are cleaned up<br>
+opportunistically.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "token": "&lt;one-time-token&gt;", "newPassword": "newpw" }
+</code></pre>
+<p>Response 200:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "message": "Password updated successfully." }
+</code></pre>
+<hr>
+<h2>Players &amp; channels</h2>
+<p>Routed from <code>src/app.ts</code>; handlers in <code>src/routes/playersRouter.ts</code>.</p>
+<h3>GET /api/v1/me</h3>
+<p>Current player profile. Requires auth.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "id": "5",
+  "name": "Alice",
+  "flags": ["connected", "player"],
+  "data": { "description": "...", "avatar": "/avatars/5" }
+}
+</code></pre>
+<h3>GET /api/v1/players/online</h3>
+<p>List currently connected players. Requires auth.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "id": "5", "name": "Alice", "location": "The Lobby" },
+  { "id": "8", "name": "Bob",   "location": "The Library" }
+]
+</code></pre>
+<h3>GET /api/v1/channels</h3>
+<p>List all channels. No auth required.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "name": "Public", "header": "[Public]", "members": 4 }
+]
+</code></pre>
+<h3>GET /api/v1/channels/:name/history</h3>
+<p>Recent messages. Requires auth. Query param <code>?limit=N</code> (default 20, max<br>
+500).</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "sender": "Alice", "message": "Hi!", "timestamp": 1750536000000 }
+]
+</code></pre>
+<hr>
+<h2>DB Objects</h2>
+<p><code>src/routes/dbObjRouter.ts</code>. All endpoints require auth.</p>
+<h3>GET /api/v1/dbos</h3>
+<p>List accessible objects. Optional <code>?flags=room</code> filter.</p>
+<h3>GET /api/v1/dbobj/:id</h3>
+<p>Fetch a single object.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "id": "5",
+  "name": "Alice",
+  "location": "1",
+  "flags": ["connected", "player"],
+  "data": { "description": "..." },
+  "contents": []
+}
+</code></pre>
+<h3>PATCH /api/v1/dbobj/:id</h3>
+<p>Update object data, name, or description. Requires ownership or admin.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "data": { "description": "A tall figure in a green cloak." } }
+</code></pre>
+<blockquote>
+<p>The engine does not currently expose <code>PUT</code> / <code>DELETE</code> for <code>/dbobj/:id</code><br>
+or any <code>/attrs</code> sub-routes. Edit attributes via the <code>&amp;attr</code> command or<br>
+a custom plugin route.</p>
+</blockquote>
+<hr>
+<h2>Scenes</h2>
+<p><code>src/routes/sceneRouter.ts</code>. All endpoints require auth.</p>
+<h3>GET /api/v1/scenes</h3>
+<p>List active scenes the caller can see.</p>
+<h3>POST /api/v1/scenes</h3>
+<p>Create a scene.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "name": "The Heist", "type": "action", "roomId": "room-5" }
+</code></pre>
+<h3>GET /api/v1/scenes/locations</h3>
+<p>List rooms that currently host scenes.</p>
+<h3>GET /api/v1/scenes/:id</h3>
+<p>Fetch a scene with its pose log and participants.</p>
+<h3>PATCH /api/v1/scenes/:id</h3>
+<p>Update scene metadata (owner or admin; ownerless scenes are adopted by<br>
+the patcher — v2.0.0 fix).</p>
+<h3>POST /api/v1/scenes/:id/pose</h3>
+<p>Add a pose, OOC line, or scene-set.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "msg": "Alice steps through the door.", "type": "pose" }
+</code></pre>
+<p><code>type</code>: <code>"pose"</code> (default), <code>"ooc"</code>, <code>"set"</code>. When type is not <code>"set"</code>,<br>
+<code>msg</code> is required (400 otherwise).</p>
+<h3>PATCH /api/v1/scenes/:id/pose/:poseId</h3>
+<p>Edit an existing pose. Owner or admin.</p>
+<h3>POST /api/v1/scenes/:id/join</h3>
+<p>Join a scene.</p>
+<h3>POST /api/v1/scenes/:id/invite</h3>
+<p>Invite a player. Owner only.</p>
+<p>Body:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "playerId": "8" }
+</code></pre>
+<h3>GET /api/v1/scenes/:id/export</h3>
+<p>Export as Markdown or JSON. Query: <code>?format=markdown</code> (default) or<br>
+<code>?format=json</code>.</p>
+<hr>
+<h2>Config &amp; text</h2>
+<p><code>src/routes/config.ts</code>. No auth required.</p>
+<h3>GET /api/v1/config</h3>
+<p>Server config (name, version, ports, theme).</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "game":   { "name": "My Game", "version": "0.0.1" },
+  "server": { "http": 4203, "telnet": 4201 },
+  "theme":  { "primary": "#...", "backgroundImage": "..." }
+}
+</code></pre>
+<h3>GET /api/v1/connect</h3>
+<p>Connect-screen text (Markdown). Reads<br>
+<code>config.game.text.connect</code> (default <code>text/default_connect.txt</code>) with a<br>
+path-traversal guard.</p>
+<h3>GET /api/v1/welcome</h3>
+<p>Post-login welcome text (from the <code>texts</code> DBO, id <code>welcome</code>).</p>
+<h3>GET /api/v1/404</h3>
+<p>Site 404 page content (from <code>texts</code> DBO, id <code>404</code>). Falls back to a<br>
+default if no entry exists.</p>
+<hr>
+<h2>UI manifest</h2>
+<h3>GET /api/v1/ui-manifest</h3>
+<p>Returns the list of UI components registered by plugins via<br>
+<code>registerUIComponent()</code>. Optionally authenticated — if a JWT is<br>
+presented, results are filtered by the caller’s privileges<br>
+(<code>requires.flag</code>, etc.).</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "element": "myplugin-panel", "title": "My Panel", "url": "..." }
+]
+</code></pre>
+<p>External script URLs are rejected at registration time (v1.9.3<br>
+hardening).</p>
+<hr>
+<h2>Avatars</h2>
+<h3>GET /avatars/:id</h3>
+<p>Public avatar image. <code>:id</code> must match <code>^[a-zA-Z0-9_-]+$</code> — dots and<br>
+slashes are rejected. Looks for <code>data/avatars/&lt;id&gt;.{png,jpg,gif,webp}</code>.<br>
+Cached for 1 hour.</p>
+<hr>
+<h2>Health</h2>
+<h3>GET /health (or GET /)</h3>
+<p>Liveness probe. No auth.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "status": "ok", "engine": "UrsaMU" }
+</code></pre>
+<hr>
+<h2>Plugin endpoints</h2>
+<p>Plugins register routes via <code>registerPluginRoute(prefix, handler)</code>. The<br>
+engine matches by <code>startsWith(prefix)</code> and forwards the request along<br>
+with the authenticated <code>userId</code> (or <code>null</code>).</p>
+<p>Official plugins:</p>
+<table>
+<thead>
+<tr>
+<th>Plugin</th>
+<th>Base path</th>
+<th>Repo</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>jobs</td>
+<td><code>/api/v1/jobs</code></td>
+<td><a href="https://github.com/UrsaMU/jobs-plugin">UrsaMU/jobs-plugin</a></td>
+</tr>
+<tr>
+<td>events</td>
+<td><code>/api/v1/events</code></td>
+<td><a href="https://github.com/UrsaMU/events-plugin">UrsaMU/events-plugin</a></td>
+</tr>
+<tr>
+<td>bbs</td>
+<td><code>/api/v1/bbs</code></td>
+<td><a href="https://github.com/UrsaMU/bbs-plugin">UrsaMU/bbs-plugin</a></td>
+</tr>
+<tr>
+<td>mail</td>
+<td><code>/api/v1/mail</code></td>
+<td><a href="https://github.com/UrsaMU/mail-plugin">UrsaMU/mail-plugin</a></td>
+</tr>
+<tr>
+<td>help</td>
+<td><code>/api/v1/help</code></td>
+<td><a href="https://github.com/UrsaMU/help-plugin">UrsaMU/help-plugin</a></td>
+</tr>
+<tr>
+<td>wiki</td>
+<td><code>/api/v1/wiki</code></td>
+<td><a href="https://github.com/UrsaMU/wiki-plugin">UrsaMU/wiki-plugin</a></td>
+</tr>
+<tr>
+<td>builder</td>
+<td><code>/api/v1/building</code></td>
+<td><a href="https://github.com/UrsaMU/builder-plugin">UrsaMU/builder-plugin</a></td>
+</tr>
+</tbody>
+</table>
+<p>Custom plugins register their own routes — see<br>
+<a href="/ursamu/plugins/">Plugin Development</a>.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/api/core/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Core API Reference</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/child-games/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/audit-holes/index.html
+++ b/docs/_site/audit-holes/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html><head><meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/audit-holes/">
+<meta name="twitter:card" content="summary">
+</head><body><h1>UrsaMU — Known Holes &amp; Incomplete Implementations</h1>
+<h2>Audit of missing side effects, stub code, and incomplete features found via static analysis.<br>
+Items are ordered by severity within each category.</h2>
+<h2>HIGH — Player Experience Broken</h2>
+<h3>1. Teleport: no auto-look, no room broadcasts</h3>
+<p><strong>Files:</strong> <code>system/scripts/teleport.ts:49</code>, <code>system/scripts/home.ts:13</code>,<br>
+<code>src/services/Sandbox/SandboxService.ts:59-67</code></p>
+<p><code>u.teleport()</code> only updates the location in memory. It does not:</p>
+<ul>
+<li>Broadcast <code>"X has left."</code> to the source room</li>
+<li>Broadcast <code>"X has arrived."</code> to the destination room</li>
+<li>Trigger auto-look for the moved player</li>
+</ul>
+<h2><code>teleport.ts</code> even has a comment claiming “SandboxService handles the actual movements and look” — it doesn’t.<br>
+<code>home.ts</code> has the same gap.</h2>
+<h3>2. Disconnect broadcast targets everyone, with dummy room data</h3>
+<p><strong>File:</strong> <code>src/services/WebSocket/index.ts:132-139</code></p>
+<p>When a player disconnects the <code>close</code> event fires <code>this.broadcast()</code> (all connected clients, not just<br>
+the room) and the payload includes a hardcoded dummy room:</p>
+<pre class="language-ts" tabindex="0"><code class="language-ts">room: { name: "", desc: "", exits: [], players: [], items: [] } // dummy
+</code></pre>
+<h2>Should target only players in the disconnected player’s room and include real room state.</h2>
+<h3>3. Broadcast <code>exclude</code> parameter is silently ignored</h3>
+<p><strong>File:</strong> <code>src/services/broadcast/broadcast.ts</code></p>
+<h2><code>send()</code> accepts <code>_exclude: string[]</code> but never uses it. Commands like <code>get.ts</code> and <code>drop.ts</code><br>
+correctly pass <code>{ exclude: [actor.id] }</code> to avoid double-messaging the actor, but it has no effect —<br>
+the actor sees their own action twice (once from <code>u.send</code>, once from <code>u.broadcast</code>).</h2>
+<h3>4. Give command: money field path wrong, no room broadcast</h3>
+<p><strong>File:</strong> <code>system/scripts/give.ts:39-40</code></p>
+<h2>Money deduction/addition uses <code>"state.money"</code> but the actual DB field is under <code>data</code>. Transfers<br>
+may not persist. Also, room bystanders see nothing — only actor and target receive messages.</h2>
+<h2>MEDIUM — Incomplete Behaviour</h2>
+<h3>5. Movement: failed exit attempt may not reach other players</h3>
+<p><strong>File:</strong> <code>src/services/commands/movement.ts:67-68</code></p>
+<h2>Sends failed-movement messages to players via <code>#&lt;id&gt;</code> strings, but <code>send()</code> expects socket IDs.<br>
+Other players in the room may not receive <code>"X tries to go North, but fails."</code>.</h2>
+<h3>6. Scene invite: only owner can invite (hard-coded “for now”)</h3>
+<p><strong>File:</strong> <code>src/routes/sceneRouter.ts:358</code></p>
+<h2>Comment: <code>// Only owner or allowed can invite? Let's say Owner for now.</code><br>
+The allowed/co-owner list is never checked.</h2>
+<h3>7. DB object API: insufficient update validation</h3>
+<p><strong>File:</strong> <code>src/routes/dbObjRouter.ts:64-67</code></p>
+<h2>Comment acknowledges incomplete field validation:<br>
+<code>// Safe update fields? Allow updating 'data' and 'description' for now.</code><br>
+No permission enforcement on which fields callers may write. Flags and IDs could be overwritten<br>
+via the API.</h2>
+<h3>8. Lock evaluation: only supports exact string equality</h3>
+<p><strong>File:</strong> <code>src/utils/evaluateLock.ts:160</code></p>
+<h2>Comment: <code>// Simple equality for now.</code><br>
+Attribute locks only match exact strings. Comparison operators (<code>&gt;</code>, <code>&lt;</code>, <code>&gt;=</code>, <code>&lt;=</code>) are not<br>
+implemented, limiting attribute-based lock expressions.</h2>
+<h3>9. Open command: quota write may not persist</h3>
+<p><strong>File:</strong> <code>system/scripts/open.ts:78</code></p>
+<h2>Decrements quota in local state then writes <code>{ data: { ...actor.state } }</code>. If <code>actor.state</code><br>
+is stale the decrement may be lost. Should write only the changed field.</h2>
+<h3>10. Link command: dot-notation field paths in <code>db.modify</code></h3>
+<p><strong>File:</strong> <code>system/scripts/link.ts:44,48,58</code></p>
+<h2>Uses <code>{ "data.dropto": id }</code> style paths in <code>db.modify</code> calls. Whether the database layer<br>
+handles dot-notation is untested — it may silently store a literal key named <code>"data.dropto"</code>.</h2>
+<h2>LOW — Missing Polish / Design Gaps</h2>
+<h3>11. Map service: vertical/relative directions map to (0,0)</h3>
+<p><strong>File:</strong> <code>src/services/Map/index.ts:39</code></p>
+<h2><code>u</code>, <code>d</code>, <code>out</code>, <code>in</code> all map to <code>{ x:0, y:0 }</code>. Multi-level or z-axis maps render incorrectly.<br>
+Needs a z-axis or explicit skip.</h2>
+<h3>12. Doing command: status change is silent</h3>
+<p><strong>File:</strong> <code>system/scripts/doing.ts</code></p>
+<h2>Updates the doing message but does not notify the room. Whether bystanders should see<br>
+<code>"X is now: &lt;doing&gt;"</code> is a design question, but currently there is no option either way.</h2>
+<h3>13. Moniker command: change is silent</h3>
+<p><strong>File:</strong> <code>system/scripts/moniker.ts</code></p>
+<h2>Display name is updated without any room broadcast. Bystanders see the new name with no<br>
+transition message.</h2>
+<h3>14. Script service: legacy placeholder code</h3>
+<p><strong>File:</strong> <code>src/services/Script/index.ts:41-45</code></p>
+<h2>Contains comments like <code>"Simplified: Just evaluating code for now to prove connection."</code> —<br>
+appears to be unreachable/unused legacy code. Should be removed or completed.</h2>
+<h3>15. Pose command: scene search on every pose</h3>
+<p><strong>File:</strong> <code>system/scripts/pose.ts:34-37</code></p>
+<h2>Queries for active scenes matching the current room on every pose. No caching. Could be slow<br>
+in rooms with high pose frequency.</h2>
+<h2>Not a Bug — Confirmed Intentional</h2>
+<table>
+<thead>
+<tr>
+<th>Item</th>
+<th>Reason</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@quit</code> global disconnect</td>
+<td>Handled correctly via WS close event</td>
+</tr>
+<tr>
+<td>Movement auto-look</td>
+<td>Already calls <code>force(ctx, "look")</code> after a successful exit</td>
+</tr>
+<tr>
+<td>Connect auto-look</td>
+<td><code>u.execute("look")</code> at end of <code>connect.ts</code></td>
+</tr>
+<tr>
+<td>Channel talking</td>
+<td>Implemented in <code>channels.ts</code> via <code>matchChannel()</code></td>
+</tr>
+</tbody>
+</table>
+</body></html>

--- a/docs/_site/child-games/index.html
+++ b/docs/_site/child-games/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Learn how to create a child game using UrsaMU as a library">
+  <meta name="description" content="Scaffold and run a derived game project on top of UrsaMU">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -267,267 +267,101 @@
 
       <!-- Page content -->
       <article class="prose">
-        <h1>Creating Child Games with UrsaMU</h1>
-<p>This guide explains how to create a child game using UrsaMU as a library.</p>
-<h2>Overview</h2>
-<p>A “child game” is a complete MU* game built on top of the UrsaMU engine. Unlike plugins, which extend the functionality of UrsaMU, a child game is a standalone application that uses UrsaMU as a library.</p>
-<p>Creating a child game allows you to:</p>
-<ul>
-<li>Create a completely customized MU* experience</li>
-<li>Define your own game world, theme, and mechanics</li>
-<li>Distribute your game as a standalone application</li>
-<li>Maintain your game separately from the UrsaMU core</li>
-</ul>
-<h2>Getting Started</h2>
-<h3>Prerequisites</h3>
-<p>Before creating a child game, ensure you have:</p>
-<ul>
-<li><a href="https://deno.land/">Deno</a> installed (version 1.37.0 or higher)</li>
-<li>Basic knowledge of TypeScript</li>
-<li>Understanding of MU* concepts</li>
-</ul>
-<h3>Installation</h3>
-<ol>
-<li>Create a new directory for your game:</li>
-</ol>
-<pre class="language-bash" tabindex="0"><code class="language-bash">mkdir my-game
+        <h1>Child Games</h1>
+<p>A “child game” is a standalone project that uses <code>@ursamu/ursamu</code> as a<br>
+library — your own config, plugins, system-script overrides, and (usually)<br>
+your own deployment.</p>
+<h2>Scaffold</h2>
+<p>The CLI ships with a generator that lays down a complete supervised<br>
+project, including daemon scripts, telnet sidecar, and a <code>.env</code> with a<br>
+fresh JWT secret (v2.4.0):</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/create my-game
 cd my-game
 </code></pre>
-<ol start="2">
-<li>Initialize a new Deno project:</li>
-</ol>
-<pre class="language-bash" tabindex="0"><code class="language-bash">deno init
+<p>The scaffold writes:</p>
+<ul>
+<li><code>deno.json</code> with <code>start</code> / <code>dev</code> / <code>test</code> tasks and import map</li>
+<li><code>config/config.json</code> — ports + default portal plugins (site + web)</li>
+<li><code>system/scripts/</code> — engine script copies / overrides</li>
+<li><code>scripts/daemon.sh</code>, <code>stop.sh</code>, <code>restart.sh</code>, <code>status.sh</code></li>
+<li><code>.env</code> with a generated <code>JWT_SECRET</code></li>
+</ul>
+<p>A <code>--local</code> variant points the import map at a monorepo checkout<br>
+instead of JSR; tasks and config shape are otherwise the same.</p>
+<h2>Running the game</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">./daemon.sh    # start under supervisor (background)
+./status.sh    # show pid / uptime / health
+./restart.sh   # SIGUSR2 → no-disconnect main restart; telnet sidecar persists
+./stop.sh      # graceful shutdown
 </code></pre>
-<ol start="3">
-<li>Install UrsaMU as a dependency:</li>
-</ol>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Add UrsaMU as a dependency in your deps.ts file
+<p>Or run in the foreground:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task start   # initializes config, ensures superuser, spawns server + telnet
+deno task dev     # same, with hot reload
 </code></pre>
-<h2>Project Structure</h2>
-<p>A typical child game project structure looks like this:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">my-game/
-├── config/                  # Configuration files
-│   ├── config.json          # Main configuration
-│   ├── text/                # Text files
-│   └── plugins/             # Plugin configurations
-├── src/                     # Source code
-│   ├── commands/            # Custom commands
-│   ├── plugins/             # Custom plugins
-│   ├── types/               # TypeScript type definitions
-│   └── main.ts              # Entry point
-├── data/                    # Database files (generated)
-├── deps.ts                  # Dependencies
-├── deno.json                # Deno configuration
-└── README.md                # Documentation
-</code></pre>
+<p>In-game <code>@reboot</code> issues the same SIGUSR2 as <code>restart.sh</code>. JWTs are<br>
+re-authenticated automatically; the telnet sidecar stays connected across<br>
+restarts.</p>
 <h2>Configuration</h2>
-<h3>Basic Configuration</h3>
-<p>Create a <code>config/config.json</code> file with your game’s configuration:</p>
+<p><code>config/config.json</code> controls server ports, KV prefixes, game identity,<br>
+theme, and per-plugin scoped config. The shape:</p>
+<ul>
+<li><code>server</code> — telnet / ws / http ports plus KV prefixes (<code>db</code>, <code>channels</code>,<br>
+<code>mail</code>, <code>wiki</code>, <code>bboard</code>, <code>counters</code>)</li>
+<li><code>game</code> — <code>name</code>, <code>description</code>, <code>version</code>, <code>playerStart</code>, text paths,<br>
+<code>timeMultiplier</code></li>
+<li><code>theme</code> — color tokens, glass values, <code>backgroundImage</code></li>
+<li><code>plugins</code> — per-plugin scoped config</li>
+</ul>
+<p><code>.env</code> is loaded via <code>dotenv/load</code> at the top of the entry point. The only<br>
+required variable is <code>JWT_SECRET</code>. Rotate it by replacing the value and<br>
+restarting; existing tokens are invalidated.</p>
+<h2>Plugins</h2>
+<p>External plugins are declared in <code>plugins.manifest.json</code> and resolved on<br>
+startup by <code>ensurePlugins</code>. Each entry:</p>
 <pre class="language-json" tabindex="0"><code class="language-json">{
-  "server": {
-    "port": 4201,
-    "host": "0.0.0.0"
-  },
-  "game": {
-    "name": "My Game",
-    "motd": "Welcome to My Game!",
-    "debug": false
-  },
-  "database": {
-    "path": "./data"
-  }
+  "name": "@ursamu/help-plugin",
+  "url": "https://github.com/UrsaMU/help-plugin",
+  "ref": "v1.0.0",
+  "version": "^1.0.0"
 }
 </code></pre>
-<h3>Text Files</h3>
-<p>UrsaMU uses text files for various game messages. Create a <code>config/text</code> directory and add your custom text files:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">config/text/
-├── connect.txt       # Connection screen
-├── motd.txt          # Message of the day
-└── welcome.txt       # Welcome message for new players
+<p><code>ref</code> is optional (git ref / tag / branch); <code>version</code> is an optional semver<br>
+range checked against the cloned plugin’s manifest. As of v2.6.0 plugin<br>
+installs are fail-fast with atomic rollback — any clone, rename, semver, or<br>
+conflict error throws a typed <code>PluginInstallError</code> and leaves the<br>
+filesystem and registry untouched. Deps without a <code>version:</code> constraint<br>
+remain legacy-compatible.</p>
+<p>Install or update from the CLI:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/plugin install &lt;url&gt; [--ref &lt;ref&gt;]
+deno run -A jsr:@ursamu/cli@0.1.2/plugin update
+deno run -A jsr:@ursamu/cli@0.1.2/plugin list
 </code></pre>
-<h2>Customization</h2>
-<h3>Creating the Main File</h3>
-<p>Create a <code>src/main.ts</code> file as the entry point for your game:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { mu } from "ursamu";
-import { config } from "../config/mod.ts";
-
-// Import your custom plugins
-import myPlugin from "./plugins/myPlugin/mod.ts";
-
-// Start the game
-await mu({
-  config,
-  plugins: [
-    myPlugin,
-    // Add more custom plugins here
-  ]
-});
-
-console.log("Game started!");
+<h2>Local script overrides</h2>
+<p>The engine has no bundled <code>system/scripts/</code> — all native commands are<br>
+<code>addCmd</code> registrations in <code>src/commands/</code>. Child games may still place<br>
+sandbox scripts under their own <code>system/scripts/&lt;name&gt;.ts</code> to:</p>
+<ul>
+<li>Override a plugin-supplied or registered script (local file wins).</li>
+<li>Add new in-sandbox commands without writing a plugin.</li>
+</ul>
+<p>Scripts run in a Web Worker — no <code>Deno.*</code>, no <code>fetch</code>, no <code>import</code> other<br>
+than ESM-style <code>export default async (u) =&gt; { ... }</code>. See <code>CLAUDE.md</code><br>
+(“Softcode / system scripts”) for the sandbox contract.</p>
+<h2>Existing child games</h2>
+<p>The following projects use UrsaMU as their engine and can be read as<br>
+working references. Treat the layout as the canonical pattern; treat<br>
+project-specific mechanics as their own.</p>
+<ul>
+<li><code>legends</code> — the in-repo reference game (gitignored under <code>games/</code>)</li>
+<li><code>salem-rentals</code></li>
+<li><code>urban-shadows</code></li>
+</ul>
+<h2>Updating the engine</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/update         # latest stable
+deno run -A jsr:@ursamu/cli@0.1.2/update main    # specific branch
 </code></pre>
-<h3>Custom Commands</h3>
-<p>Create custom commands in the <code>src/commands</code> directory:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/commands/hello.ts
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "hello",
-  pattern: /^hello\s*(.*)/i,
-  lock: "connected",
-  exec: (u: IUrsamuSDK) =&gt; {
-    const target = u.cmd.args[0]?.trim() || "World";
-    u.send(`Hello, ${target}!`);
-  }
-});
-</code></pre>
-<h3>Custom Plugins</h3>
-<p>Create custom plugins in the <code>src/plugins</code> directory:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/myPlugin/mod.ts
-import { IPlugin } from "ursamu";
-
-const myPlugin: IPlugin = {
-  name: "my-plugin",
-  version: "1.0.0",
-  description: "A custom plugin for my game",
-  
-  init: async () =&gt; {
-    console.log("My plugin initialized!");
-    return true;
-  },
-  
-  remove: async () =&gt; {
-    console.log("My plugin removed!");
-  }
-};
-
-export default myPlugin;
-</code></pre>
-<h2>Deployment</h2>
-<h3>Running Your Game</h3>
-<p>Run your game with Deno:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">deno run --allow-net --allow-read --allow-write --allow-env src/main.ts
-</code></pre>
-<h3>Creating a Startup Script</h3>
-<p>Create a <code>start.sh</code> script for easier startup:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">#!/bin/bash
-deno run --allow-net --allow-read --allow-write --allow-env src/main.ts
-</code></pre>
-<p>Make it executable:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">chmod +x start.sh
-</code></pre>
-<h3>Docker Deployment</h3>
-<p>Create a <code>Dockerfile</code> for containerized deployment:</p>
-<pre class="language-dockerfile" tabindex="0"><code class="language-dockerfile">FROM denoland/deno:1.37.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN deno cache src/main.ts
-
-EXPOSE 4201
-
-CMD ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "--allow-env", "src/main.ts"]
-</code></pre>
-<p>Build and run the Docker container:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">docker build -t my-game .
-docker run -p 4201:4201 my-game
-</code></pre>
-<h2>Examples</h2>
-<h3>Basic Child Game</h3>
-<p>Here’s a complete example of a basic child game:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/main.ts
-import { mu } from "jsr:@ursamu/ursamu";
-import welcomePlugin from "./plugins/welcome/mod.ts";
-
-// Define configuration
-const config = {
-  server: {
-    telnet: 4201,
-    ws: 4202,
-    http: 4203,
-  },
-  game: {
-    name: "My First MU",
-    motd: "Welcome to My First MU!"
-  }
-};
-
-// Start the game
-await mu(config, [welcomePlugin]);
-
-console.log(`${config.game.name} is running`);
-
-// src/plugins/welcome/mod.ts
-import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IPlugin, IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-const welcomePlugin: IPlugin = {
-  name: "welcome",
-  version: "1.0.0",
-  description: "A welcome plugin for new players",
-
-  init: async () =&gt; {
-    // Register a welcome command
-    addCmd({
-      name: "welcome",
-      pattern: /^welcome\s*(.*)/i,
-      lock: "connected",
-      exec: (u: IUrsamuSDK) =&gt; {
-        const target = u.cmd.args[0]?.trim() || "friend";
-        u.send(`Welcome to our game, ${target}!`);
-      }
-    });
-
-    return true;
-  },
-
-  remove: async () =&gt; {
-    // Cleanup code here
-  }
-};
-
-export default welcomePlugin;
-</code></pre>
-<h3>Advanced Child Game</h3>
-<p>For a more advanced example, see the <a href="https://github.com/UrsaMU/examples">UrsaMU Examples repository</a> which contains complete child game examples with various features.</p>
-<h3>Customizing the Database</h3>
-<p>You can customize how your game uses the database:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/main.ts
-import { mu } from "../deps.ts";
-
-await mu({
-  config: {
-    // ... other config options
-    database: {
-      path: "./custom-data",
-      backupInterval: 3600000 // Backup every hour
-    }
-  }
-});
-</code></pre>
-<h3>Creating a Custom Theme</h3>
-<p>You can create a custom theme by overriding the default text files and adding custom CSS for the web interface:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/theme/mod.ts
-import { IPlugin } from "../../../deps.ts";
-
-const themePlugin: IPlugin = {
-  name: "custom-theme",
-  version: "1.0.0",
-  description: "Custom theme for my game",
-  
-  init: async () =&gt; {
-    // Register custom CSS
-    // Set up custom colors
-    // Override default text files
-    return true;
-  }
-};
-
-export default themePlugin;
-</code></pre>
-<p>By following this guide, you can create a fully customized MU* game using UrsaMU as a foundation, while maintaining the flexibility to extend and modify it to suit your specific needs.</p>
+<p>The updater rewrites the import map and re-runs <code>ensurePlugins</code>. Restart<br>
+the game after an update.</p>
 
       </article>
 
@@ -552,11 +386,47 @@ export default themePlugin;
       
         
           
+        
+      
+        
+          
           
         
       
         
           
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -605,9 +475,9 @@ export default themePlugin;
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/api/core/" class="page-nav-btn prev">
+          <a href="/ursamu/api/rest/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">REST API Reference</span>
           </a>
         
 

--- a/docs/_site/configuration/index.html
+++ b/docs/_site/configuration/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Configuration | UrsaMU Documentation</title>
-  <meta name="description" content="Learn how to configure UrsaMU for your needs">
+  <meta name="description" content="Configure UrsaMU — server ports, KV prefixes, game settings, theme, plugins, and the JWT_SECRET environment variable.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,247 +268,301 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Configuring UrsaMU</h1>
-<p>This guide explains how to configure UrsaMU for your specific needs.</p>
-<h2>Overview</h2>
-<p>UrsaMU uses a flexible configuration system that allows you to customize various<br>
-aspects of the game. The configuration is stored in JSON files and can be<br>
-accessed programmatically through the configuration API.</p>
-<h2>Configuration Files</h2>
-<p>The main configuration file is typically located at <code>config/config.json</code>. This<br>
-file contains settings for the server, game, database, and other components.</p>
-<p>Here’s an example of a basic configuration file:</p>
+<p>This page documents the v2.6.0 configuration surface — <code>config/config.json</code> and<br>
+the environment variables consumed at startup.</p>
+<h2>Files</h2>
+<ul>
+<li><code>config/config.json</code> — runtime configuration, validated at boot</li>
+<li><code>.env</code> — secrets (notably <code>JWT_SECRET</code>), loaded by <code>src/main.ts</code> via <code>dotenv/load</code></li>
+</ul>
+<p><code>ursamu create</code> scaffolds both with sensible defaults and a fresh <code>JWT_SECRET</code>.</p>
+<h2>Top-Level Shape</h2>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "server": { /* transport + KV prefixes */ },
+  "game":   { /* world metadata */ },
+  "theme":  { /* web client styling */ },
+  "plugins": { /* per-plugin scoped config */ }
+}
+</code></pre>
+<h2><code>server</code></h2>
+<p>Transport ports and Deno-KV collection prefixes.</p>
 <pre class="language-json" tabindex="0"><code class="language-json">{
   "server": {
     "telnet": 4201,
-    "ws": 4202,
-    "http": 4203,
-    "db": "data/ursamu.db",
+    "ws":     4202,
+    "http":   4203,
+    "db":       "data/ursamu.db",
     "counters": "counters",
-    "chans": "chans",
-    "mail": "mail",
-    "bboard": "bboard"
-  },
+    "chans":    "chans",
+    "mail":     "mail",
+    "wiki":     "wiki",
+    "bboard":   "bboard"
+  }
+}
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Type</th>
+<th>Default</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>telnet</code></td>
+<td>number</td>
+<td><code>4201</code></td>
+<td>Telnet sidecar port</td>
+</tr>
+<tr>
+<td><code>ws</code></td>
+<td>number</td>
+<td><code>4202</code></td>
+<td>Legacy standalone WebSocket port (the hub also accepts WS upgrades on <code>http</code>)</td>
+</tr>
+<tr>
+<td><code>http</code></td>
+<td>number</td>
+<td><code>4203</code></td>
+<td>Hub HTTP + REST + WebSocket port</td>
+</tr>
+<tr>
+<td><code>db</code></td>
+<td>string</td>
+<td><code>data/ursamu.db</code></td>
+<td>Fallback Deno KV database path (only used if fallback DenoKvAdapter is enabled)</td>
+</tr>
+<tr>
+<td><code>counters</code></td>
+<td>string</td>
+<td><code>counters</code></td>
+<td>KV prefix for ID counters</td>
+</tr>
+<tr>
+<td><code>chans</code></td>
+<td>string</td>
+<td><code>chans</code></td>
+<td>KV prefix for channels</td>
+</tr>
+<tr>
+<td><code>mail</code></td>
+<td>string</td>
+<td><code>mail</code></td>
+<td>KV prefix for player mail</td>
+</tr>
+<tr>
+<td><code>wiki</code></td>
+<td>string</td>
+<td><code>wiki</code></td>
+<td>KV prefix for wiki pages</td>
+</tr>
+<tr>
+<td><code>bboard</code></td>
+<td>string</td>
+<td><code>bboard</code></td>
+<td>KV prefix for bulletin boards</td>
+</tr>
+</tbody>
+</table>
+<h2><code>game</code></h2>
+<pre class="language-json" tabindex="0"><code class="language-json">{
   "game": {
-    "name": "UrsaMU",
-    "description": "A Modern MUSH-Like engine written in Typescript.",
-    "version": "0.0.1",
+    "name":            "My UrsaMU Game",
+    "description":     "A collaborative-fiction MUSH.",
+    "version":         "1.0.0",
+    "playerStart":     "1",
+    "timeMultiplier":  1,
     "text": {
-      "connect": "text/default_connect.txt"
-    },
-    "playerStart": "1"
-  }
-}
-</code></pre>
-<h2>Server Configuration</h2>
-<p>The <code>server</code> section of the configuration file contains settings related to the<br>
-server:</p>
-<pre class="language-json" tabindex="0"><code class="language-json">{
-  "server": {
-    "telnet": 4201,
-    "ws": 4202,
-    "http": 4203,
-    "db": "data/ursamu.db",
-    "counters": "counters",
-    "chans": "chans",
-    "mail": "mail",
-    "bboard": "bboard"
-  }
-}
-</code></pre>
-<h3>Server Options</h3>
-<ul>
-<li><code>telnet</code> (number): The port for the telnet server (default: 4201)</li>
-<li><code>ws</code> (number): The port for the WebSocket server (default: 4202)</li>
-<li><code>http</code> (number): The port for the HTTP server (default: 4203)</li>
-<li><code>db</code> (string): Path to the database file (default: “data/ursamu.db”)</li>
-<li><code>counters</code> (string): DB prefix for counters (default: “counters”)</li>
-<li><code>chans</code> (string): DB prefix for channels (default: “chans”)</li>
-<li><code>mail</code> (string): DB prefix for mail (default: “mail”)</li>
-<li><code>bboard</code> (string): DB prefix for bulletin boards (default: “bboard”)</li>
-</ul>
-<h2>Game Configuration</h2>
-<p>The <code>game</code> section contains settings related to the game itself:</p>
-<pre class="language-json" tabindex="0"><code class="language-json">{
-  "game": {
-    "name": "My UrsaMU Game",
-    "motd": "Welcome to My UrsaMU Game!",
-    "debug": false,
-    "startingRoom": "1",
-    "startingMoney": 100,
-    "maxPlayers": 100,
-    "idleTimeout": 3600
-  }
-}
-</code></pre>
-<h3>Game Options</h3>
-<ul>
-<li><code>name</code> (string): The name of the game (default: “UrsaMU”)</li>
-<li><code>motd</code> (string): Message of the day (default: “Welcome to UrsaMU!”)</li>
-<li><code>debug</code> (boolean): Whether to enable debug mode (default: false)</li>
-<li><code>startingRoom</code> (string): The ID of the starting room for new players (default:<br>
-“1”)</li>
-<li><code>startingMoney</code> (number): The amount of money new players start with<br>
-(default: 0)</li>
-<li><code>maxPlayers</code> (number): The maximum number of players allowed (default: 0,<br>
-unlimited)</li>
-<li><code>idleTimeout</code> (number): The number of seconds before a player is considered<br>
-idle (default: 3600)</li>
-</ul>
-<h2>Plugin Configuration</h2>
-<p>Plugins can have their own configuration sections in the main configuration<br>
-file:</p>
-<pre class="language-json" tabindex="0"><code class="language-json">{
-  "plugins": {
-    "my-plugin": {
-      "enabled": true,
-      "option1": "value1",
-      "option2": 42
+      "connect": "text/default_connect.txt",
+      "welcome": "text/welcome.txt",
+      "404":     "text/404.txt"
     }
   }
 }
 </code></pre>
-<h3>Accessing Plugin Configuration</h3>
-<p>Plugins can access their configuration using the <code>getConfig</code> function:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { getConfig } from "../../services/Config/mod.ts";
-
-// Get a plugin configuration value with a default fallback
-const option1 = getConfig("plugins.my-plugin.option1", "default");
-const option2 = getConfig("plugins.my-plugin.option2", 0);
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Type</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td>string</td>
+<td>Game name (shown in <code>who</code>, REST <code>/api/v1/config</code>)</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td>string</td>
+<td>Free-form description</td>
+</tr>
+<tr>
+<td><code>version</code></td>
+<td>string</td>
+<td>Reported via <code>@version</code></td>
+</tr>
+<tr>
+<td><code>playerStart</code></td>
+<td>string</td>
+<td>DBref of the starting room for new characters</td>
+</tr>
+<tr>
+<td><code>timeMultiplier</code></td>
+<td>number</td>
+<td>In-game-clock multiplier (<code>u.sys.gameTime()</code>)</td>
+</tr>
+<tr>
+<td><code>text.connect</code></td>
+<td>path</td>
+<td>Pre-auth banner</td>
+</tr>
+<tr>
+<td><code>text.welcome</code></td>
+<td>path</td>
+<td>Post-create welcome</td>
+</tr>
+<tr>
+<td><code>text.404</code></td>
+<td>path</td>
+<td>Static-route fallback</td>
+</tr>
+<tr>
+<td><code>layout.header</code></td>
+<td>mushcode</td>
+<td>Template for <code>header()</code> / <code>u.util.header</code></td>
+</tr>
+<tr>
+<td><code>layout.divider</code></td>
+<td>mushcode</td>
+<td>Template for <code>divider()</code> / <code>u.util.divider</code></td>
+</tr>
+<tr>
+<td><code>layout.footer</code></td>
+<td>mushcode</td>
+<td>Template for <code>footer()</code> / <code>u.util.footer</code></td>
+</tr>
+</tbody>
+</table>
+<h3><code>game.layout</code> — header / divider / footer mushcode</h3>
+<p>Override the engine layout helpers with TinyMUX-style templates. When set,<br>
+these apply to native <code>header()</code> / <code>divider()</code> / <code>footer()</code>, sandbox<br>
+<code>u.util.*</code>, and softcode <code>[header()]</code> / <code>[divider()]</code> / <code>[footer()]</code>.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "game": {
+    "layout": {
+      "header":  "[center(%ch%cy%0%cn,%1,%cg=%cn)]",
+      "divider": "[center(%ch%cy%0%cn,%1,%cg-%cn)]",
+      "footer":  "[repeat(%cg=%cn,%1)]"
+    }
+  }
+}
 </code></pre>
-<h2>Text Files</h2>
-<p>UrsaMU uses text files for various game messages. These files are typically<br>
-located in the <code>config/text</code> directory:</p>
-<ul>
-<li><code>connect.txt</code>: The connection screen shown to players when they connect</li>
-<li><code>motd.txt</code>: The message of the day shown to players when they connect</li>
-<li><code>welcome.txt</code>: The welcome message shown to new players</li>
-<li><code>help.txt</code>: The help text shown to players when they type “help”</li>
-</ul>
-<h3>Example Text File</h3>
-<p>Here’s an example of a <code>connect.txt</code> file:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">%ch%cy==================================%cn
-%ch%cw           My UrsaMU Game        %cn
-%ch%cy==================================%cn
-
-Welcome to My UrsaMU Game!
-
-Type 'connect &lt;name&gt; &lt;password&gt;' to connect.
-Type 'create &lt;name&gt; &lt;password&gt;' to create a new character.
-Type 'quit' to disconnect.
-
-%ch%cy==================================%cn
+<table>
+<thead>
+<tr>
+<th>Placeholder</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>%0</code></td>
+<td>Title / label</td>
+</tr>
+<tr>
+<td><code>%1</code></td>
+<td>Width (default <code>78</code>)</td>
+</tr>
+<tr>
+<td><code>%2</code></td>
+<td>Filler character(s)</td>
+</tr>
+</tbody>
+</table>
+<p>Supported bracket functions inside templates (sync subset):<br>
+<code>center</code>, <code>ljust</code>, <code>rjust</code>, <code>repeat</code>, <code>space</code>, <code>cat</code>, <code>lit</code>, <code>strlen</code>.<br>
+Color codes (<code>%ch</code>, <code>%cy</code>, …) and <code>%r</code> / <code>%t</code> / <code>%b</code> pass through.</p>
+<p>Plugin <code>registerHeader</code> / <code>registerDivider</code> / <code>registerFooter</code> still work<br>
+when no config template is set for that slot. A config template for a slot<br>
+takes priority over registered plugin layout functions.</p>
+<h2><code>theme</code></h2>
+<p>Theme tokens read by the bundled web client and <code>/api/v1/config</code>:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "theme": {
+    "primary":    "#7f5af0",
+    "secondary":  "#2cb67d",
+    "accent":     "#ff8906",
+    "background": "#16161a",
+    "surface":    "#242629",
+    "text":       "#fffffe",
+    "muted":      "#94a1b2",
+    "glass":      0.6,
+    "backgroundImage": "https://example.com/bg.jpg"
+  }
+}
 </code></pre>
-<h3>Color Codes</h3>
-<p>Text files can use color codes to add color to the text:</p>
-<ul>
-<li><code>%cn</code>: Reset to default color</li>
-<li><code>%ch</code>: Highlight (bold)</li>
-<li><code>%cr</code>: Red</li>
-<li><code>%cg</code>: Green</li>
-<li><code>%cy</code>: Yellow</li>
-<li><code>%cb</code>: Blue</li>
-<li><code>%cm</code>: Magenta</li>
-<li><code>%cc</code>: Cyan</li>
-<li><code>%cw</code>: White</li>
-</ul>
-<h2>Advanced Configuration</h2>
-<h3>Configuration API</h3>
-<p>UrsaMU provides a configuration API for accessing and modifying configuration<br>
-values programmatically:</p>
+<h2><code>plugins</code></h2>
+<p>Per-plugin scoped config. Plugins read their slice via<br>
+<code>PluginConfigManager</code> or <code>getConfig("plugins.&lt;name&gt;.&lt;key&gt;", default)</code>.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "plugins": {
+    "discord": { "enabled": true, "token": "...", "channelId": "..." },
+    "my-game": { "startingGold": 100 }
+  }
+}
+</code></pre>
+<p>Plugin manifests (<code>ursamu.plugin.json</code>) declare their dependencies — see<br>
+<a href="../plugins/">Plugin development</a> for the manifest format and atomic-install<br>
+behavior introduced in v2.6.0.</p>
+<h2>Environment Variables</h2>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Required</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>JWT_SECRET</code></td>
+<td>Yes</td>
+<td>HMAC secret for JWT signing. Loaded from <code>.env</code> by <code>src/main.ts</code>. If unset, JWT issuance fails — start scripts generate one automatically.</td>
+</tr>
+<tr>
+<td><code>URSAMU_TYPEGRAPH_DB</code></td>
+<td>No</td>
+<td>Database directory/file path for the primary TypeGraph/PGlite database. Defaults to <code>${Deno.cwd()}/data/typegraph.db</code> (or <code>memory://</code> during test runs).</td>
+</tr>
+</tbody>
+</table>
+<p><code>.env</code> is generated by <code>ursamu create</code> and excluded from git by the scaffold’s<br>
+<code>.gitignore</code>. Rotate by replacing the secret and restarting the hub; existing<br>
+sessions will be invalidated.</p>
+<h2>Runtime Configuration API</h2>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { getConfig, setConfig } from "../../services/Config/mod.ts";
 
-// Get a configuration value
-const port = getConfig("server.port", 4201);
+const port = getConfig&lt;number&gt;("server.http", 4203);
+await setConfig("game.name", "New Name");
+</code></pre>
+<p><code>u.sys.setConfig(key, value)</code> is the sandbox equivalent — restricted to<br>
+admin/wizard at the command layer.</p>
+<h2>Text Files</h2>
+<p>The paths in <code>game.text.*</code> resolve relative to the game project root. Files<br>
+support the full MUSH color-code set (<code>%ch</code>, <code>%cn</code>, <code>%cr</code>, <code>%cg</code>, <code>%cb</code>, <code>%cy</code>,<br>
+<code>%cw</code>, <code>%cc</code>, <code>%cm</code>, plus <code>%xRRGGBB</code> truecolor and <code>%r</code>/<code>%t</code>/<code>%b</code>).</p>
+<pre class="language-text" tabindex="0"><code class="language-text">%ch%cy==================================%cn
+%ch%cw           Welcome                 %cn
+%ch%cy==================================%cn
 
-// Set a configuration value
-await setConfig("server.port", 4202);
+Type 'connect &lt;name&gt; &lt;password&gt;' to log in.
+Type 'create &lt;name&gt; &lt;password&gt;' to make a new character.
 </code></pre>
-<h3>Environment Variables</h3>
-<p>UrsaMU supports environment variables for configuration. Environment variables<br>
-take precedence over values in the configuration file.</p>
-<p>Environment variables should be prefixed with <code>URSAMU_</code> and use underscores<br>
-instead of dots:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">URSAMU_SERVER_PORT=4202
-URSAMU_GAME_NAME="My UrsaMU Game"
-URSAMU_DATABASE_PATH="./custom-data"
-</code></pre>
-<h3>Configuration Hierarchy</h3>
-<p>UrsaMU uses the following hierarchy for configuration values (from highest to<br>
-lowest precedence):</p>
-<ol>
-<li>Environment variables</li>
-<li>Values set programmatically via <code>setConfig</code></li>
-<li>Values in the configuration file</li>
-<li>Default values</li>
-</ol>
-<h3>Custom Configuration Files</h3>
-<p>You can specify a custom configuration file when starting UrsaMU:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { mu } from "ursamu";
-import { config } from "./my-custom-config.ts";
-
-await mu({ config });
-</code></pre>
-<h3>Dynamic Configuration</h3>
-<p>Some configuration values can be changed at runtime:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { setConfig } from "../../services/Config/mod.ts";
-
-// Change the game name at runtime
-await setConfig("game.name", "New Game Name");
-</code></pre>
-<h3>Configuration Validation</h3>
-<p>UrsaMU validates configuration values to ensure they are of the correct type and<br>
-within acceptable ranges. If a configuration value is invalid, UrsaMU will log a<br>
-warning and use the default value instead.</p>
-<h3>Example: Complete Configuration</h3>
-<p>Here’s an example of a complete configuration file with all available options:</p>
-<pre class="language-json" tabindex="0"><code class="language-json">{
-  "server": {
-    "port": 4201,
-    "host": "0.0.0.0",
-    "webSocket": true,
-    "telnet": true,
-    "web": true,
-    "webPort": 4202,
-    "ssl": {
-      "enabled": false,
-      "key": "path/to/key.pem",
-      "cert": "path/to/cert.pem"
-    }
-  },
-  "game": {
-    "name": "My UrsaMU Game",
-    "motd": "Welcome to My UrsaMU Game!",
-    "debug": false,
-    "startingRoom": "1",
-    "startingMoney": 100,
-    "maxPlayers": 100,
-    "idleTimeout": 3600,
-    "registerEnabled": true,
-    "guestEnabled": true,
-    "guestPrefix": "Guest"
-  },
-  "database": {
-    "path": "./data",
-    "backupInterval": 3600000,
-    "maxBackups": 5
-  },
-  "plugins": {
-    "my-plugin": {
-      "enabled": true,
-      "option1": "value1",
-      "option2": 42
-    }
-  },
-  "logging": {
-    "level": "info",
-    "file": "logs/ursamu.log",
-    "maxSize": 10485760,
-    "maxFiles": 5
-  }
-}
-</code></pre>
-<p>By following this guide, you can configure UrsaMU to suit your specific needs<br>
-and create a customized MU* experience.</p>
 
       </article>
 
@@ -537,11 +591,47 @@ and create a customized MU* experience.</p>
       
         
           
+        
+      
+        
+          
           
         
       
         
           
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         

--- a/docs/_site/development/contributing/index.html
+++ b/docs/_site/development/contributing/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Learn how to contribute to the UrsaMU project">
+  <meta name="description" content="How to contribute to UrsaMU — branching, PRs, commits, and the pre-commit gauntlet.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,107 +268,98 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Contributing to UrsaMU</h1>
-<p>Thank you for your interest in contributing to UrsaMU! This guide will help you get started with contributing to the project.</p>
-<h2>Code of Conduct</h2>
-<p>UrsaMU has adopted a Code of Conduct that we expect project participants to adhere to. Please read <a href="./code-of-conduct.md">the full text</a> so that you can understand what actions will and will not be tolerated.</p>
-<h2>Getting Started</h2>
-<h3>Prerequisites</h3>
-<p>Before you begin, ensure you have the following installed:</p>
+<p>Thanks for your interest in contributing to UrsaMU. This page captures the<br>
+ground rules for v2.6.0.</p>
+<h2>Prerequisites</h2>
 <ul>
-<li><a href="https://deno.land/">Deno</a> (version 1.37.0 or higher)</li>
+<li><a href="https://deno.land/">Deno</a> 1.45+ (for <code>--unstable-kv</code>)</li>
 <li><a href="https://git-scm.com/">Git</a></li>
-<li>A code editor (we recommend <a href="https://code.visualstudio.com/">VS Code</a> with the Deno extension)</li>
+<li>An editor with the Deno extension (VS Code recommended)</li>
 </ul>
-<h3>Setting Up Your Development Environment</h3>
-<ol>
-<li>Fork the <a href="https://github.com/lcanady/ursamu">UrsaMU repository</a> on GitHub</li>
-<li>Clone your fork to your local machine:<pre class="language-bash" tabindex="0"><code class="language-bash">git clone https://github.com/YOUR_USERNAME/ursamu.git
+<h2>Initial Setup</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">git clone https://github.com/lcanady/ursamu.git
 cd ursamu
+deno task test   # confirm clean baseline
 </code></pre>
-</li>
-<li>Add the original repository as a remote:<pre class="language-bash" tabindex="0"><code class="language-bash">git remote add upstream https://github.com/lcanady/ursamu.git
+<p>If you plan to send PRs, fork on GitHub and add your fork as <code>origin</code>,<br>
+keeping <code>upstream</code> pointed at <code>lcanady/ursamu</code>.</p>
+<h2>Branching</h2>
+<p>Always work on a topic branch off <code>main</code>:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">git fetch upstream
+git checkout -b feature/short-description upstream/main
 </code></pre>
-</li>
-<li>Install dependencies:<pre class="language-bash" tabindex="0"><code class="language-bash">deno task setup
+<p>There is no long-lived <code>develop</code> branch — <code>main</code> is the release line.</p>
+<h2>Pre-Commit Gauntlet</h2>
+<p>Run these four steps in order before every commit. They mirror CI:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno check --unstable-kv mod.ts
+deno lint
+deno test tests/ --allow-all --unstable-kv --no-check
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
 </code></pre>
-</li>
-</ol>
-<h2>Development Process</h2>
-<h3>Branching Strategy</h3>
+<p>A commit isn’t ready until all four pass.</p>
+<h2>Docs Stay in Sync</h2>
+<p>If you touch a public API, command, config key, script, scaffold output, or<br>
+plugin surface — update <code>README.md</code> and the relevant page under <code>docs/</code> in the<br>
+same commit. Stale docs ship as broken docs.</p>
+<h2>Commits</h2>
 <ul>
-<li><code>main</code> - The main development branch</li>
-<li><code>release/*</code> - Release branches</li>
-<li><code>feature/*</code> - Feature branches</li>
-<li><code>bugfix/*</code> - Bug fix branches</li>
+<li>Write descriptive, present-tense subject lines: <code>feat:</code>, <code>fix:</code>, <code>docs:</code>, <code>chore:</code>, <code>refactor:</code>, <code>test:</code>.</li>
+<li>One logical change per commit.</li>
+<li><strong>No AI/Claude attribution.</strong> Do not add <code>Co-Authored-By: Claude …</code>, do not<br>
+reference AI tools in commit messages, PR descriptions, or code comments.</li>
+<li>Never amend a commit that failed a pre-commit hook — fix and create a new<br>
+commit instead.</li>
 </ul>
-<p>Always create a new branch for your changes:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">git checkout -b feature/your-feature-name
-</code></pre>
-<h3>Development Workflow</h3>
-<ol>
-<li>Make sure your branch is up to date with the latest changes:<pre class="language-bash" tabindex="0"><code class="language-bash">git fetch upstream
-git rebase upstream/main
-</code></pre>
-</li>
-<li>Make your changes</li>
-<li>Run tests to ensure your changes don’t break anything:<pre class="language-bash" tabindex="0"><code class="language-bash">deno task test
-</code></pre>
-</li>
-<li>Commit your changes with a descriptive commit message:<pre class="language-bash" tabindex="0"><code class="language-bash">git commit -m "Add feature: your feature description"
-</code></pre>
-</li>
-<li>Push your changes to your fork:<pre class="language-bash" tabindex="0"><code class="language-bash">git push origin feature/your-feature-name
-</code></pre>
-</li>
-</ol>
 <h2>Pull Requests</h2>
-<p>When you’re ready to submit your changes, create a pull request:</p>
 <ol>
-<li>Go to your fork on GitHub</li>
-<li>Select your branch</li>
-<li>Click “Pull Request”</li>
-<li>Fill out the pull request template with details about your changes</li>
-<li>Submit the pull request</li>
+<li>Push your branch to your fork.</li>
+<li>Open a PR against <code>lcanady/ursamu:main</code>.</li>
+<li>Keep PRs scoped — one feature or fix per PR.</li>
+<li>Fill in the description: what changed, why, and how it was tested.</li>
+<li>Make sure CI is green.</li>
 </ol>
-<h3>Pull Request Guidelines</h3>
-<ul>
-<li>Keep pull requests focused on a single feature or bug fix</li>
-<li>Make sure all tests pass</li>
-<li>Update documentation as needed</li>
-<li>Follow the coding standards</li>
-<li>Be responsive to feedback and questions</li>
-</ul>
-<h2>Coding Standards</h2>
-<p>UrsaMU follows a set of coding standards to maintain consistency across the codebase:</p>
-<ul>
-<li>Use TypeScript for all code</li>
-<li>Follow the <a href="https://deno.land/manual/contributing/style_guide">Deno Style Guide</a></li>
-<li>Use meaningful variable and function names</li>
-<li>Write comments for complex logic</li>
-<li>Include JSDoc comments for public APIs</li>
-<li>Write tests for new features and bug fixes</li>
-</ul>
-<h2>Documentation</h2>
-<p>Documentation is a crucial part of UrsaMU. When contributing, please:</p>
-<ul>
-<li>Update the documentation for any changes to APIs or features</li>
-<li>Use clear, concise language</li>
-<li>Include examples where appropriate</li>
-<li>Follow the <a href="./documentation-guidelines.md">documentation guidelines</a></li>
-</ul>
-<h3>Building Documentation</h3>
-<p>To build and preview the documentation locally:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">deno task docs
+<p>PRs are <strong>squash-merged</strong>. After merge, maintainers tag the release:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">git tag v&lt;version&gt;
+git push --tags
 </code></pre>
-<p>This will start a local server where you can preview the documentation.</p>
-<h2>Getting Help</h2>
-<p>If you need help with contributing to UrsaMU, you can:</p>
+<p>No AI attribution in PR titles or bodies either.</p>
+<h2>Coding Standards</h2>
 <ul>
-<li>Join the <a href="#">UrsaMU Discord server</a></li>
-<li>Open an issue on GitHub</li>
-<li>Reach out to the maintainers</li>
+<li>TypeScript only. Follow the<br>
+<a href="https://docs.deno.com/runtime/contributing/style_guide/">Deno style guide</a>.</li>
+<li>Early return over nested conditionals.</li>
+<li>No function longer than ~50 lines; no file longer than ~200 lines — decompose.</li>
+<li><code>catch (e: unknown)</code> — never bare <code>catch</code>.</li>
+<li>Library-first: if the SDK does it, use the SDK.</li>
+<li>No comments unless the <em>why</em> is non-obvious (hidden invariant, bug workaround).</li>
 </ul>
-<p>Thank you for contributing to UrsaMU! Your efforts help make the project better for everyone.</p>
+<h2>Testing</h2>
+<ul>
+<li>All new commands need tests in <code>tests/</code>.</li>
+<li>See <a href="/ursamu/development/testing/">Testing</a> for <code>mockPlayer</code> / <code>mockU</code> helpers and DB<br>
+cleanup conventions.</li>
+</ul>
+<h2>Plugin Audit Checklist</h2>
+<p>Mental pass before opening a PR that touches plugins or core commands:</p>
+<ul>
+<li><code>u.util.stripSubs()</code> on user strings before DB ops or length checks</li>
+<li><code>await u.canEdit(u.me, target)</code> before modifying any object not owned by <code>u.me</code></li>
+<li>DB writes use <code>"$set"</code> / <code>"$inc"</code> / <code>"$unset"</code> / <code>"$push"</code> — never raw overwrite</li>
+<li><code>u.util.target()</code> result null-checked</li>
+<li>Admin-only paths gate on <code>u.me.flags</code> explicitly</li>
+<li><code>system/scripts/</code> files use no Deno APIs, no <code>fetch</code>, no non-<code>u</code> globals</li>
+<li>All <code>%c*</code> color codes closed with <code>%cn</code></li>
+<li><code>gameHooks.on()</code> in <code>init()</code> paired with <code>gameHooks.off()</code> in <code>remove()</code> (same named ref)</li>
+<li>DBO collection names prefixed with <code>&lt;pluginName&gt;.</code></li>
+<li>REST handlers return 401 before any work when <code>userId</code> is null</li>
+<li><code>init()</code> returns <code>true</code></li>
+</ul>
+<h2>Getting Help</h2>
+<ul>
+<li>File an issue on GitHub</li>
+<li>Join the Discord linked from the project README</li>
+<li>Reach out to maintainers in the PR thread</li>
+</ul>
 
       </article>
 
@@ -405,11 +396,47 @@ git rebase upstream/main
       
         
           
+        
+      
+        
+          
           
         
       
         
           
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -459,9 +486,9 @@ git rebase upstream/main
         
 
         
-          <a href="/ursamu/extending/" class="page-nav-btn next">
+          <a href="/ursamu/development/testing/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Testing</span>
           </a>
         
       </nav>

--- a/docs/_site/development/index.html
+++ b/docs/_site/development/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Contribute to the UrsaMU project and help make it better">
+  <meta name="description" content="Contribute to UrsaMU — pre-commit gauntlet, repo layout, and the contributor workflow for v2.6.0.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,50 +268,109 @@
       <!-- Page content -->
       <article class="prose">
         <h1>UrsaMU Development</h1>
-<p>This section covers how to contribute to the UrsaMU project, whether you’re fixing bugs, adding features, or improving documentation.</p>
-<h2>Getting Started</h2>
-<p>Everything you need to start contributing to UrsaMU:</p>
+<p>This section covers how to contribute to UrsaMU — fixing bugs, adding commands,<br>
+shipping plugins, or improving the docs. UrsaMU is v2.6.0; the test suite is<br>
+1464 passing across 480 lint-clean files.</p>
+<h2>Pre-Commit Gauntlet</h2>
+<p>Every commit must pass these four steps in order — they mirror the CI workflow<br>
+in <code>.github/workflows/ci.yml</code>:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno check --unstable-kv mod.ts                                       # type check
+deno lint                                                              # lint
+deno test tests/ --allow-all --unstable-kv --no-check                  # unit tests
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check # security
+</code></pre>
+<p>If any step fails, the commit is not ready. CI will reject it.</p>
+<h2>Day-to-Day Commands</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task test          # full suite — must stay green
+deno task test:coverage # LCOV at coverage/lcov.info
+deno task start         # run the hub + telnet sidecar
+deno task dev           # dev mode with auto-restart
+deno lint               # must be clean across all 480 files
+</code></pre>
+<h2>Repo Layout</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">packages/
+  core/              @ursamu/core — transport, DB, plugin loader, event bus
+  mush/              @ursamu/mush — MUSH world layer (IDBObj, flags, locks, softcode, addCmd)
+src/
+  @types/            TypeScript interfaces (IDBObj, IUrsamuSDK, ICmd, IPlugin, …)
+  commands/          Native addCmd registrations (Deno context, full APIs)
+  plugins/&lt;name&gt;/    Bundled plugins — index.ts + commands.ts + help/ + README.md
+  routes/            Express REST routers (auth, dbObj, scenes, players, config)
+  services/          Core engine (Database, Sandbox, GameClock, Hooks, JWT, …)
+  utils/             Shared helpers (flags, target, locks, formatHandlers, …)
+system/
+  scripts/           Sandbox scripts — one file per command (no Deno APIs)
+  help/              In-game help text
+tests/               Deno test files — always place new tests here
+docs/                Lume static site
+config/              Runtime configuration (config.json, text/)
+</code></pre>
+<h2>Packages</h2>
+<p>The engine is organized as a monorepo with two published packages:</p>
 <ul>
-<li><a href="./environment.md">Development Environment</a> - Set up your development environment</li>
-<li><a href="./structure.md">Project Structure</a> - Understand the UrsaMU codebase</li>
-<li><a href="./building.md">Building from Source</a> - How to build UrsaMU from source</li>
-<li><a href="./testing.md">Running Tests</a> - How to run the UrsaMU test suite</li>
+<li><strong><code>@ursamu/core</code></strong> (<code>packages/core/</code>) — generic server infrastructure: transport<br>
+abstraction, database layer (TypeGraph/PGlite and Deno KV adapters), plugin lifecycle, and the event bus. Has no<br>
+MUSH-specific concepts and can be reused for other game types.</li>
+<li><strong><code>@ursamu/mush</code></strong> (<code>packages/mush/</code>) — the MUSH world layer built on top of core:<br>
+<code>IDBObj</code>, flag system, lock evaluation, TinyMUX softcode engine, <code>addCmd</code>, and the<br>
+full <code>IUrsamuSDK</code>. This is what plugins and game scripts import.</li>
+<li><strong><code>@ursamu/ursamu</code></strong> — a backwards-compat shim that re-exports everything from<br>
+<code>@ursamu/mush</code>. Existing plugins importing <code>jsr:@ursamu/mush</code> continue to work.<br>
+New projects should prefer <code>jsr:@ursamu/mush</code>.</li>
 </ul>
-<h2>Development Workflow</h2>
-<p>The UrsaMU development process:</p>
+<p>Package tests live alongside their source:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">packages/core/tests/      core infrastructure tests (including security/)
+packages/mush/tests/      MUSH engine tests
+</code></pre>
+<h2>Where Changes Go</h2>
+<table>
+<thead>
+<tr>
+<th>Adding</th>
+<th>Location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A new core command</td>
+<td><code>src/commands/&lt;name&gt;.ts</code>, registered via <code>addCmd</code></td>
+</tr>
+<tr>
+<td>A plugin command</td>
+<td><code>src/plugins/&lt;plugin&gt;/commands.ts</code>, imported by <code>index.ts</code></td>
+</tr>
+<tr>
+<td>A REST endpoint</td>
+<td><code>src/routes/</code> (core) or <code>registerPluginRoute</code> (plugin)</td>
+</tr>
+<tr>
+<td>A sandbox script</td>
+<td><code>system/scripts/&lt;name&gt;.ts</code>, ESM <code>export default</code></td>
+</tr>
+<tr>
+<td>A new hook event</td>
+<td>Extend <code>GameHookMap</code> via declaration merging</td>
+</tr>
+<tr>
+<td>A custom lockfunc</td>
+<td><code>registerLockFunc(name, fn)</code> in plugin <code>init()</code></td>
+</tr>
+<tr>
+<td>A format slot</td>
+<td><code>registerFormatHandler</code> (TS) or <code>registerFormatTemplate</code> (softcode)</td>
+</tr>
+</tbody>
+</table>
+<h2>Sub-Pages</h2>
 <ul>
-<li><a href="/ursamu/development/contributing/">Contributing Guide</a> - How to contribute to UrsaMU</li>
-<li><a href="./issues.md">Issue Tracking</a> - How we track issues and feature requests</li>
-<li><a href="./pull-requests.md">Pull Requests</a> - How to submit changes to UrsaMU</li>
-<li><a href="./code-review.md">Code Review</a> - Our code review process</li>
+<li><a href="/ursamu/development/testing/">Testing</a> — mock SDK, sandbox stubs, DB cleanup, CI integration</li>
+<li><a href="/ursamu/development/contributing/">Contributing</a> — branching, PRs, commit conventions</li>
 </ul>
-<h2>Code Standards</h2>
-<p>Our coding standards and best practices:</p>
+<h2>Reference</h2>
 <ul>
-<li><a href="./style.md">Coding Style</a> - UrsaMU coding style guidelines</li>
-<li><a href="./typescript.md">TypeScript Guidelines</a> - TypeScript-specific guidelines</li>
-<li><a href="./testing-guidelines.md">Testing Guidelines</a> - How to write tests for UrsaMU</li>
-<li><a href="./documentation-guidelines.md">Documentation Guidelines</a> - How to document your code</li>
-</ul>
-<h2>Documentation</h2>
-<p>How to contribute to UrsaMU documentation:</p>
-<ul>
-<li><a href="./docs-structure.md">Documentation Structure</a> - How the documentation is organized</li>
-<li><a href="./writing-docs.md">Writing Documentation</a> - How to write clear and helpful documentation</li>
-<li><a href="./api-docs.md">API Documentation</a> - How to document APIs</li>
-<li><a href="./building-docs.md">Building Documentation</a> - How to build and test documentation locally</li>
-</ul>
-<h2>Architecture</h2>
-<ul>
-<li><a href="./architecture.md">System Architecture</a></li>
-<li><a href="./database-schema.md">Database Schema</a></li>
-<li><a href="./command-system.md">Command System</a></li>
-</ul>
-<h2>Advanced Topics</h2>
-<ul>
-<li><a href="./performance.md">Performance Optimization</a></li>
-<li><a href="./security.md">Security Considerations</a></li>
-<li><a href="./testing.md">Testing</a></li>
+<li>Authoritative API surface: <code>src/@types/UrsamuSDK.ts</code> and<br>
+<a href="/ursamu/llms/"><code>docs/llms.md</code></a></li>
+<li>Project conventions: <code>CLAUDE.md</code> at the repo root</li>
 </ul>
 
       </article>
@@ -345,11 +404,47 @@
       
         
           
+        
+      
+        
+          
           
         
       
         
           
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         

--- a/docs/_site/development/testing/index.html
+++ b/docs/_site/development/testing/index.html
@@ -1,0 +1,800 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Testing | UrsaMU Documentation</title>
+  <meta name="description" content="How to run the UrsaMU test suite and write tests for commands, scripts, and plugins.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/development/testing/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link active">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Testing</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Testing</h1>
+<h2>UrsaMU uses <a href="https://docs.deno.com/runtime/fundamentals/testing/">Deno’s built-in test runner</a>.<br>
+The v2.6.0 suite is <strong>1464 passing, 0 failing</strong> across 480 lint-clean files —<br>
+covering authentication, command parsing, sandbox scripting, softcode evaluation,<br>
+plugin lifecycle, WebSocket rate limiting, scene export, format handlers,<br>
+plugin install atomicity, and security regression tests.</h2>
+<h2>Running Tests</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Full test suite
+deno task test
+
+# With LCOV coverage report
+deno task test:coverage
+
+# Single file
+deno test --allow-all --unstable-kv --no-check tests/auth.test.ts
+
+# Filter by test name
+deno test --allow-all --unstable-kv --no-check --filter "auth login"
+</code></pre>
+<blockquote>
+<p>Always use <code>--no-check</code> — the suite is large and type-checking adds significant overhead<br>
+with no benefit for test runs.</p>
+</blockquote>
+<h3>Running package tests</h3>
+<p>The monorepo packages each have their own test directories. Run them directly<br>
+to isolate failures to a specific layer:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># core infrastructure tests (includes 12 security tests)
+deno test packages/core/tests/ --allow-all --unstable-kv --no-check
+
+# MUSH engine tests
+deno test packages/mush/tests/ --allow-all --unstable-kv --no-check
+
+# both together
+deno test packages/core/tests/ packages/mush/tests/ --allow-all --unstable-kv --no-check
+</code></pre>
+<h3>Checking package boundaries</h3>
+<p>The <code>tools/check-boundaries.ts</code> script verifies that <code>@ursamu/core</code> does not<br>
+import from <code>@ursamu/mush</code> (enforcing the one-way dependency):</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A tools/check-boundaries.ts
+</code></pre>
+<p>Run this before committing changes that touch <code>packages/</code>.</p>
+<hr>
+<h2>Test Structure</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">tests/
+├── auth.test.ts               # JWT auth, login, rate limiting
+├── gameclock.test.ts          # In-game calendar &amp; time
+├── plugin_deps.test.ts        # Plugin loading &amp; manifest
+├── queue_scene_discord.test.ts# Async queue, scenes, Discord hooks
+├── scripts_attrs.test.ts      # @set, @examine, @describe, @flags, @name
+├── scripts_comms.test.ts      # say, pose, who, score
+├── scripts_identity.test.ts   # connect, create, quit
+├── scripts_interaction.test.ts# drop, give, get, trigger
+├── scripts_world.test.ts      # look, dig, go (exit matching)
+├── websocket_e2e.test.ts      # Lifecycle, rate limit, broadcast, disconnect
+└── …
+</code></pre>
+<hr>
+<h2>Required Test Options</h2>
+<p>When a test imports anything from the service layer (e.g. <code>cmdParser</code>, <code>DBO</code>, <code>sandboxService</code>),<br>
+use these options to suppress Deno’s resource-leak and pending-op warnings:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const OPTS = {
+  sanitizeResources: false,
+  sanitizeOps: false,
+};
+
+Deno.test({ name: "my test", ...OPTS, fn: async () =&gt; { … } });
+</code></pre>
+<p><code>cmdParser</code> triggers async file reads at init and never fully closes them, which would<br>
+otherwise cause every test that imports it to fail sanitization.</p>
+<hr>
+<h2>Testing System Scripts</h2>
+<p>System scripts (<code>system/scripts/*.ts</code>) are TypeScript files that default-export an<br>
+async function <code>(u: IUrsamuSDK) =&gt; void</code>. They can be tested directly by importing<br>
+them and calling them with a mock SDK object.</p>
+<h3>Basic pattern</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import script from "../system/scripts/say.ts";
+
+Deno.test({ name: "say", ...OPTS, fn: async () =&gt; {
+  let sent = "";
+  let broadcast = "";
+
+  const u = {
+    me: { id: "p1", name: "Alice", flags: new Set(["connected"]), state: {}, contents: [] },
+    cmd: { args: ["Hello world"], switches: [] },
+    send: (msg: string) =&gt; { sent += msg; },
+    emit: (msg: string) =&gt; { broadcast += msg; },
+    // … add other stubs as needed
+  } as any;
+
+  await script(u);
+
+  if (!sent.includes("You say")) throw new Error("Missing 'You say' echo");
+  if (!broadcast.includes("Alice says")) throw new Error("Missing broadcast");
+}});
+</code></pre>
+<h3>wrapScript — running scripts as legacy blocks</h3>
+<p>When a script needs access to the full Sandbox (e.g. scripts that call <code>u.db.*</code><br>
+or <code>u.ui.layout()</code>), use <code>wrapScript</code> to strip the <code>import</code>/<code>export</code> declarations<br>
+and run the script as a legacy block inside the Sandbox service:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { sandboxService } from "../src/services/Sandbox/SandboxService.ts";
+
+function wrapScript(content: string): string {
+  return content
+    .replace(/^import\s.*?;?\s*$/gm, "")
+    .replace(/^export\s+default\s+/m, "const _main = ")
+    .replace(/^export\s+const\s+/gm, "const ")
+    + "\nawait _main(u);";
+}
+
+const raw = await Deno.readTextFile("system/scripts/look.ts");
+const result = await sandboxService.runScript(wrapScript(raw), {
+  id: "actor1",
+  me: { id: "actor1", name: "Bob", flags: new Set(["connected"]), state: {}, contents: [] },
+  here: { id: "room1", name: "Lobby", flags: new Set(["room"]), state: {}, contents: [] },
+  location: "room1",
+  state: {},
+  socketId: "sock1",
+});
+</code></pre>
+<h3>Scripts that emit <code>u.ui.layout()</code></h3>
+<p>Scripts like <code>who</code> and <code>score</code> call <code>u.ui.layout()</code> which posts a <code>type: "result"</code> message<br>
+that resolves the sandbox early. Use an extended stub that captures both <code>_sent</code> and<br>
+<code>_broadcast</code> and stubs <code>u.ui.layout</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const extra = `
+  const _sent = [];
+  const _broadcast = [];
+  u.send = (msg) =&gt; { _sent.push(msg); };
+  u.emit = (msg) =&gt; { _broadcast.push(msg); };
+  u.ui = { layout: (data) =&gt; { postMessage({ type: "result", data }); } };
+`;
+</code></pre>
+<hr>
+<h2>Testing Commands Registered with addCmd()</h2>
+<p>For commands registered via <code>addCmd()</code>, import the command module directly,<br>
+call the <code>exec</code> function, and inspect the mock SDK:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd, cmds } from "../src/services/commands/cmdParser.ts";
+
+Deno.test({ name: "greet command", ...OPTS, fn: async () =&gt; {
+  // Register the command
+  addCmd({
+    name: "greet",
+    pattern: /^greet\s+(.+)/i,
+    exec: async (u) =&gt; {
+      u.send(`You wave at ${u.cmd.args[0]}.`);
+    },
+  });
+
+  let output = "";
+  const u = {
+    me: { id: "p1", name: "Alice", flags: new Set(["connected"]), state: {}, contents: [] },
+    cmd: { args: ["Bob"], switches: [], original: "greet Bob" },
+    send: (msg: string) =&gt; { output += msg; },
+    emit: () =&gt; {},
+  } as any;
+
+  const cmd = cmds.find(c =&gt; c.name === "greet")!;
+  await cmd.exec(u);
+
+  if (!output.includes("wave at Bob")) throw new Error(output);
+}});
+</code></pre>
+<hr>
+<h2>Testing Plugins</h2>
+<p>Test a plugin’s <code>init()</code> and <code>remove()</code> in isolation by calling them directly.<br>
+Use a shared DB prefix that won’t collide with other tests.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import myPlugin from "../src/plugins/my-feature/index.ts";
+import { DBO } from "../src/services/Database/index.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const db = new DBO&lt;{ title: string }&gt;("test.my-feature");
+
+Deno.test({ name: "my-feature plugin", ...OPTS, fn: async (t) =&gt; {
+  await myPlugin.init();
+
+  await t.step("creates a record", async () =&gt; {
+    await db.create({ title: "hello" });
+    const result = await db.queryOne({ title: "hello" });
+    if (!result || result.title !== "hello") throw new Error("Record not found");
+  });
+
+  // Always clean up
+  await myPlugin.remove?.();
+  await db.deleteAll({});
+}});
+</code></pre>
+<hr>
+<h2>Database IDs</h2>
+<p>Prefix DB IDs in tests to avoid collisions between test files that run in parallel:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Good — unique prefix per test file
+const actor = { id: "sa_actor1", … };  // "sa_" = scripts_attrs
+const room   = { id: "sa_room1",  … };
+
+// Bad — generic IDs collide across test files
+const actor = { id: "actor1", … };
+</code></pre>
+<p>Close the DB in the last test of the file:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { DBO as _DBO } from "../src/services/Database/index.ts";
+
+// Last test in the file:
+Deno.test({ name: "cleanup", ...OPTS, fn: async () =&gt; {
+  await _DBO.close();
+}});
+</code></pre>
+<hr>
+<h2>Stubbing the Sandbox</h2>
+<p>Scripts that reference in-game objects (exits, inventory, rooms) need the sandbox<br>
+stubs set up with inline JavaScript object literals — <strong>not <code>JSON.stringify</code></strong>, which<br>
+breaks <code>Set</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const jsExit = `{ id: "x1", name: "North", flags: new Set(["exit"]), state: {}, contents: [] }`;
+
+// Counter must be defined INSIDE the extra string so it's scoped to the worker:
+const extra = `
+  let _callCount = 0;
+  u.db = {
+    ...u.db,
+    search: async () =&gt; ++_callCount === 1 ? [${jsExit}] : [],
+  };
+`;
+</code></pre>
+<hr>
+<h2>Coverage</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task test:coverage
+</code></pre>
+<p>This runs the full suite, then outputs:</p>
+<ol>
+<li>An LCOV file at <code>coverage/lcov.info</code> — compatible with most CI coverage dashboards</li>
+<li>A summary table in the terminal</li>
+</ol>
+<p>To view HTML coverage (requires <code>genhtml</code> from <code>lcov</code>):</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">genhtml coverage/lcov.info -o coverage/html
+open coverage/html/index.html
+</code></pre>
+<hr>
+<h2>CI</h2>
+<p>The project uses GitHub Actions. The workflow is at <code>.github/workflows/ci.yml</code>.<br>
+Tests run on every push and pull request:</p>
+<pre class="language-yaml" tabindex="0"><code class="language-yaml">- name: Run tests
+  run: deno test --allow-all --unstable-kv --no-check
+</code></pre>
+<p>Tests must pass before a PR can be merged.</p>
+<hr>
+<h2>Pre-Commit Gauntlet</h2>
+<p>These four steps mirror CI and must pass before every commit:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno check --unstable-kv mod.ts
+deno lint
+deno test tests/ --allow-all --unstable-kv --no-check
+deno test tests/security_*.test.ts --allow-all --unstable-kv --no-check
+</code></pre>
+<p>The full suite is green on <code>main</code> — there are no expected failures. If a test<br>
+fails on your branch, fix it before submitting a PR.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/development/contributing/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+
+        
+          <a href="/ursamu/extending/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/discord-webhook/index.html
+++ b/docs/_site/discord-webhook/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html><head><meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/discord-webhook/">
+<meta name="twitter:card" content="summary">
+</head><body><h1>Discord Webhook Plugin Plan</h1>
+<h2>Overview</h2>
+<p>A webhook-based Discord integration plugin. Uses Discord’s per-message <code>username</code><br>
+and <code>avatar_url</code> overrides so a single webhook can post as different named players<br>
+with unique avatars. No bot account, no gateway connection — one-directional (game → Discord).</p>
+<h2>Avatar source (priority order)</h2>
+<ol>
+<li>Player’s locally-saved avatar served at <code>GET /avatars/:id</code> (see avatar system)</li>
+<li>Fallback: <code>https://robohash.org/{encodedName}?set=set4&amp;size=80x80</code> (unique per name, free)</li>
+</ol>
+<h2>Requires <code>publicUrl</code> in game config so the plugin can construct absolute avatar URLs.</h2>
+<h2>Plugin location</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">src/plugins/discord/
+  index.ts              ← IPlugin entry, registers commands + hooks
+  webhook.ts            ← low-level HTTP poster (queue, retry, 429 handling)
+  config.ts             ← read/write webhook config from game DB config
+  commands.ts           ← @discord/set, @discord/list, @discord/test
+  router.ts             ← REST API for managing webhooks
+  ursamu.plugin.json
+</code></pre>
+<hr>
+<h2>Configuration</h2>
+<p>Stored in game config under the <code>"discord"</code> key:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "webhooks": {
+    "jobs":   "https://discord.com/api/webhooks/…/…",
+    "ooc":    "https://discord.com/api/webhooks/…/…",
+    "scenes": "https://discord.com/api/webhooks/…/…"
+  },
+  "publicUrl": "https://mygame.example.com"
+}
+</code></pre>
+<h2><code>publicUrl</code> is used to construct <code>avatar_url</code> values for Discord.<br>
+Topics are optional — unconfigured topics are silently skipped.</h2>
+<h2>webhook.ts — low-level poster</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface WebhookPayload {
+  content?: string;
+  username?: string;
+  avatar_url?: string;
+  embeds?: DiscordEmbed[];
+}
+</code></pre>
+<ul>
+<li>POST to webhook URL with <code>Content-Type: application/json</code></li>
+<li>Respects Discord <code>429 Too Many Requests</code> — reads <code>retry_after</code>, waits, retries once</li>
+<li>Per-webhook outgoing queue (one at a time per URL) to avoid burst rate-limiting</li>
+<li>Silent failure on non-retryable errors (logs to console, never crashes game)</li>
+</ul>
+<hr>
+<h2>In-game commands (wizard/admin only)</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">@discord/set &lt;topic&gt;=&lt;url&gt;    ← set or update a webhook URL
+@discord/set &lt;topic&gt;=         ← clear/disable a topic
+@discord/list                 ← show configured topics (URLs truncated)
+@discord/test &lt;topic&gt;         ← post a test message to a topic
+</code></pre>
+<hr>
+<h2>REST API</h2>
+<p>All endpoints require staff (admin/wizard).</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Path</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GET</td>
+<td>/api/v1/discord/webhooks</td>
+<td>List topics (URLs truncated to 40 chars)</td>
+</tr>
+<tr>
+<td>POST</td>
+<td>/api/v1/discord/webhooks</td>
+<td><code>{ topic, url }</code> — set webhook</td>
+</tr>
+<tr>
+<td>DELETE</td>
+<td>/api/v1/discord/webhooks/:topic</td>
+<td>Remove topic</td>
+</tr>
+<tr>
+<td>POST</td>
+<td>/api/v1/discord/webhooks/:topic/test</td>
+<td>Send test message</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Event → Discord mapping</h2>
+<h3><code>jobs</code> topic — subscribes to <code>jobHooks</code></h3>
+<table>
+<thead>
+<tr>
+<th>Hook event</th>
+<th>Discord output</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>job:created</code></td>
+<td>Green embed: “New job #N — [title]” — submitter as username</td>
+</tr>
+<tr>
+<td><code>job:assigned</code></td>
+<td>Blue embed: “Job #N assigned to [staff]”</td>
+</tr>
+<tr>
+<td><code>job:commented</code></td>
+<td>Plain message as comment author (skips <code>staffOnly</code> comments)</td>
+</tr>
+<tr>
+<td><code>job:status-changed</code></td>
+<td>Yellow embed: status transition</td>
+</tr>
+<tr>
+<td><code>job:resolved</code></td>
+<td>Teal embed: “Job #N resolved by [staff]”</td>
+</tr>
+<tr>
+<td><code>job:closed</code></td>
+<td>Gray embed: “Job #N closed by [staff]”</td>
+</tr>
+<tr>
+<td><code>job:deleted</code></td>
+<td>Red embed: “Job #N deleted”</td>
+</tr>
+</tbody>
+</table>
+<h3><code>ooc</code> topic — in-game public channel relay</h3>
+<p>Subscribe to channel talk events on channels flagged as public.<br>
+Post as the speaking player with their avatar.</p>
+<p>Format: <code>content: message</code> (plain, no embed — keeps it readable)</p>
+<h3><code>scenes</code> topic — scene pose relay</h3>
+<p>Subscribe to scene pose events.<br>
+Post as the posing player with their avatar.</p>
+<h2>Format: pose text as-is (no prefix), player as username.</h2>
+<h2>Avatar URL resolution</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">function avatarUrl(playerId: string, playerName: string, config: DiscordConfig): string {
+  // Check if player has a saved avatar
+  if (playerHasAvatar(playerId)) {
+    return `${config.publicUrl}/avatars/${playerId}`;
+  }
+  // Fallback to RoboHash
+  return `https://robohash.org/${encodeURIComponent(playerName)}?set=set4&amp;size=80x80`;
+}
+</code></pre>
+<hr>
+<h2>Message format examples</h2>
+<p><strong>Job created (embed):</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "username": "Mira",
+  "avatar_url": "https://mygame.com/avatars/obj-42",
+  "embeds": [{
+    "color": 5763719,
+    "title": "New Job #17 — Fix the north gate",
+    "description": "The north gate latch is broken again.",
+    "footer": { "text": "Category: maintenance • Priority: normal" }
+  }]
+}
+</code></pre>
+<p><strong>OOC channel message:</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "username": "Mira",
+  "avatar_url": "https://mygame.com/avatars/obj-42",
+  "content": "Anyone want to run a scene tonight?"
+}
+</code></pre>
+<hr>
+<h2>What’s NOT included (future work)</h2>
+<ul>
+<li>Discord → game bridging (requires bot/gateway)</li>
+<li>Per-player opt-out (<code>@discord/optout</code>)</li>
+<li>Per-channel subscription mapping (which game channels go to which topic)</li>
+<li>Thread-per-scene (Discord webhook API limitation — needs a bot)</li>
+<li>Attachment/image forwarding from in-game</li>
+</ul>
+<hr>
+<h2>Dependencies</h2>
+<ul>
+<li>Avatar system (<code>src/commands/avatar.ts</code> + <code>/avatars/:id</code> route) — must exist first</li>
+<li><code>jobHooks</code> from <code>src/plugins/jobs/hooks.ts</code></li>
+<li>Game config system (<code>getConfig</code> / <code>setConfig</code>)</li>
+<li><code>publicUrl</code> configured in game config</li>
+</ul>
+</body></html>

--- a/docs/_site/extending/index.html
+++ b/docs/_site/extending/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Learn how to extend UrsaMU with custom functionality">
+  <meta name="description" content="Extension points exposed by the UrsaMU engine">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,355 +268,129 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Extending UrsaMU</h1>
-<p>This guide explains how to extend UrsaMU with custom functionality beyond what plugins provide.</p>
-<h2>Overview</h2>
-<p>UrsaMU is designed to be highly extensible. While plugins are the primary way to add functionality, there are several other extension points that allow you to customize the system at a deeper level.</p>
-<p>Extension points include:</p>
+<p>UrsaMU exposes a small set of named registries through <code>jsr:@ursamu/mush</code><br>
+(<code>mod.ts</code>). Each one is a stable extension point intended for plugins and<br>
+child-game code. Plugins are still the preferred packaging unit — these<br>
+registries are what plugins use under the hood.</p>
+<p>All examples assume the JSR import path used by external plugins:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { /* ... */ } from "jsr:@ursamu/mush";
+</code></pre>
+<h2>Commands</h2>
+<p><code>addCmd({ name, pattern, lock, category, help, exec })</code> registers a command.<br>
+The <code>exec</code> handler receives an <code>IUrsamuSDK</code> (<code>u</code>) with <code>u.me</code>, <code>u.here</code>,<br>
+<code>u.cmd</code>, <code>u.send</code>, <code>u.db</code>, <code>u.util</code>, <code>u.canEdit</code>, and the other SDK<br>
+namespaces listed in <code>docs/api/core.md</code>. See <code>CLAUDE.md</code> for the <code>addCmd</code><br>
+skeleton and pattern cheat-sheet (catch-all switch gotcha included).</p>
+<h2>Format handlers</h2>
+<p>Format handlers customize how named display slots (NAMEFORMAT, DESCFORMAT,<br>
+CONFORMAT, EXITFORMAT, WHOFORMAT, WHOROWFORMAT, PSFORMAT, PSROWFORMAT, or any<br>
+arbitrary uppercase slot name) render. Two entry points:</p>
 <ul>
-<li>Custom commands</li>
-<li>Custom flags</li>
-<li>Custom functions</li>
-<li>Custom hooks</li>
-<li>Advanced extensions (middleware, services, etc.)</li>
+<li><code>registerFormatHandler(slot, fn)</code> — TS function that returns a string.</li>
+<li><code>registerFormatTemplate(slot, mushSource)</code> — raw MUSH softcode body, parsed<br>
+and evaluated as if it were a <code>&amp;NAMEFORMAT</code> attribute (v2.4.0).</li>
 </ul>
-<h2>Extension Points</h2>
-<h3>When to Use Extensions vs. Plugins</h3>
+<p>Lookups go through <code>resolveFormat</code> / <code>resolveFormatOr</code> (per-target) and<br>
+<code>resolveGlobalFormat</code> / <code>resolveGlobalFormatOr</code> (two-tier <code>#0</code> → <code>u.me</code>).<br>
+<code>unregisterFormatHandler(slot)</code> removes a registration. All four resolvers<br>
+are reachable from softcode via <code>u.util</code>. See <code>docs/api/core.md</code> for the<br>
+full slot list and priority rules.</p>
+<h2>Lock functions</h2>
+<p><code>registerLockFunc(name, fn)</code> adds a callable lock primitive usable inside<br>
+lock strings (<code>tribe(glasswaler)</code>, <code>attr(mortal) || !tribe(glasswaler)</code>,<br>
+<code>connected &amp;&amp; perm(builder)</code>). Built-in names — <code>flag</code>, <code>attr</code>, <code>type</code>,<br>
+<code>is</code>, <code>holds</code>, <code>perm</code> — are protected and cannot be overwritten. Locks are<br>
+fail-closed: unknown function or thrown error evaluates to <code>false</code>. Max<br>
+length 4096 chars / 256 tokens. Lock strings support <code>&amp;&amp;</code>, <code>||</code>, <code>!</code>, and<br>
+<code>()</code> grouping; legacy <code>&amp;</code> / <code>|</code> still parse.</p>
+<h2>Softcode functions and substitutions</h2>
 <ul>
-<li><strong>Plugins</strong>: Use plugins for self-contained features that can be enabled or disabled as a unit.</li>
-<li><strong>Extensions</strong>: Use extensions when you need to modify core behavior or add functionality that integrates deeply with the system.</li>
+<li><code>registerSoftcodeFunc(name, fn)</code> adds a stdlib function callable from any<br>
+evaluated attribute (e.g. <code>magic(x, y)</code>).</li>
+<li><code>registerSoftcodeSub(name, fn)</code> adds a <code>%</code>-substitution handler (e.g.<br>
+<code>%mxp[...]</code>).</li>
 </ul>
-<p>Extensions are typically implemented within plugins but can also be added directly in a child game.</p>
-<h2>Custom Commands</h2>
-<p>Commands are the primary way players interact with UrsaMU. You can create custom commands to add new functionality.</p>
-<h3>Registering Commands</h3>
-<p>Use the <code>addCmd</code> function to register a new command:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-
-addCmd({
-  name: "mycommand",                    // Unique identifier for the command
-  pattern: /^mycommand\s*(.*)/i,        // Regex pattern to match user input
-  lock: "connected",                    // Lock expression required to use the command
-  exec: (u: IUrsamuSDK) =&gt; {           // Function to execute when command is triggered
-    const args = u.cmd.args[0]?.trim() ?? "";
-    u.send(`You typed: ${args}`);
-  }
-});
-</code></pre>
-<h3>Command Context (IUrsamuSDK)</h3>
-<p>The <code>u</code> object passed to the <code>exec</code> function contains:</p>
+<p>Both feed the same <code>softcodeService</code> evaluator used by <code>u.eval</code> /<br>
+<code>u.evalString</code> and by <code>&amp;attr</code>/<code>@trigger</code> dispatch.</p>
+<h2>Command middleware</h2>
+<p><code>registerCmdMiddleware(fn)</code> inserts a middleware function into the command<br>
+pipeline before <code>exec</code> runs. Use it for logging, audit, rate-limiting, or<br>
+short-circuit interception. Middleware receives the same context the<br>
+dispatcher builds and can call <code>next()</code> to continue or return early to<br>
+abort.</p>
+<h2>Scripts</h2>
+<p><code>registerScript(name, content)</code> registers a sandbox script (legacy block or<br>
+ESM <code>export default async (u) =&gt; { ... }</code>). Resolution order at dispatch<br>
+time: local <code>system/scripts/&lt;name&gt;.ts</code> override → plugin registry → engine<br>
+bundled. Use this when a plugin wants to ship a sandboxed script without<br>
+writing to disk.</p>
+<h2>REST routes</h2>
+<p><code>registerPluginRoute(method, path, handler)</code> attaches an Express handler to<br>
+the main HTTP app. The handler receives the standard Express<br>
+<code>(req, res, next)</code> triple. Return 401 before any work when <code>req.userId</code> is<br>
+null. Routes are namespaced by convention under <code>/api/v1/&lt;plugin&gt;/...</code>.</p>
+<h2>UI components</h2>
+<p><code>registerUIComponent(component)</code> adds an entry to <code>GET /api/v1/ui-manifest</code><br>
+so the bundled web client (and any other client that reads the manifest)<br>
+can discover plugin-provided UI. <code>unregisterUIComponent(id)</code> removes it;<br>
+<code>getRegisteredUIComponents()</code> lists current entries.</p>
+<h2>Stat systems</h2>
+<p><code>registerStatSystem(system)</code> registers an <code>IStatSystem</code> implementation<br>
+(stats, skills, validation, sheet rendering) that chargen plugins and game<br>
+projects can target. <code>getStatSystem(name)</code>, <code>getDefaultStatSystem()</code>, and<br>
+<code>getStatSystemNames()</code> are the read-side helpers.</p>
+<h2>Game hooks</h2>
+<p><code>gameHooks</code> is the engine’s <code>EventEmitter</code>. Subscribe with<br>
+<code>gameHooks.on(event, listener)</code> and pair every listener with a matching<br>
+<code>gameHooks.off(event, listener)</code> in <code>remove()</code> — using the same named<br>
+reference is non-negotiable (see <code>CLAUDE.md</code>). Typed events<br>
+(<code>GameHookMap</code>):</p>
 <ul>
-<li><code>u.me</code>: The actor who triggered the command (<code>IDBObj</code> with <code>id</code>, <code>state</code>, <code>flags</code>, etc.)</li>
-<li><code>u.here</code>: The room the actor is currently in</li>
-<li><code>u.cmd.args</code>: Array of regex capture groups from the matched pattern</li>
-<li><code>u.cmd.switches</code>: Array of switches (e.g. <code>@command/switch</code>)</li>
-<li><code>u.send(msg)</code>: Send output to the actor</li>
-<li><code>u.broadcast(roomId, msg)</code>: Broadcast a message to a room</li>
-<li><code>u.force(cmd)</code>: Execute a command as the actor</li>
-<li><code>u.setFlags(target, flags)</code>: Set flags on an object</li>
-<li><code>u.db</code>: Database operations (search, create, modify, destroy)</li>
-<li><code>u.util</code>: Utilities (target, stripSubs, etc.)</li>
+<li><code>player:login</code>, <code>player:logout</code></li>
+<li><code>say</code>, <code>pose</code>, <code>page</code>, <code>move</code></li>
+<li><code>channel:message</code></li>
+<li><code>object:created</code>, <code>object:destroyed</code>, <code>object:modified</code>, <code>object:moved</code></li>
+<li><code>scene:created</code>, <code>scene:pose</code>, <code>scene:set</code>, <code>scene:title</code>, <code>scene:clear</code></li>
+<li><code>mail:received</code></li>
 </ul>
-<h3>Command Patterns</h3>
-<p>Command patterns are regular expressions. Capture groups become <code>u.cmd.args</code>:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// /^look\s*(.*)/i — captures the optional target as u.cmd.args[0]
-// /^give\s+(\S+)\s+to\s+(.*)/i — two capture groups: args[0] and args[1]
-// /^quit$/i — exact match, no capture groups
-</code></pre>
-<h2>Custom Flags</h2>
-<p>Flags are used to control access to commands and features. You can create custom flags to implement your own permission system.</p>
-<h3>Registering Flags</h3>
-<p>Use the <code>registerFlag</code> function to register a new flag:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFlag } from "../../services/Flags/mod.ts";
+<h2>Plugin skeleton</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import "./commands.ts"; // Phase 1: addCmd at module load
+import {
+  gameHooks,
+  registerFormatTemplate,
+  registerLockFunc,
+} from "jsr:@ursamu/mush";
+import type { IPlugin, SessionEvent } from "jsr:@ursamu/mush";
 
-registerFlag({
-  name: "myflag",          // Name of the flag
-  description: "My custom flag", // Description of what the flag does
-  default: false           // Default value for new objects
-});
-</code></pre>
-<h3>Checking Flags</h3>
-<p>Use the <code>hasFlag</code> function to check if an object has a flag:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { hasFlag } from "../../services/Flags/mod.ts";
+const onLogin = (e: SessionEvent) =&gt; { /* ... */ };
 
-// Check if player has the "myflag" flag
-if (hasFlag(player, "myflag")) {
-  // Do something
-}
-</code></pre>
-<h3>Setting Flags</h3>
-<p>Use the <code>setFlag</code> function to set a flag on an object:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { setFlag } from "../../services/Flags/mod.ts";
-
-// Set the "myflag" flag on a player
-await setFlag(player, "myflag", true);
-</code></pre>
-<h2>Custom Functions</h2>
-<p>Functions are used in expressions and can be called from commands. You can create custom functions to add new capabilities to the expression system.</p>
-<h3>Registering Functions</h3>
-<p>Use the <code>registerFunction</code> function to register a new function:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFunction } from "../../services/Functions/mod.ts";
-
-registerFunction({
-  name: "myfunc",          // Name of the function
-  description: "My custom function", // Description of what the function does
-  args: ["arg1", "?arg2"],  // Arguments (? prefix means optional)
-  exec: (args, ctx) =&gt; {    // Function to execute
-    const [arg1, arg2 = "default"] = args;
-    return `${arg1} and ${arg2}`;
-  }
-});
-</code></pre>
-<h3>Using Custom Functions</h3>
-<p>Once registered, your function can be used in expressions:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">&gt; think myfunc(hello, world)
-hello and world
-</code></pre>
-<h2>Custom Hooks</h2>
-<p>Hooks allow you to run code at specific points in the system’s execution. You can create custom hooks to add behavior that runs automatically.</p>
-<h3>Registering Hooks</h3>
-<p>Use the <code>registerHook</code> function to register a new hook:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerHook } from "../../services/Hooks/mod.ts";
-
-// Register a hook that runs when a player connects
-registerHook("playerConnect", async (player) =&gt; {
-  console.log(`Player ${player.data.name} connected`);
-  
-  // You can modify the player or perform other actions
-  player.data.lastLogin = new Date().toISOString();
-  await dbojs.update(player);
-});
-</code></pre>
-<h3>Available Hook Points</h3>
-<p>UrsaMU provides several hook points:</p>
-<ul>
-<li><code>playerConnect</code>: Triggered when a player connects</li>
-<li><code>playerDisconnect</code>: Triggered when a player disconnects</li>
-<li><code>playerCreate</code>: Triggered when a player is created</li>
-<li><code>commandBefore</code>: Triggered before a command is executed</li>
-<li><code>commandAfter</code>: Triggered after a command is executed</li>
-<li><code>objectCreate</code>: Triggered when an object is created</li>
-<li><code>objectDestroy</code>: Triggered when an object is destroyed</li>
-</ul>
-<h3>Creating Custom Hook Points</h3>
-<p>You can create your own hook points for plugins to use:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerHookPoint, triggerHook } from "../../services/Hooks/mod.ts";
-
-// Register a new hook point
-registerHookPoint("myCustomHook");
-
-// Trigger the hook somewhere in your code
-await triggerHook("myCustomHook", { data: "some data" });
-</code></pre>
-<h2>Advanced Extensions</h2>
-<h3>Custom Middleware</h3>
-<p>You can create custom middleware to process commands before they’re executed:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerMiddleware } from "../../services/Commands/mod.ts";
-
-// Register middleware that logs all commands
-registerMiddleware(async (ctx, next) =&gt; {
-  console.log(`Player ${ctx.player.data.name} executed: ${ctx.cmd} ${ctx.args}`);
-  
-  // Call the next middleware in the chain
-  await next();
-  
-  console.log("Command execution completed");
-});
-</code></pre>
-<h3>Custom Services</h3>
-<p>You can create custom services to provide functionality to other parts of the system:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/services/MyService/mod.ts
-class MyService {
-  private data: Map&lt;string, any&gt; = new Map();
-  
-  constructor() {
-    console.log("MyService initialized");
-  }
-  
-  set(key: string, value: any): void {
-    this.data.set(key, value);
-  }
-  
-  get(key: string): any {
-    return this.data.get(key);
-  }
-}
-
-// Create a singleton instance
-export const myService = new MyService();
-</code></pre>
-<h3>Custom Database Models</h3>
-<p>You can create custom database models to store specialized data:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { dbojs } from "../../services/Database/index.ts";
-
-// Define a type for your model
-interface MyModel {
-  id: string;
-  name: string;
-  data: Record&lt;string, any&gt;;
-}
-
-// Create functions to work with your model
-async function createMyModel(data: Omit&lt;MyModel, "id"&gt;): Promise&lt;MyModel&gt; {
-  const model = await dbojs.create({
-    flags: "mymodel",
-    data: {
-      name: data.name,
-      ...data.data
-    }
-  });
-  
-  return {
-    id: model.id,
-    name: data.name,
-    data: data.data
-  };
-}
-
-async function getMyModels(): Promise&lt;MyModel[]&gt; {
-  const models = await dbojs.query({ flags: /mymodel/i });
-  
-  return models.map(model =&gt; ({
-    id: model.id,
-    name: model.data.name,
-    data: { ...model.data }
-  }));
-}
-</code></pre>
-<h3>Custom Web Routes</h3>
-<p>If you’re using the web interface, you can add custom routes:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { app } from "../../app.ts";
-
-// Add a custom API endpoint
-app.router.get("/api/custom", (ctx) =&gt; {
-  ctx.response.body = { message: "Custom API endpoint" };
-});
-
-// Add a custom page
-app.router.get("/custom", async (ctx) =&gt; {
-  ctx.response.body = await app.render("custom.html", {
-    title: "Custom Page",
-    data: { /* your data */ }
-  });
-});
-</code></pre>
-<h3>Example: Complete Extension</h3>
-<p>Here’s an example of a plugin that uses multiple extension points:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { IPlugin, addCmd } from "jsr:@ursamu/ursamu";
-import type { IUrsamuSDK } from "jsr:@ursamu/ursamu";
-import { registerFlag } from "../../services/Flags/mod.ts";
-import { registerFunction } from "../../services/Functions/mod.ts";
-import { registerHook } from "../../services/Hooks/mod.ts";
-import { dbojs } from "../../services/Database/index.ts";
-
-const myExtensionPlugin: IPlugin = {
-  name: "my-extension",
+export const plugin: IPlugin = {
+  name: "myplugin",
   version: "1.0.0",
-  description: "A plugin that demonstrates various extension points",
-  
-  init: async () =&gt; {
-    // Register a custom flag
-    registerFlag({
-      name: "vip",
-      description: "VIP player with special privileges",
-      default: false
-    });
-    
-    // Register a custom function
-    registerFunction({
-      name: "isvip",
-      description: "Check if a player is a VIP",
-      args: ["player"],
-      exec: async (args, ctx) =&gt; {
-        const [playerName] = args;
-        
-        // Find the player
-        const players = await dbojs.query({
-          "data.name": new RegExp(`^${playerName}$`, "i"),
-          flags: /player/i
-        });
-        
-        if (players.length === 0) {
-          return "0";
-        }
-        
-        // Check if the player has the VIP flag
-        return players[0].flags.includes("vip") ? "1" : "0";
-      }
-    });
-    
-    // Register a custom command
-    addCmd({
-      name: "vip",
-      pattern: /^vip\s+(\S+)\s+(.*)/i,
-      lock: "wizard",
-      exec: async (u: IUrsamuSDK) =&gt; {
-        const action = u.cmd.args[0]?.trim() ?? "";
-        const target = u.cmd.args[1]?.trim() ?? "";
-
-        if (!action || !target) {
-          return u.send("Usage: vip add/remove &lt;player&gt;");
-        }
-
-        // Find the target player
-        const players = await dbojs.query({
-          "data.name": new RegExp(`^${target}$`, "i"),
-          flags: /player/i
-        });
-
-        if (players.length === 0) {
-          return u.send(`Player '${target}' not found.`);
-        }
-
-        const player = players[0];
-        const playerName = String(player.data?.name ?? player.id);
-
-        if (action === "add") {
-          if (!player.flags.includes("vip")) {
-            await u.setFlags(player.id, "+vip");
-            u.send(`Added VIP status to ${playerName}.`);
-          } else {
-            u.send(`${playerName} is already a VIP.`);
-          }
-        } else if (action === "remove") {
-          if (player.flags.includes("vip")) {
-            await u.setFlags(player.id, "-vip");
-            u.send(`Removed VIP status from ${playerName}.`);
-          } else {
-            u.send(`${playerName} is not a VIP.`);
-          }
-        } else {
-          u.send("Usage: vip add/remove &lt;player&gt;");
-        }
-      }
-    });
-    
-    // Register a hook
-    registerHook("playerConnect", async (player) =&gt; {
-      // Check if the player is a VIP
-      if (player.flags.includes("vip")) {
-        // Broadcast a message to all connected players
-        const connectedPlayers = await dbojs.query({
-          flags: /connected/i
-        });
-        
-        for (const p of connectedPlayers) {
-          p.send(`VIP player ${player.data.name} has connected!`);
-        }
-      }
-    });
-    
+  description: "One sentence.",
+  init: () =&gt; {
+    gameHooks.on("player:login", onLogin);
+    registerLockFunc("tribe", (en, _t, args) =&gt;
+      String(en.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+    );
+    registerFormatTemplate("NAMEFORMAT", "[name(%0)] &lt;&lt;%1&gt;&gt;");
     return true;
   },
-  
-  remove: async () =&gt; {
-    // Cleanup code here
-  }
+  remove: () =&gt; {
+    gameHooks.off("player:login", onLogin);
+  },
 };
-
-export default myExtensionPlugin;
 </code></pre>
-<p>By using these extension points, you can deeply customize UrsaMU to create a unique game experience tailored to your needs.</p>
+<p>See <code>docs/api/core.md</code> for full signatures and the complete <code>IUrsamuSDK</code><br>
+surface.</p>
+<h2>Building non-MUSH servers</h2>
+<p>If you want to use the same transport/session infrastructure without the MUSH<br>
+command model, import from <code>jsr:@ursamu/core</code> instead. It exposes<br>
+<code>createServer</code>, <code>websocketTransport</code>, <code>telnetTransport</code>, <code>httpTransport</code>,<br>
+<code>registerFallback</code>, <code>addHandler</code>, <code>runPipeline</code>, <code>sessions</code>, and<br>
+<code>registerSender</code> — the primitives <code>@ursamu/mush</code> is built on — without<br>
+pulling in any MUSH-specific concepts (softcode, flags, locks, format slots,<br>
+etc.).</p>
 
       </article>
 
@@ -657,11 +431,49 @@ export default myExtensionPlugin;
       
         
           
+        
+      
+        
           
         
       
         
           
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -702,9 +514,9 @@ export default myExtensionPlugin;
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/development/contributing/" class="page-nav-btn prev">
+          <a href="/ursamu/development/testing/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Testing</span>
           </a>
         
 

--- a/docs/_site/guides/admin-guide/index.html
+++ b/docs/_site/guides/admin-guide/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -276,17 +276,17 @@ including user management, configuration, backups, and troubleshooting.</p>
 <p>Run the server for the first time:</p>
 <pre class="language-bash" tabindex="0"><code class="language-bash">deno task start
 </code></pre>
-<p>When the database is empty, the startup script pauses and prompts you:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">No players found in the database.
-Welcome! Let's set up your superuser account.
+<p>When the database is empty, the engine prints:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">Fresh database detected — no players exist yet.
 
-Enter email address: you@example.com
-Enter username: Admin
-Enter password: ••••••••
+Connect via telnet and run:
+  create &lt;name&gt; &lt;password&gt;
 
-Superuser 'Admin' created successfully!
+The first player created is automatically given superuser access.
 </code></pre>
-<p>After setup completes, the Hub, Telnet sidecar, and web client all start automatically.</p>
+<p>Connect with a Telnet client (<code>telnet localhost 4201</code>) and create your<br>
+account. The first player created on a fresh database is automatically<br>
+granted the <code>superuser</code> flag.</p>
 <h3>Permission levels</h3>
 <p>UrsaMU uses a flag-based permission system:</p>
 <table>
@@ -342,13 +342,8 @@ Superuser 'Admin' created successfully!
 </code></pre>
 <p>The <code>superuser</code> flag cannot be granted via <code>@set</code> — it can only be created<br>
 through the first-run interactive prompt.</p>
-<blockquote>
-<p><strong>Non-interactive environments</strong>: If you run <code>deno task start</code> without a TTY<br>
-(e.g. in a Docker container), the prompt is skipped. Run <code>deno task server</code><br>
-directly in an interactive terminal to complete first-run setup, then switch<br>
-back to <code>deno task start</code> for normal operation.</p>
-</blockquote>
-<hr>
+<h2>The <code>superuser</code> flag itself cannot be granted via <code>@set</code> from inside the<br>
+game — it can only be created via this first-run flow.</h2>
 <h2>User Management</h2>
 <h3>Creating Admin Users</h3>
 <p>To grant admin privileges to an existing player, use the <code>@set</code> command as a<br>
@@ -358,7 +353,9 @@ superuser or existing admin:</p>
 <h3>Managing User Accounts</h3>
 <p>As an administrator, you can manage user accounts with these commands:</p>
 <ul>
-<li><code>@newpassword &lt;user&gt;=&lt;password&gt;</code> — Reset a user’s password</li>
+<li><code>@newpassword &lt;user&gt;=&lt;password&gt;</code> — Reset a user’s password directly</li>
+<li><code>@resettoken &lt;user&gt;</code> — Generate a one-time password-reset token (valid 1 hour);<br>
+give the token to the player so they can reset via <code>POST /api/v1/auth/reset-password</code></li>
 <li><code>@boot &lt;user&gt;</code> — Disconnect a player from the server</li>
 <li><code>@toad &lt;user&gt;</code> — Convert a player object into a regular thing (removes player<br>
 flag and disconnects)</li>
@@ -416,6 +413,25 @@ additional commands:</p>
 @chanset &lt;name&gt;/hidden=true|false    -- Toggle channel visibility
 @chanset &lt;name&gt;/masking=true|false   -- Toggle name masking
 </code></pre>
+<h3>Master Room &amp; Zones</h3>
+<h4>Master Room</h4>
+<p>UrsaMU supports a single designated <em>master room</em>. Commands and <code>$</code>-pattern attributes set on objects in the master room are checked globally — any player anywhere on the game can trigger them, as if those objects were in the same room.</p>
+<p>The master room ID is configured via <code>game.masterRoom</code> in <code>config.json</code>:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "game": {
+    "masterRoom": "1"
+  }
+}
+</code></pre>
+<p><code>ACONNECT</code> and <code>ADISCONNECT</code> attributes fire on both the connected player’s own object and on objects in the master room, allowing global connection hooks without touching the player object.</p>
+<h4>Zone System</h4>
+<p>Zones allow a <em>zone master</em> object to share <code>$</code>-pattern commands across all objects assigned to it.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@zone &lt;object&gt;=&lt;zone master&gt;   -- assign object to a zone
+@zone &lt;object&gt;=                -- clear zone assignment
+</code></pre>
+<p>Objects in a zone inherit <code>$</code>-pattern command dispatch from the zone master, making it easy to share a command set across many rooms or items without duplicating attributes on each one.</p>
+<p>To see what zone an object belongs to, use <code>examine &lt;object&gt;</code> — the zone master dbref is listed in the output.</p>
+<hr>
 <h3>Rate Limiting</h3>
 <p>The server enforces a WebSocket command rate limit of <strong>10 commands per second</strong><br>
 per connection. Requests that exceed this are silently dropped and logged to<br>
@@ -424,35 +440,6 @@ stderr:</p>
 </code></pre>
 <p>This is a fixed limit defined in <code>WebSocketService</code> and cannot currently be<br>
 configured at runtime.</p>
-<h2>Web Client</h2>
-<p>UrsaMU ships with an optional browser-based client built with Deno Fresh<br>
-(<code>src/web-client/</code>). When <code>src/web-client/</code> is present, <strong><code>deno task start</code><br>
-starts it automatically</strong> alongside the Hub and Telnet sidecar.</p>
-<p>The web client runs at <a href="http://localhost:8000">http://localhost:8000</a>.</p>
-<h3>What the Web Client Provides</h3>
-<ul>
-<li>Login / character registration forms</li>
-<li>In-game terminal interface (sends/receives WebSocket commands)</li>
-<li>Scene viewer and scene builder</li>
-<li>Character profile and character sheet pages</li>
-<li>Player directory</li>
-<li>Wiki pages</li>
-</ul>
-<h3>Starting Manually</h3>
-<p>If you want to run the web client independently (e.g. during development):</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">cd src/web-client
-deno task start
-</code></pre>
-<h3>Production Deployment</h3>
-<p>For production, build the Fresh app first:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">cd src/web-client
-deno task build
-deno task preview    # runs the pre-built version
-</code></pre>
-<p>Point a reverse proxy (nginx, Caddy) at port <code>8000</code> for TLS termination. The<br>
-main Hub (port <code>4203</code>) should also be proxied for WebSocket connections from<br>
-the web client.</p>
-<hr>
 <h2>Server Configuration</h2>
 <h3>Basic Configuration</h3>
 <p>Run the interactive configuration wizard:</p>
@@ -460,19 +447,289 @@ the web client.</p>
 </code></pre>
 <p>Key configuration areas:</p>
 <ul>
-<li>Server ports (Hub WS: 4202, Hub HTTP: 4203, Telnet: 4201, Web client: 8000)</li>
+<li>Server ports (Hub WS: 4202, Hub HTTP: 4203, Telnet: 4201)</li>
 <li>Game name and welcome messages</li>
 <li>Starting room ID</li>
 </ul>
+<h3>Runtime Configuration (<code>@site</code>)</h3>
+<p>Admins and wizards can change a subset of server configuration values at runtime<br>
+without restarting:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@site server.name=My Awesome Game
+@site game.loginMessage=Welcome back!
+@site game.welcomeMessage=Welcome to the game!
+@site server.banner=A roleplay game set in urban fantasy
+</code></pre>
+<p>Allowed keys: <code>server.name</code>, <code>server.description</code>, <code>server.banner</code>,<br>
+<code>server.corsOrigins</code>, <code>server.maxConnections</code>, <code>game.maxPlayers</code>,<br>
+<code>game.description</code>, <code>game.loginMessage</code>, <code>game.welcomeMessage</code>.</p>
+<p>Attempts to set other keys (e.g. <code>server.db</code>, <code>jwt.secret</code>) are blocked and<br>
+logged to the security log.</p>
 <h3>Restarting and Shutting Down</h3>
 <p>From in-game (admin or wizard required):</p>
 <pre class="language-none" tabindex="0"><code class="language-none">@reboot      -- Gracefully restart the server
 @shutdown    -- Shut down the server
+@update      -- Pull latest code from git and restart (see below)
 </code></pre>
-<p>From the terminal, use <code>Ctrl+C</code> to stop a running process, then restart with:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">deno task server    # Hub only
-deno task start     # Hub + telnet with file watching
+<p>From the terminal:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task start           # Start Hub + Telnet sidecar (foreground)
+deno task dev             # Same, with file watching (development)
+bash scripts/daemon.sh    # Supervised background process (production)
+bash scripts/restart.sh   # No-disconnect restart of the supervised main
+bash scripts/stop.sh      # Graceful stop (disconnects everyone)
 </code></pre>
+<p>The supervised scaffold is created automatically by <code>ursamu create</code>. See<br>
+<a href="/ursamu/guides/deployment/#supervised-daemon-mode">Production Deployment</a> for the<br>
+signal model (SIGUSR2 = no-disconnect restart; Telnet sidecar persists<br>
+across <code>@reboot</code> and JWT auto-reauth).</p>
+<h3>Hot-Reload (<code>@reload</code>)</h3>
+<p>Without restarting or disconnecting any players, admins and wizards can reload<br>
+individual parts of the running server:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@reload                    -- reload everything (config + text + commands + plugins)
+@reload/config             -- reload config.json from disk only
+@reload/text               -- reload text files (motd, etc.) only
+@reload/cmds               -- reload native commands and system aliases only
+@reload/plugins            -- hot-reload all installed plugins
+@reload/plugin &lt;name&gt;      -- hot-reload one specific plugin by name
+</code></pre>
+<p><strong>Example — reload just the jobs plugin after an update:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">@reload/plugin jobs
+</code></pre>
+<p>The response shows each subsystem’s status. Partial failures are reported<br>
+inline so you can see which component (if any) didn’t reload cleanly.</p>
+<blockquote>
+<p><code>@reload/plugin &lt;name&gt;</code> is case-insensitive and matches against the plugin’s<br>
+registered name. To see what’s loaded: <code>@reload/plugin</code> (no name) prints<br>
+the list of currently loaded plugins.</p>
+</blockquote>
+<blockquote>
+<p><strong>System scripts</strong> (<code>system/scripts/*.ts</code>) are always executed live — the<br>
+engine reads and compiles them on each invocation — so they never need a<br>
+reload.</p>
+</blockquote>
+<h3>Plugin Install Behavior</h3>
+<p>On startup the engine resolves and installs every plugin declared in<br>
+<code>src/plugins/plugins.manifest.json</code> (plus their transitive <code>deps[]</code>). Two<br>
+things to know when editing the manifest:</p>
+<ul>
+<li><strong>Optional <code>deps[].version</code> semver range</strong> — each dep entry may set<br>
+<code>"version": "^1.2.0"</code> (or <code>"&gt;=1.0.0 &lt;2.0.0"</code>, etc.). The installer<br>
+reads the dep’s own <code>ursamu.plugin.json</code> <code>version</code> and aborts the run<br>
+if it doesn’t satisfy the range. Entries without <code>version</code> install<br>
+unconditionally — backwards compatible.</li>
+<li><strong>Fail-fast, whole-manifest rollback</strong> — if any plugin or transitive<br>
+dep fails to clone, has an unsafe name or URL, violates a <code>version</code><br>
+range, or has incompatible ranges from multiple requesters, the entire<br>
+install run aborts. Disk and <code>src/plugins/.registry.json</code> are left<br>
+exactly as they were before the run — your previously installed<br>
+plugins are not touched. The error names which entry failed and why.</li>
+</ul>
+<p>In practice: after editing the manifest, restart the server. If the run<br>
+aborts, fix the offending entry and restart again — there is no partial<br>
+state to clean up.</p>
+<h3>Updating from Git (<code>@update</code>)</h3>
+<p>Admins and wizards can update the running server from in-game without touching<br>
+the terminal:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@update              -- git pull from the default branch (origin/main)
+@update main         -- pull a specific branch
+@upgrade             -- alias for @update
+</code></pre>
+<p>The command:</p>
+<ol>
+<li>Broadcasts <code>%chGame&gt;%cn Updating from git...</code> to all connected players</li>
+<li>Runs <code>git pull origin &lt;branch&gt;</code></li>
+<li>Exits with code 75, which tells the daemon restart loop to reboot the server</li>
+</ol>
+<blockquote>
+<p>Telnet connections survive the reboot — the Telnet sidecar stays up and<br>
+reconnects to the Hub automatically.</p>
+</blockquote>
+<h3>Daemon Restart Loop</h3>
+<p>When started via <code>bash scripts/daemon.sh</code>, the server runs inside a restart<br>
+loop (<code>scripts/main-loop.sh</code>) that watches the process exit code:</p>
+<table>
+<thead>
+<tr>
+<th>Exit code</th>
+<th>Meaning</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>75</code></td>
+<td>Restart signal (<code>@reboot</code>, <code>@update</code>)</td>
+<td>Restart after delay</td>
+</tr>
+<tr>
+<td><code>0</code></td>
+<td>Clean shutdown (<code>@shutdown</code>)</td>
+<td>Stop — do not restart</td>
+</tr>
+<tr>
+<td>Other</td>
+<td>Unexpected crash</td>
+<td>Stop — check logs</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Rapid-restart protection</strong> — if the server exits in under 5 seconds the<br>
+restart delay doubles (1 s → 2 s → 4 s → … capped at 60 s). A stable<br>
+long-running restart resets the delay back to 1 second.</p>
+<p>The deno child PID is written to <code>.ursamu-deno.pid</code>; the loop PID is in<br>
+<code>.ursamu.pid</code>. Use <code>bash scripts/stop.sh</code> to gracefully stop both.</p>
+<h2>Help Administration</h2>
+<p>The <code>help</code> command is provided by the <strong><a href="https://github.com/UrsaMU/help-plugin">help-plugin</a></strong>,<br>
+which aggregates entries from three sources in priority order:</p>
+<table>
+<thead>
+<tr>
+<th>Priority</th>
+<th>Source</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>100</td>
+<td>Database</td>
+<td>Entries created with <code>+help/set</code> — override everything</td>
+</tr>
+<tr>
+<td>50</td>
+<td>Files</td>
+<td>Markdown files in <code>./help/</code> and plugin help dirs</td>
+</tr>
+<tr>
+<td>10</td>
+<td>Commands</td>
+<td>Inline <code>help:</code> fields from <code>addCmd()</code> registrations</td>
+</tr>
+</tbody>
+</table>
+<h3>In-game admin commands</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">+help/set &lt;topic&gt;=&lt;text&gt;   ← create or update a DB entry (Markdown supported)
++help/del &lt;topic&gt;          ← delete a DB entry
++help/reload               ← bust the file cache after adding/removing files
+</code></pre>
+<p>DB entries immediately override any file or command entry with the same slug.<br>
+Use <code>+help/del</code> to restore the underlying file entry.</p>
+<h3>REST API</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">GET    /api/v1/help              ← list all sections and topics
+GET    /api/v1/help/:topic       ← fetch a topic (?format=md for raw Markdown)
+POST   /api/v1/help/:topic       ← create/update (admin token required)
+DELETE /api/v1/help/:topic       ← delete (admin token required)
+</code></pre>
+<h3>Adding help files</h3>
+<p>Drop <code>.md</code> or <code>.txt</code> files in <code>./help/</code> (or a subdirectory) and run<br>
+<code>+help/reload</code> in-game. No restart needed. See <a href="/ursamu/guides/help-authoring/">Writing Help Files</a><br>
+for directory layout and Markdown conventions.</p>
+<hr>
+<h2>Wiki Administration</h2>
+<p>The wiki plugin stores articles as Markdown files in <code>./wiki/</code> with a<br>
+folder-driven URL structure. Admins and wizards manage pages with <code>@wiki</code><br>
+in-game commands.</p>
+<h3>In-game wiki commands</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@wiki/create &lt;path&gt;=&lt;title&gt;/&lt;body&gt;
+  -- Create a new wiki page. Path mirrors the folder structure.
+  -- Example: @wiki/create news/patch-notes=Patch Notes/Details here...
+
+@wiki/edit &lt;path&gt;=&lt;new body&gt;
+  -- Replace the body of an existing page (frontmatter is preserved).
+  -- Example: @wiki/edit news/patch-notes=Updated content here.
+
+@wiki/fetch &lt;url&gt;=&lt;wiki-path&gt;
+  -- Download an image or PDF from a public URL into the wiki folder.
+  -- Example: @wiki/fetch https://example.com/map.png=maps/world.png
+  -- Allowed types: .jpg .jpeg .png .gif .webp .svg .pdf (max 10 MB)
+</code></pre>
+<blockquote>
+<p><strong>Security note:</strong> <code>@wiki/fetch</code> blocks private/loopback/link-local IP<br>
+ranges (localhost, 127.x, 10.x, 192.168.x, etc.) to prevent SSRF attacks.<br>
+Only publicly routable URLs are permitted.</p>
+</blockquote>
+<h3>Wiki REST API</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Endpoint</th>
+<th>Auth</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Required</td>
+<td>List all pages (title + path)</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki?q=&lt;query&gt;</code></td>
+<td>Required</td>
+<td>Full-text search (title, body, tags)</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Required</td>
+<td>Read a page or list a directory</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/&lt;path.ext&gt;</code></td>
+<td>Required</td>
+<td>Serve a static asset (image, PDF)</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Staff</td>
+<td>Create a page</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Staff</td>
+<td>Update body and/or frontmatter</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Staff</td>
+<td>Delete a page or asset</td>
+</tr>
+<tr>
+<td><code>PUT</code></td>
+<td><code>/api/v1/wiki/&lt;path.ext&gt;</code></td>
+<td>Staff</td>
+<td>Upload a static asset (binary)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example — create a page:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST https://yourgame.example.com/api/v1/wiki \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "news/patch-notes",
+    "title": "Patch Notes",
+    "date": "2026-03-18",
+    "body": "## Changes\n- Added new location."
+  }'
+</code></pre>
+<p><strong>Wiki page frontmatter format:</strong></p>
+<pre class="language-yaml" tabindex="0"><code class="language-yaml">---
+title: My Page Title
+date: 2026-03-18
+author: Admin
+tags: [news, update]
+---
+
+Page body in Markdown here.
+</code></pre>
+<h2>All metadata keys must match <code>/^[\w-]+$/</code>. Body size limit is <strong>10 MB</strong>.</h2>
 <h2>Scene Management</h2>
 <p>Scenes are collaborative roleplay logs. They can be exported via the HTTP API.</p>
 <h3>Exporting a Scene</h3>
@@ -509,7 +766,7 @@ curl -H "Authorization: Bearer &lt;token&gt;" \
 <h2>REST API Reference</h2>
 <p>All endpoints are served on the Hub’s HTTP port (default <code>4203</code>). Most require<br>
 a <code>Bearer</code> JWT token in the <code>Authorization</code> header, obtained from<br>
-<code>POST /api/v1/auth/login</code>.</p>
+<code>POST /api/v1/auth</code>.</p>
 <h3>Authentication</h3>
 <table>
 <thead>
@@ -522,13 +779,18 @@ a <code>Bearer</code> JWT token in the <code>Authorization</code> header, obtain
 <tbody>
 <tr>
 <td><code>POST</code></td>
-<td><code>/api/v1/auth/login</code></td>
+<td><code>/api/v1/auth</code></td>
 <td>Returns <code>{ token }</code></td>
 </tr>
 <tr>
 <td><code>POST</code></td>
 <td><code>/api/v1/auth/register</code></td>
 <td>Create a new character</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/auth/reset-password</code></td>
+<td>Consume a reset token and set a new password</td>
 </tr>
 <tr>
 <td><code>GET</code></td>
@@ -694,9 +956,101 @@ a <code>Bearer</code> JWT token in the <code>Authorization</code> header, obtain
 <td>List scenes</td>
 </tr>
 <tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Create a scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/locations</code></td>
+<td>List accessible rooms</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Scene detail</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Update name, desc, status, sceneType</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/pose</code></td>
+<td>Add a pose/ooc/set entry</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id/pose/:poseId</code></td>
+<td>Edit a pose</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/join</code></td>
+<td>Join a scene</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/invite</code></td>
+<td>Invite a player</td>
+</tr>
+<tr>
 <td><code>GET</code></td>
 <td><code>/api/v1/scenes/:id/export</code></td>
 <td>Export as <code>?format=markdown</code> or <code>?format=json</code></td>
+</tr>
+</tbody>
+</table>
+<h3>Wiki</h3>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Endpoint</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>List all pages</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki?q=&lt;query&gt;</code></td>
+<td>Full-text search</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Read page or directory listing</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/&lt;path.ext&gt;</code></td>
+<td>Serve static asset</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Create page <em>(staff)</em></td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Update page <em>(staff)</em></td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/wiki/&lt;path&gt;</code></td>
+<td>Delete page or asset <em>(staff)</em></td>
+</tr>
+<tr>
+<td><code>PUT</code></td>
+<td><code>/api/v1/wiki/&lt;path.ext&gt;</code></td>
+<td>Upload static asset <em>(staff)</em></td>
 </tr>
 </tbody>
 </table>
@@ -706,13 +1060,12 @@ sending <code>connect &lt;name&gt; &lt;password&gt;</code> as your first message
 JWT at connection time:</p>
 <pre class="language-none" tabindex="0"><code class="language-none">ws://host:4203?token=&lt;jwt&gt;&amp;client=web
 </code></pre>
-<p>The <code>client=web</code> parameter enables rich JSON payloads instead of plain text.</p>
-<hr>
+<h2>The <code>client=web</code> parameter enables rich JSON payloads instead of plain text.</h2>
 <h2>Troubleshooting</h2>
 <h3>Common Issues</h3>
 <h4>Server Won’t Start</h4>
 <ul>
-<li>Check if a port is already in use (<code>4201</code>, <code>4202</code>, <code>4203</code>, or <code>8000</code>)</li>
+<li>Check if a port is already in use (<code>4201</code>, <code>4202</code>, <code>4203</code>)</li>
 <li>Ensure Deno is installed and up to date (<code>deno upgrade</code>)</li>
 <li>Check for errors in configuration output (<code>deno task config</code>)</li>
 </ul>
@@ -720,32 +1073,71 @@ JWT at connection time:</p>
 <ul>
 <li>Confirm the Hub is running (<code>deno task server</code>)</li>
 <li>For Telnet clients, confirm the Telnet sidecar is running (<code>deno task telnet</code>)</li>
-<li>For the web client, confirm it is running (<code>deno task start</code> in<br>
-<code>src/web-client/</code>)</li>
 </ul>
 <h4>Permission Denied Errors</h4>
 <ul>
 <li>Verify the player has the correct flags set (<code>@set &lt;player&gt;=admin</code>)</li>
-<li>The <code>wizard</code> flag can only be set by a superuser at the database level</li>
+<li>The <code>wizard</code> flag can only be granted by a <strong>superuser</strong> (<code>@set &lt;player&gt;=wizard</code>)</li>
 </ul>
 <h3>Logs</h3>
 <p>UrsaMU logs to stdout/stderr. Redirect output to a file if you need persistent<br>
 logs:</p>
 <pre class="language-bash" tabindex="0"><code class="language-bash">deno task server &gt; logs/server.log 2&gt;&amp;1
 </code></pre>
+<h2>Password Reset</h2>
+<p>See the full <a href="/ursamu/guides/password-reset/">Password Reset guide</a> for the step-by-step<br>
+flow. In brief:</p>
+<ol>
+<li>Run <code>@resettoken &lt;player&gt;</code> in-game — a UUID token is printed to your session</li>
+<li>Pass the token to the player out-of-band (Discord, email, etc.)</li>
+<li>The player calls <code>POST /api/v1/auth/reset-password</code> with <code>{ token, newPassword }</code></li>
+<li>The token is single-use and expires after <strong>1 hour</strong></li>
+</ol>
+<hr>
 <h2>Security</h2>
 <h3>Securing Your Server</h3>
 <ul>
-<li>Place the Hub behind a reverse proxy (e.g., nginx) for TLS termination</li>
-<li>Set up a firewall to limit external access to only the necessary ports</li>
+<li>Place the Hub behind a reverse proxy (e.g., nginx, Caddy) for TLS termination</li>
+<li>Set up a firewall to limit external access to only the necessary ports (<code>4201</code>, <code>4202</code>, <code>4203</code>)</li>
 <li>Keep Deno and dependencies updated</li>
+<li>Set a strong <code>JWT_SECRET</code> environment variable before starting (see below)</li>
 <li>Use strong passwords — the <code>auth.hash</code> SDK method uses bcrypt</li>
 </ul>
+<h3>JWT Secret</h3>
+<p>UrsaMU signs session tokens with a secret key. Set it via environment variable<br>
+before starting the server:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">export JWT_SECRET="your-long-random-secret-here"
+deno task start
+</code></pre>
+<p>If <code>JWT_SECRET</code> is not set, a random secret is generated at startup and a<br>
+warning is printed. This means all sessions are invalidated on restart.</p>
+<h3>Brute-Force Login Protection</h3>
+<p>The login endpoint (<code>POST /api/v1/auth</code>) enforces a per-IP rate limit of<br>
+<strong>10 failed attempts per minute</strong>. After that threshold is reached the server<br>
+returns <code>429 Too Many Requests</code> and logs the event to <code>logs/security.log</code>.</p>
+<h3>Security Headers</h3>
+<p>All HTTP responses include hardening headers:</p>
+<ul>
+<li><code>X-Content-Type-Options: nosniff</code></li>
+<li><code>X-Frame-Options: DENY</code></li>
+<li><code>Referrer-Policy: strict-origin-when-cross-origin</code></li>
+</ul>
+<h3>Security Logging</h3>
+<p>Security events are written to <code>logs/security.log</code>:</p>
+<ul>
+<li><code>LOGIN_FAILED</code> — wrong password</li>
+<li><code>LOGIN_RATE_LIMITED</code> — IP blocked after too many failures</li>
+<li><code>PASSWORD_RESET</code> — password reset token consumed</li>
+<li><code>ADMIN_BOOT</code>, <code>ADMIN_TOAD</code>, <code>ADMIN_NEWPASSWORD</code> — admin user management actions</li>
+<li><code>ADMIN_SITE_SET</code>, <code>ADMIN_SITE_BLOCKED</code> — <code>@site</code> command activity</li>
+<li><code>ADMIN_RESETTOKEN</code> — reset token generation</li>
+</ul>
 <h3>The <code>wizard</code> Flag</h3>
-<p>The <code>wizard</code> flag is locked to <strong>superuser</strong> level and cannot be granted by<br>
-regular admins. It is intended for server owners who need a permanent,<br>
-unforgeable high-privilege account. Set it directly at the database level during<br>
-initial setup.</p>
+<p>The <code>wizard</code> flag sits at the same permission level as <code>admin</code> (level 9) but<br>
+can only be granted by a <strong>superuser</strong>. Regular admins cannot elevate another<br>
+player to wizard. Grant it with:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@set &lt;player&gt;=wizard
+</code></pre>
 
       </article>
 
@@ -794,11 +1186,49 @@ initial setup.</p>
       
         
           
+        
+      
+        
           
         
       
         
           
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -842,9 +1272,9 @@ initial setup.</p>
         
 
         
-          <a href="/ursamu/guides/customization/" class="page-nav-btn next">
+          <a href="/ursamu/guides/cli/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">Customization Guide</span>
+            <span class="page-nav-title">CLI Reference</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/cli/index.html
+++ b/docs/_site/guides/cli/index.html
@@ -1,0 +1,696 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CLI Reference | UrsaMU Documentation</title>
+  <meta name="description" content="Complete reference for the UrsaMU command-line interface — create projects, scaffold plugins, and manage packages.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/cli/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">CLI Reference</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>CLI Reference</h1>
+<p>The CLI ships as <strong><code>jsr:@ursamu/cli</code></strong>. No global install required —<br>
+run it with <code>deno run</code>.</p>
+<p>Pin a known release in scripts and docs:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/&lt;export&gt; …
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Export</th>
+<th>Entry</th>
+<th>Use</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>/create</code></td>
+<td>project + plugin scaffold</td>
+<td>everyday</td>
+</tr>
+<tr>
+<td><code>/ursamu</code></td>
+<td>interactive menu</td>
+<td>package picker, helpers</td>
+</tr>
+<tr>
+<td><code>/update</code></td>
+<td>bump engine import</td>
+<td>existing games</td>
+</tr>
+<tr>
+<td><code>/plugin</code></td>
+<td>manifest plugin ops</td>
+<td>git plugins</td>
+</tr>
+<tr>
+<td><code>/start</code></td>
+<td>supervised start helper</td>
+<td>advanced</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>create</h2>
+<h3>New game project</h3>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/create &lt;project-name&gt;
+deno run -A jsr:@ursamu/cli@0.1.2/create &lt;project-name&gt; --local
+</code></pre>
+<p>Creates a directory with a supervised UrsaMU game:</p>
+<ul>
+<li><code>main.ts</code> / telnet entry — boot <code>@ursamu/mush</code></li>
+<li><code>config/config.json</code> — ports + default portal plugins</li>
+<li><code>deno.json</code> — import map + tasks</li>
+<li><code>.env</code> — generated <code>JWT_SECRET</code></li>
+<li><code>scripts/daemon.sh</code> (and stop/restart/status)</li>
+<li>Default plugins: builder, channels, help, bbs, mail, wiki,<br>
+<strong>web</strong>, <strong>site</strong> (<code>serveRoot: true</code>)</li>
+</ul>
+<p><code>--local</code> points imports at a monorepo checkout instead of JSR.</p>
+<h3>In-tree plugin</h3>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/create plugin &lt;name&gt;
+</code></pre>
+<p>Run from a game project root. Options:</p>
+<table>
+<thead>
+<tr>
+<th>Flag</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>--standalone</code></td>
+<td>Separate publishable plugin repo</td>
+</tr>
+<tr>
+<td><code>--admin-embed</code> / <code>-A</code></td>
+<td>Staff page under <code>/admin/&lt;name&gt;/</code></td>
+</tr>
+<tr>
+<td><code>--site-static</code> / <code>-S</code></td>
+<td>Public page at <code>/site/p/&lt;name&gt;/</code></td>
+</tr>
+<tr>
+<td><code>--non-interactive</code></td>
+<td>CI-friendly (no prompts)</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Interactive menu</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/ursamu
+</code></pre>
+<p>Create games/plugins, manage packages, update the engine, and edit<br>
+shell scripts from a simple numbered menu.</p>
+<hr>
+<h2>plugin</h2>
+<p>Manage git-based entries in <code>plugins.manifest.json</code> (when used):</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/plugin list
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install &lt;github-url&gt;
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install &lt;github-url&gt; --ref v1.2.0
+deno run -A jsr:@ursamu/cli@0.1.2/plugin update &lt;name&gt;
+deno run -A jsr:@ursamu/cli@0.1.2/plugin remove &lt;name&gt;
+deno run -A jsr:@ursamu/cli@0.1.2/plugin info &lt;name&gt;
+deno run -A jsr:@ursamu/cli@0.1.2/plugin search &lt;query&gt;
+</code></pre>
+<p>Most new games load official packages via <strong>JSR</strong> in<br>
+<code>config.json</code> → <code>server.plugins</code> and the import map — prefer that for<br>
+<code>@ursamu/help</code>, <code>@ursamu/bbs</code>, <code>@ursamu/site</code>, etc.</p>
+<h3>Install behavior</h3>
+<p>Fail-fast installs with whole-run rollback on unsafe names/URLs,<br>
+clone failures, or semver conflicts. See<br>
+<a href="/ursamu/guides/admin-guide/#plugin-install-behavior">Admin Guide → Plugin Install Behavior</a>.</p>
+<hr>
+<h2>update</h2>
+<p>Bump the engine import in an existing game:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/update
+deno run -A jsr:@ursamu/cli@0.1.2/update --dry-run
+</code></pre>
+<hr>
+<h2>scripts</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/scripts list
+</code></pre>
+<p>Lists registered script names/aliases (engine + plugins).</p>
+<hr>
+<h2>config (game task)</h2>
+<p>Inside a scaffolded project:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task config
+deno task config --get server.apiPort
+deno task config --set game.name "My Game"
+</code></pre>
+<hr>
+<h2>Optional global install</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno install -Ag -n ursamu jsr:@ursamu/cli@0.1.2/ursamu
+# or create only:
+deno install -Ag -n ursamu-create jsr:@ursamu/cli@0.1.2/create
+</code></pre>
+<p>Then: <code>ursamu</code> / <code>ursamu-create my-game</code>.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/admin-guide/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Admin Guide</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/commands/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Command Reference</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/commands/index.html
+++ b/docs/_site/guides/commands/index.html
@@ -1,0 +1,1176 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Command Reference | UrsaMU Documentation</title>
+  <meta name="description" content="Complete reference for all built-in UrsaMU in-game commands — player, channel, mail, bulletin boards, building, and admin.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/commands/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Command Reference</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Command Reference</h1>
+<h2>All built-in commands available in UrsaMU. Commands marked <strong>admin+</strong> require the <code>admin</code> or <code>wizard</code> flag. Commands marked <strong>builder+</strong> require <code>builder</code> or above.</h2>
+<h2>Player Commands</h2>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>look</code> / <code>l</code></td>
+<td>Look at your surroundings or a named object</td>
+</tr>
+<tr>
+<td><code>say &lt;msg&gt;</code> / <code>"&lt;msg&gt;</code></td>
+<td>Speak to everyone in the room</td>
+</tr>
+<tr>
+<td><code>pose &lt;action&gt;</code> / <code>:&lt;action&gt;</code></td>
+<td>Emote an action</td>
+</tr>
+<tr>
+<td><code>;</code></td>
+<td>Pose without a space (possessive — <code>Alice;'s phone rings</code>)</td>
+</tr>
+<tr>
+<td><code>think &lt;msg&gt;</code></td>
+<td>Private message visible only to you</td>
+</tr>
+<tr>
+<td><code>page &lt;player&gt;=&lt;msg&gt;</code></td>
+<td>Send a private message to any online player</td>
+</tr>
+<tr>
+<td><code>page &lt;player&gt;=:&lt;pose&gt;</code></td>
+<td>Page with a pose (<code>From afar, Alice waves.</code>)</td>
+</tr>
+<tr>
+<td><code>who</code></td>
+<td>List currently connected players</td>
+</tr>
+<tr>
+<td><code>@doing &lt;text&gt;</code></td>
+<td>Set your status message shown in <code>who</code></td>
+</tr>
+<tr>
+<td><code>@away [&lt;text&gt;]</code></td>
+<td>Set or clear an away message shown when paged</td>
+</tr>
+<tr>
+<td><code>@last [&lt;player&gt;]</code></td>
+<td>Show last login/logout timestamps</td>
+</tr>
+<tr>
+<td><code>inventory</code> / <code>i</code></td>
+<td>List items you are carrying</td>
+</tr>
+<tr>
+<td><code>score</code></td>
+<td>View your character stats</td>
+</tr>
+<tr>
+<td><code>get &lt;object&gt;</code></td>
+<td>Pick up an object</td>
+</tr>
+<tr>
+<td><code>drop &lt;object&gt;</code></td>
+<td>Drop an object</td>
+</tr>
+<tr>
+<td><code>give &lt;object&gt;=&lt;player&gt;</code></td>
+<td>Give an object to another player</td>
+</tr>
+<tr>
+<td><code>home</code></td>
+<td>Return to your home location</td>
+</tr>
+<tr>
+<td><code>@teleport &lt;destination&gt;</code></td>
+<td>Teleport to a location or object (builder+)</td>
+</tr>
+<tr>
+<td><code>examine &lt;object&gt;</code> / <code>ex</code></td>
+<td>Inspect an object in detail</td>
+</tr>
+<tr>
+<td><code>@desc &lt;object&gt;=&lt;text&gt;</code></td>
+<td>Set an object’s description</td>
+</tr>
+<tr>
+<td><code>@name &lt;object&gt;=&lt;name&gt;</code></td>
+<td>Rename an object</td>
+</tr>
+<tr>
+<td><code>whisper &lt;player&gt;=&lt;msg&gt;</code></td>
+<td>Private in-room message; others see attribution only</td>
+</tr>
+<tr>
+<td><code>quit</code></td>
+<td>Disconnect from the server</td>
+</tr>
+<tr>
+<td><code>@version</code></td>
+<td>Show the engine version</td>
+</tr>
+<tr>
+<td><code>@poll</code></td>
+<td>Show the current poll, if any</td>
+</tr>
+<tr>
+<td><code>help [&lt;topic&gt;]</code></td>
+<td>Display help text (provided by <a href="https://github.com/UrsaMU/help-plugin">help-plugin</a>)</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Channel Commands</h2>
+<p>Channels are provided by the <a href="https://github.com/UrsaMU/channel-plugin">channel-plugin</a>.<br>
+Players join channels and get a short alias to speak with.</p>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@channel/list</code></td>
+<td>List all available channels</td>
+</tr>
+<tr>
+<td><code>@channel/join &lt;name&gt;=&lt;alias&gt;</code></td>
+<td>Join a channel and assign a local alias</td>
+</tr>
+<tr>
+<td><code>@channel/leave &lt;alias&gt;</code></td>
+<td>Leave a channel by alias</td>
+</tr>
+<tr>
+<td><code>&lt;alias&gt; &lt;message&gt;</code></td>
+<td>Send a message on that channel</td>
+</tr>
+<tr>
+<td><code>&lt;alias&gt; :&lt;pose&gt;</code></td>
+<td>Pose on the channel</td>
+</tr>
+<tr>
+<td><code>&lt;alias&gt; on</code></td>
+<td>Re-activate a channel you temporarily left</td>
+</tr>
+<tr>
+<td><code>&lt;alias&gt; off</code></td>
+<td>Temporarily stop receiving a channel</td>
+</tr>
+<tr>
+<td><code>@addcom &lt;alias&gt;=&lt;channel&gt;</code></td>
+<td>Add a channel alias (TinyMUX-style)</td>
+</tr>
+<tr>
+<td><code>@delcom &lt;alias&gt;</code></td>
+<td>Remove a channel alias</td>
+</tr>
+<tr>
+<td><code>@allcom</code></td>
+<td>List all your channel aliases</td>
+</tr>
+<tr>
+<td><code>@clearcom</code></td>
+<td>Remove all your channel aliases</td>
+</tr>
+<tr>
+<td><code>@comtitle &lt;alias&gt;=&lt;title&gt;</code></td>
+<td>Set a display title prefix for a channel</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Mail Commands</h2>
+<p>Mail is provided by the <a href="https://github.com/UrsaMU/mail-plugin">mail-plugin</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@mail</code></td>
+<td>Show your inbox</td>
+</tr>
+<tr>
+<td><code>@mail/send &lt;to&gt;=&lt;subject&gt;/&lt;body&gt;</code></td>
+<td>Send a mail message</td>
+</tr>
+<tr>
+<td><code>@mail/read &lt;num&gt;</code></td>
+<td>Read a message (marks as read)</td>
+</tr>
+<tr>
+<td><code>@mail/reply &lt;num&gt;=&lt;body&gt;</code></td>
+<td>Reply to a message</td>
+</tr>
+<tr>
+<td><code>@mail/replyall &lt;num&gt;=&lt;body&gt;</code></td>
+<td>Reply to all recipients</td>
+</tr>
+<tr>
+<td><code>@mail/forward &lt;num&gt;=&lt;to&gt;</code></td>
+<td>Forward a message</td>
+</tr>
+<tr>
+<td><code>@mail/cc &lt;addr&gt;</code></td>
+<td>Add a CC recipient while composing</td>
+</tr>
+<tr>
+<td><code>@mail/bcc &lt;addr&gt;</code></td>
+<td>Add a BCC recipient while composing</td>
+</tr>
+<tr>
+<td><code>@mail/subject &lt;text&gt;</code></td>
+<td>Set subject while composing</td>
+</tr>
+<tr>
+<td><code>@mail/proof</code></td>
+<td>Preview the message being composed</td>
+</tr>
+<tr>
+<td><code>@mail/abort</code></td>
+<td>Discard the message being composed</td>
+</tr>
+<tr>
+<td><code>@mail/delete &lt;num&gt;</code></td>
+<td>Delete a message</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Bulletin Board Commands</h2>
+<p>Bulletin boards are provided by the <a href="https://github.com/UrsaMU/bbs-plugin">bbs-plugin</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>+bblist</code></td>
+<td>List all bulletin boards with post and unread counts</td>
+</tr>
+<tr>
+<td><code>+bbread &lt;board&gt;</code></td>
+<td>List posts on a board</td>
+</tr>
+<tr>
+<td><code>+bbread &lt;board&gt;/&lt;num&gt;</code></td>
+<td>Read a specific post</td>
+</tr>
+<tr>
+<td><code>+bbpost &lt;board&gt;=&lt;subject&gt;/&lt;body&gt;</code></td>
+<td>Post to a board</td>
+</tr>
+<tr>
+<td><code>+bbpost/edit &lt;board&gt;/&lt;num&gt;=&lt;body&gt;</code></td>
+<td>Edit your own post</td>
+</tr>
+<tr>
+<td><code>+bbpost/delete &lt;board&gt;/&lt;num&gt;</code></td>
+<td>Delete your own post</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Building Commands</h2>
+<p>Building commands are provided by the <a href="https://github.com/UrsaMU/builder-plugin">builder-plugin</a>. Requires <code>builder+</code> flag unless noted.</p>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@dig &lt;name&gt;</code></td>
+<td>Create a new room</td>
+</tr>
+<tr>
+<td><code>@create &lt;name&gt;</code></td>
+<td>Create a new object</td>
+</tr>
+<tr>
+<td><code>@open &lt;exit&gt;=&lt;dest&gt;</code></td>
+<td>Create an exit to another room</td>
+</tr>
+<tr>
+<td><code>@link &lt;object&gt;=&lt;dest&gt;</code></td>
+<td>Link an exit or set home/dropto</td>
+</tr>
+<tr>
+<td><code>@unlink &lt;object&gt;</code></td>
+<td>Remove a link from an object</td>
+</tr>
+<tr>
+<td><code>@clone &lt;object&gt;</code></td>
+<td>Clone an existing object</td>
+</tr>
+<tr>
+<td><code>@destroy &lt;object&gt;</code></td>
+<td>Destroy an object</td>
+</tr>
+<tr>
+<td><code>@alias &lt;object&gt;=&lt;alias&gt;</code></td>
+<td>Set an alias on an object</td>
+</tr>
+<tr>
+<td><code>@parent &lt;object&gt;=&lt;parent&gt;</code></td>
+<td>Set an object’s parent</td>
+</tr>
+<tr>
+<td><code>@parent/clear &lt;object&gt;</code></td>
+<td>Clear an object’s parent</td>
+</tr>
+<tr>
+<td><code>@lock &lt;object&gt;=&lt;expr&gt;</code></td>
+<td>Set a lock expression on an object</td>
+</tr>
+<tr>
+<td><code>@unlock &lt;object&gt;</code></td>
+<td>Remove a lock from an object</td>
+</tr>
+<tr>
+<td><code>@set &lt;object&gt;=&lt;flag&gt;</code></td>
+<td>Set a flag on an object</td>
+</tr>
+<tr>
+<td><code>@set &lt;object&gt;=&lt;attr&gt;:&lt;value&gt;</code></td>
+<td>Set an attribute on an object</td>
+</tr>
+<tr>
+<td><code>&amp;&lt;ATTR&gt; &lt;object&gt;=&lt;value&gt;</code></td>
+<td>Shorthand attribute assignment</td>
+</tr>
+<tr>
+<td><code>@wipe &lt;object&gt;</code></td>
+<td>Remove all attributes from an object</td>
+</tr>
+<tr>
+<td><code>@trigger &lt;object&gt;/&lt;attr&gt;</code></td>
+<td>Execute a stored script attribute</td>
+</tr>
+<tr>
+<td><code>@nameformat &lt;object&gt;=&lt;format&gt;</code></td>
+<td>Custom name format</td>
+</tr>
+<tr>
+<td><code>@descformat &lt;object&gt;=&lt;format&gt;</code></td>
+<td>Custom description format</td>
+</tr>
+<tr>
+<td><code>@conformat &lt;object&gt;=&lt;format&gt;</code></td>
+<td>Custom contents format</td>
+</tr>
+<tr>
+<td><code>@exitformat &lt;object&gt;=&lt;format&gt;</code></td>
+<td>Custom exits format</td>
+</tr>
+<tr>
+<td><code>@decompile[/tf] &lt;object&gt;</code></td>
+<td>Dump object as copyable <code>@name</code>/<code>&amp;ATTR</code> lines</td>
+</tr>
+<tr>
+<td><code>@find [&lt;name&gt;]</code></td>
+<td>Search objects by name or flag</td>
+</tr>
+<tr>
+<td><code>@quota</code></td>
+<td>Show your object creation quota</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Admin Commands</h2>
+<p>Requires <code>admin</code> or <code>wizard</code> flag unless noted.</p>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@boot &lt;player&gt;</code></td>
+<td>Disconnect a player</td>
+</tr>
+<tr>
+<td><code>@toad &lt;player&gt;</code></td>
+<td>Convert a player to an object</td>
+</tr>
+<tr>
+<td><code>@newpassword &lt;player&gt;=&lt;pass&gt;</code></td>
+<td>Reset a player’s password</td>
+</tr>
+<tr>
+<td><code>@chown &lt;object&gt;=&lt;player&gt;</code></td>
+<td>Transfer ownership of an object</td>
+</tr>
+<tr>
+<td><code>@moniker &lt;object&gt;=&lt;name&gt;</code></td>
+<td>Set an alternate display name</td>
+</tr>
+<tr>
+<td><code>@emit &lt;message&gt;</code></td>
+<td>Attributed room-wide message</td>
+</tr>
+<tr>
+<td><code>@remit &lt;message&gt;</code></td>
+<td>Unattributed room-wide message</td>
+</tr>
+<tr>
+<td><code>@pemit &lt;player&gt;=&lt;message&gt;</code></td>
+<td>Send directly to a player</td>
+</tr>
+<tr>
+<td><code>@cemit &lt;channel&gt;=&lt;message&gt;</code></td>
+<td>Unattributed channel broadcast</td>
+</tr>
+<tr>
+<td><code>@fsay &lt;object&gt;=&lt;message&gt;</code></td>
+<td>Force-speak as an owned object</td>
+</tr>
+<tr>
+<td><code>@fpose &lt;object&gt;=&lt;action&gt;</code></td>
+<td>Force-pose as an owned object</td>
+</tr>
+<tr>
+<td><code>@femit &lt;object&gt;=&lt;message&gt;</code></td>
+<td>Force-emit as an owned object</td>
+</tr>
+<tr>
+<td><code>@npemit &lt;player&gt;=&lt;message&gt;</code></td>
+<td>Send to a player with no prefix</td>
+</tr>
+<tr>
+<td><code>@motd</code></td>
+<td>Show the message of the day</td>
+</tr>
+<tr>
+<td><code>@motd/set &lt;text&gt;</code></td>
+<td>Set the message of the day</td>
+</tr>
+<tr>
+<td><code>@motd/clear</code></td>
+<td>Clear the message of the day</td>
+</tr>
+<tr>
+<td><code>@stats [/full]</code></td>
+<td>Show server statistics</td>
+</tr>
+<tr>
+<td><code>@search [&lt;flags&gt;]</code></td>
+<td>Search objects server-wide</td>
+</tr>
+<tr>
+<td><code>@quota &lt;player&gt;=&lt;num&gt;</code></td>
+<td>Set a player’s object quota</td>
+</tr>
+<tr>
+<td><code>@sweep</code></td>
+<td>Remove all non-player objects from a room</td>
+</tr>
+<tr>
+<td><code>@entrances [&lt;object&gt;]</code></td>
+<td>List all objects that link to an object</td>
+</tr>
+<tr>
+<td><code>@halt [&lt;player&gt;]</code></td>
+<td>Cancel queued actions (own or target’s if admin)</td>
+</tr>
+<tr>
+<td><code>@switch[/first] &lt;val&gt;=&lt;case&gt;,&lt;cmd&gt;,...</code></td>
+<td>Case-branch command execution</td>
+</tr>
+<tr>
+<td><code>@dolist &lt;list&gt;=&lt;action&gt;</code></td>
+<td>Iterate a space-delimited list; execute action per item (<code>##</code> = item, <code>#@</code> = index)</td>
+</tr>
+<tr>
+<td><code>@if &lt;expr&gt;=&lt;true&gt;[,&lt;false&gt;]</code></td>
+<td>Conditional execution</td>
+</tr>
+<tr>
+<td><code>@while &lt;expr&gt;=&lt;action&gt;</code></td>
+<td>Loop while expression is true</td>
+</tr>
+<tr>
+<td><code>@break</code></td>
+<td>Exit the current <code>@dolist</code> or <code>@while</code> loop</td>
+</tr>
+<tr>
+<td><code>@wait &lt;seconds&gt;=&lt;action&gt;</code></td>
+<td>Delay an action by N seconds</td>
+</tr>
+<tr>
+<td><code>@assert &lt;condition&gt;</code></td>
+<td>Abort trigger chain if condition is false</td>
+</tr>
+<tr>
+<td><code>@zone &lt;object&gt;=&lt;zone master&gt;</code></td>
+<td>Assign an object to a zone master</td>
+</tr>
+<tr>
+<td><code>@zone &lt;object&gt;=</code></td>
+<td>Clear zone assignment</td>
+</tr>
+<tr>
+<td><code>@function &lt;name&gt;=&lt;obj&gt;/&lt;attr&gt;</code></td>
+<td>Define a global softcode user function</td>
+</tr>
+<tr>
+<td><code>@cpattr &lt;src&gt;/&lt;attr&gt;=&lt;dst&gt;[/&lt;newname&gt;]</code></td>
+<td>Copy an attribute to another object</td>
+</tr>
+<tr>
+<td><code>@mvattr &lt;src&gt;/&lt;attr&gt;=&lt;dst&gt;[/&lt;newname&gt;]</code></td>
+<td>Move an attribute to another object</td>
+</tr>
+<tr>
+<td><code>@grep &lt;obj&gt;=&lt;pattern&gt;</code></td>
+<td>Search object attributes by name pattern</td>
+</tr>
+<tr>
+<td><code>@ps</code></td>
+<td>List all pending <code>@wait</code> jobs</td>
+</tr>
+<tr>
+<td><code>@drain &lt;obj&gt;</code></td>
+<td>Cancel all pending <code>@wait</code> jobs on an object</td>
+</tr>
+<tr>
+<td><code>@notify &lt;obj&gt;[/&lt;sem&gt;][=&lt;count&gt;]</code></td>
+<td>Signal a semaphore (<code>@wait/until</code>)</td>
+</tr>
+<tr>
+<td><code>@reboot</code></td>
+<td>Restart the server</td>
+</tr>
+<tr>
+<td><code>@shutdown</code></td>
+<td>Shut down the server</td>
+</tr>
+<tr>
+<td><code>@site &lt;key&gt;=&lt;value&gt;</code></td>
+<td>Set a server configuration value</td>
+</tr>
+<tr>
+<td><code>@resettoken &lt;player&gt;</code></td>
+<td>Generate a password-reset token for a player</td>
+</tr>
+<tr>
+<td><code>@chancreate &lt;name&gt;[=&lt;header&gt;]</code></td>
+<td>Create a channel</td>
+</tr>
+<tr>
+<td><code>@chandestroy &lt;name&gt;</code></td>
+<td>Destroy a channel</td>
+</tr>
+<tr>
+<td><code>@chanset &lt;name&gt;/&lt;prop&gt;=&lt;value&gt;</code></td>
+<td>Configure a channel</td>
+</tr>
+<tr>
+<td><code>+bbcreate &lt;name&gt;[=&lt;description&gt;]</code></td>
+<td>Create a bulletin board</td>
+</tr>
+<tr>
+<td><code>+bbdestroy &lt;board&gt;</code></td>
+<td>Destroy a bulletin board</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Plugin Commands</h2>
+<p>Commands provided by official plugins are documented in their respective repos.</p>
+<table>
+<thead>
+<tr>
+<th>Plugin</th>
+<th>Commands</th>
+<th>Docs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>jobs</strong></td>
+<td><code>+job</code>, <code>+jobs</code>, <code>+job/create</code>, etc.</td>
+<td><a href="https://github.com/UrsaMU/jobs-plugin#commands">UrsaMU/jobs-plugin</a></td>
+</tr>
+<tr>
+<td><strong>events</strong></td>
+<td><code>+event</code>, <code>+events</code></td>
+<td><a href="https://github.com/UrsaMU/events-plugin#commands">UrsaMU/events-plugin</a></td>
+</tr>
+<tr>
+<td><strong>discord</strong></td>
+<td>Bridge only — no in-game commands</td>
+<td><a href="https://github.com/UrsaMU/discord-plugin">UrsaMU/discord-plugin</a></td>
+</tr>
+</tbody>
+</table>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/cli/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">CLI Reference</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/customization/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Customization Guide</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/customization/index.html
+++ b/docs/_site/guides/customization/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Customization Guide | UrsaMU Documentation</title>
-  <meta name="description" content="Learn how to customize your UrsaMU server">
+  <meta name="description" content="How to customize UrsaMU — MUSH colors, custom commands, plugins, REST routes, and external integrations.">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,176 +268,489 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Customization Guide</h1>
-<p>This guide covers how to customize your UrsaMU server to create a unique<br>
-experience for your players.</p>
-<h2>Themes</h2>
-<h3>Visual Themes</h3>
-<p>UrsaMU supports customizable visual themes for the web interface:</p>
-<ol>
-<li>Create a new theme directory in <code>themes/</code></li>
-<li>Create CSS files for your theme</li>
-<li>Configure your theme in <code>config.json</code>:<pre class="language-json" tabindex="0"><code class="language-json">"theme": {
-  "name": "your-theme-name",
-  "options": {
-    "primaryColor": "#3498db",
-    "secondaryColor": "#2ecc71"
-  }
-}
+<h2>This guide covers the real extension points for UrsaMU — the patterns you<br>
+actually use to add commands, store per-object data, build plugins, and connect<br>
+to outside services.</h2>
+<h2>Text Formatting</h2>
+<p>UrsaMU uses MUSH-style substitution codes for in-game text. They work in any<br>
+string you pass to <code>u.send()</code>, <code>u.broadcast()</code>, or stored in a help file.</p>
+<h3>Color codes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Color / Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>%cr</code></td>
+<td>Red</td>
+</tr>
+<tr>
+<td><code>%cg</code></td>
+<td>Green</td>
+</tr>
+<tr>
+<td><code>%cy</code></td>
+<td>Yellow</td>
+</tr>
+<tr>
+<td><code>%cb</code></td>
+<td>Blue</td>
+</tr>
+<tr>
+<td><code>%cm</code></td>
+<td>Magenta</td>
+</tr>
+<tr>
+<td><code>%cw</code></td>
+<td>White</td>
+</tr>
+<tr>
+<td><code>%ch</code></td>
+<td>Bold / bright</td>
+</tr>
+<tr>
+<td><code>%cn</code></td>
+<td>Reset to normal</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">u.send("%ch%crERROR:%cn You can't do that.");
+// → bold red "ERROR:" followed by normal text
 </code></pre>
-</li>
-</ol>
-<h3>Text Formatting</h3>
-<p>You can customize text formatting with ANSI color codes:</p>
-<ul>
-<li><code>%r</code> - Red</li>
-<li><code>%g</code> - Green</li>
-<li><code>%b</code> - Blue</li>
-<li><code>%c</code> - Cyan</li>
-<li><code>%m</code> - Magenta</li>
-<li><code>%y</code> - Yellow</li>
-<li><code>%w</code> - White</li>
-<li><code>%x</code> - Reset to default</li>
-</ul>
-<p>Example: <code>%rThis text is red%x and this is normal.</code></p>
-<h2>Commands</h2>
-<h3>Creating Custom Commands</h3>
-<p>You can create custom commands using the command API:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.commands.add({
-  name: "mycmd",
-  pattern: /^mycmd\s+(.+)$/i,
-  flags: "connected",
-  exec: (match, context) =&gt; {
-    const arg = match[1];
-    context.send(`You used mycmd with argument: ${arg}`);
+<h3>Other substitutions</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Expands to</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>%n</code></td>
+<td>Actor’s name</td>
+</tr>
+<tr>
+<td><code>%r</code></td>
+<td>Newline</td>
+</tr>
+<tr>
+<td><code>%t</code></td>
+<td>Tab</td>
+</tr>
+<tr>
+<td><code>%b</code></td>
+<td>Space</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><strong>Note:</strong> In the old Customization guide this was listed as <code>%r = Red</code>. That<br>
+was wrong — <code>%r</code> is a <strong>newline</strong>, not red. Red is <code>%cr</code>.</p>
+</blockquote>
+<hr>
+<h2>Custom Commands</h2>
+<p>Register new in-game commands with <code>addCmd()</code>. Call it at module level — it<br>
+runs once when your file is imported at server startup.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/mush";
+import type { IUrsamuSDK } from "jsr:@ursamu/mush";
+
+addCmd({
+  name: "+roll",
+  pattern: /^\+roll(?:\s+(\d+)d(\d+))?/i,
+  lock: "connected",
+  exec: async (u: IUrsamuSDK) =&gt; {
+    const count = parseInt(u.cmd.args[0] || "1");
+    const sides = parseInt(u.cmd.args[1] || "6");
+    const results: number[] = [];
+    for (let i = 0; i &lt; count; i++) {
+      results.push(Math.ceil(Math.random() * sides));
+    }
+    const total = results.reduce((a, b) =&gt; a + b, 0);
+    u.send(`%ch+ROLL:%cn ${results.join(", ")} = %ch${total}%cn`);
   },
+  help: "+roll [&lt;count&gt;d&lt;sides&gt;]\nRolls dice. Default: 1d6.",
 });
 </code></pre>
-<h3>Modifying Existing Commands</h3>
-<p>You can override existing commands by registering a new command with the same<br>
-name:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.commands.add({
+<h3>ICmd fields</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td><code>string</code></td>
+<td>Yes</td>
+<td>Display name for help listings</td>
+</tr>
+<tr>
+<td><code>pattern</code></td>
+<td><code>string | RegExp</code></td>
+<td>Yes</td>
+<td>Matched against raw input; capture groups become <code>u.cmd.args</code></td>
+</tr>
+<tr>
+<td><code>lock</code></td>
+<td><code>string</code></td>
+<td>No</td>
+<td>Lock expression evaluated before exec (default: none)</td>
+</tr>
+<tr>
+<td><code>exec</code></td>
+<td><code>(u: IUrsamuSDK) =&gt; void | Promise&lt;void&gt;</code></td>
+<td>Yes</td>
+<td>Command handler</td>
+</tr>
+<tr>
+<td><code>help</code></td>
+<td><code>string</code></td>
+<td>No</td>
+<td>Help text shown by the <code>help</code> command</td>
+</tr>
+<tr>
+<td><code>hidden</code></td>
+<td><code>boolean</code></td>
+<td>No</td>
+<td>If <code>true</code>, omit from help listings</td>
+</tr>
+<tr>
+<td><code>category</code></td>
+<td><code>string</code></td>
+<td>No</td>
+<td>Groups commands under a category in help</td>
+</tr>
+</tbody>
+</table>
+<h3>Overriding built-in commands</h3>
+<p>Register a command with the same name — the last one registered wins.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">addCmd({
   name: "look",
   pattern: /^(?:look|l)(?:\s+(.+))?$/i,
-  flags: "connected",
-  exec: (match, context) =&gt; {
-    // Your custom look implementation
+  lock: "connected",
+  exec: async (u: IUrsamuSDK) =&gt; {
+    const arg = (u.cmd.args[0] || "").trim();
+    if (arg) {
+      const target = await u.util.target(u.me, arg);
+      if (!target) return u.send("I don't see that here.");
+      return u.send(target.state.desc as string || "You see nothing special.");
+    }
+    u.send(u.here.state.desc as string || "You see nothing special.");
   },
 });
 </code></pre>
-<h2>Game Mechanics</h2>
-<h3>Custom Attributes</h3>
-<p>You can define custom attributes for objects and characters:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.attributes.define({
-  name: "strength",
-  defaultValue: 10,
-  min: 1,
-  max: 20,
-  flags: ["character", "numeric"],
-});
-</code></pre>
-<h3>Custom Functions</h3>
-<p>Create custom functions for use in your game:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.functions.add({
-  name: "add",
-  args: ["num1", "num2"],
-  exec: (args, context) =&gt; {
-    return Number(args.num1) + Number(args.num2);
+<h3>Switches</h3>
+<p>Commands can accept <code>/switch</code> syntax — <code>@set/quiet object=flag</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">addCmd({
+  name: "@myset",
+  pattern: /^@myset(?:\/([\w]+))?\s+(.*)/i,
+  lock: "connected",
+  exec: (u: IUrsamuSDK) =&gt; {
+    const sw  = (u.cmd.args[0] || "").toLowerCase();
+    const arg = u.cmd.args[1] || "";
+    if (sw === "quiet") {
+      // suppress output
+    }
+    u.send(`Set: ${arg}`);
   },
 });
 </code></pre>
-<h3>Custom Flags</h3>
-<p>Define custom flags for objects:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.flags.define({
-  name: "invisible",
-  description: "Object is invisible to normal players",
-  defaultValue: false,
+<hr>
+<h2>Custom Attributes</h2>
+<p>All game objects have a <code>state</code> field (<code>Record&lt;string, unknown&gt;</code>) for storing<br>
+arbitrary data. Use <code>u.db.modify()</code> to write and <code>obj.state</code> to read.</p>
+<h3>Storing a value</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Set "gold" on the actor
+await u.db.modify(u.me.id, "state", { ...u.me.state, gold: 100 });
+</code></pre>
+<h3>Reading a value</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const gold = u.me.state.gold as number || 0;
+u.send(`%chGOLD:%cn You have ${gold} gold.`);
+</code></pre>
+<h3>Storing on another object</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const target = await u.util.target(u.me, u.cmd.args[0]);
+if (!target) return u.send("Not found.");
+await u.db.modify(target.id, "state", { ...target.state, desc: u.cmd.args[1] });
+u.send("Description set.");
+</code></pre>
+<h3>Per-object stats example</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// +stats command
+addCmd({
+  name: "+stats",
+  pattern: /^\+stats(?:\s+(.+))?/i,
+  lock: "connected",
+  exec: async (u: IUrsamuSDK) =&gt; {
+    const who = u.cmd.args[0]
+      ? await u.util.target(u.me, u.cmd.args[0])
+      : u.me;
+    if (!who) return u.send("Not found.");
+    const str = who.state.str as number || 10;
+    const dex = who.state.dex as number || 10;
+    const con = who.state.con as number || 10;
+    u.send(
+      `%ch${who.name}%cn — STR: %ch${str}%cn  DEX: %ch${dex}%cn  CON: %ch${con}%cn`
+    );
+  },
 });
 </code></pre>
-<h2>Integration</h2>
-<h3>External APIs</h3>
-<p>UrsaMU can integrate with external APIs:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">game.hooks.on("command:weather", async (context) =&gt; {
-  const weather = await fetch("https://api.weather.com/...");
-  const data = await weather.json();
-  context.send(`Current weather: ${data.description}`);
-});
-</code></pre>
-<h3>Database Integration</h3>
-<p>Connect to external databases:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">const db = new Database({
-  type: "postgres",
-  host: "localhost",
-  port: 5432,
-  username: "user",
-  password: "password",
-  database: "mydb",
-});
-
-game.hooks.on("startup", () =&gt; {
-  db.connect();
-});
-</code></pre>
+<hr>
 <h2>Plugins</h2>
-<h3>Installing Plugins</h3>
-<p>To install a plugin:</p>
-<ol>
-<li>Download the plugin to the <code>plugins/</code> directory</li>
-<li>Add the plugin to your configuration:<pre class="language-json" tabindex="0"><code class="language-json">"plugins": [
-  "my-plugin"
-]
+<p>A plugin is a TypeScript module with an optional <code>init()</code> function. Plugins<br>
+are imported by your game’s <code>src/main.ts</code> at startup.</p>
+<h3>Plugin structure</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">src/plugins/my-plugin/
+├── index.ts        ← IPlugin export (optional init hook)
+└── commands.ts     ← addCmd() registrations
 </code></pre>
-</li>
-<li>Restart your server</li>
-</ol>
-<h3>Creating Plugins</h3>
-<p>Create your own plugins to extend UrsaMU:</p>
-<ol>
-<li>Create a new directory in <code>plugins/</code></li>
-<li>Create a <code>plugin.json</code> file:<pre class="language-json" tabindex="0"><code class="language-json">{
-  "name": "my-plugin",
-  "version": "1.0.0",
-  "description": "My custom plugin",
-  "main": "index.ts"
-}
+<h3><code>index.ts</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import type { IPlugin } from "jsr:@ursamu/mush";
+import "./commands.ts";   // importing triggers addCmd() registrations
+
+export const plugin: IPlugin = {
+  name:        "my-plugin",
+  version:     "1.0.0",
+  description: "Does cool things.",
+  init: async () =&gt; {
+    // One-time setup runs before the first player connects.
+    // Fetch external data, seed DB records, register scheduled jobs, etc.
+    console.log("[my-plugin] Ready.");
+    return true;
+  },
+  remove: () =&gt; {
+    // Optional cleanup if the plugin is ever unloaded.
+  },
+};
 </code></pre>
-</li>
-<li>Create an <code>index.ts</code> file with your plugin code</li>
-<li>See the <a href="/ursamu/plugins/">Plugin Development</a> section for more details</li>
-</ol>
-<h2>Web Interface</h2>
-<h3>Customizing the Web Client</h3>
-<p>The web client can be customized by modifying the templates:</p>
-<ol>
-<li>Copy the default templates from <code>templates/</code> to <code>custom-templates/</code></li>
-<li>Modify the templates as needed</li>
-<li>Configure UrsaMU to use your custom templates:<pre class="language-json" tabindex="0"><code class="language-json">"templates": {
-  "directory": "custom-templates"
-}
+<h3>Loading a plugin in <code>src/main.ts</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { plugin as myPlugin } from "./plugins/my-plugin/index.ts";
+
+if (myPlugin.init) await myPlugin.init();
 </code></pre>
-</li>
-</ol>
-<h3>Custom CSS</h3>
-<p>Add custom CSS to the web interface:</p>
-<ol>
-<li>Create a <code>custom.css</code> file in <code>public/css/</code></li>
-<li>Add your custom styles</li>
-<li>Configure UrsaMU to include your CSS:<pre class="language-json" tabindex="0"><code class="language-json">"webClient": {
-  "customCSS": ["custom.css"]
-}
+<h3>IPlugin fields</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td><code>string</code></td>
+<td>Yes</td>
+<td>Unique plugin identifier</td>
+</tr>
+<tr>
+<td><code>version</code></td>
+<td><code>string</code></td>
+<td>Yes</td>
+<td>Semver version string</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td><code>string</code></td>
+<td>No</td>
+<td>Human-readable description</td>
+</tr>
+<tr>
+<td><code>init</code></td>
+<td><code>() =&gt; boolean | Promise&lt;boolean&gt;</code></td>
+<td>No</td>
+<td>Called once at startup; return <code>false</code> to abort</td>
+</tr>
+<tr>
+<td><code>remove</code></td>
+<td><code>() =&gt; void | Promise&lt;void&gt;</code></td>
+<td>No</td>
+<td>Called when plugin is unloaded</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>REST Routes</h2>
+<p>Register custom HTTP endpoints with <code>registerPluginRoute()</code>. Routes are<br>
+mounted alongside the built-in <code>/api/v1/</code> routes.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerPluginRoute } from "jsr:@ursamu/mush";
+
+registerPluginRoute("/api/v1/my-plugin", async (req, userId) =&gt; {
+  if (req.method !== "GET") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  return Response.json({ message: "Hello from my plugin!", userId });
+});
 </code></pre>
-</li>
-</ol>
-<h3>Custom JavaScript</h3>
-<p>Add custom JavaScript to the web interface:</p>
-<ol>
-<li>Create a <code>custom.js</code> file in <code>public/js/</code></li>
-<li>Add your custom scripts</li>
-<li>Configure UrsaMU to include your JavaScript:<pre class="language-json" tabindex="0"><code class="language-json">"webClient": {
-  "customJS": ["custom.js"]
-}
+<p>The handler receives:</p>
+<ul>
+<li><code>req: Request</code> — the Deno <code>Request</code> object</li>
+<li><code>userId: string | null</code> — the authenticated player’s DB ID, or <code>null</code> if<br>
+the request has no valid JWT</li>
+</ul>
+<blockquote>
+<p><strong>Auth tip:</strong> Check <code>userId</code> and return <code>401</code> for endpoints that require<br>
+authentication. The JWT is decoded for you — you don’t need to re-verify it.</p>
+</blockquote>
+<h3>Returning data from the DB</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerPluginRoute("/api/v1/leaderboard", async (_req, _userId) =&gt; {
+  const players = await dbojs.queryAll((o) =&gt; o.flags.has("player"));
+  const ranked = players
+    .map((p) =&gt; ({ name: p.data?.name, gold: p.data?.state?.gold ?? 0 }))
+    .sort((a, b) =&gt; (b.gold as number) - (a.gold as number))
+    .slice(0, 10);
+  return Response.json(ranked);
+});
 </code></pre>
-</li>
+<hr>
+<h2>Format Handlers</h2>
+<p>The format-handler pipeline lets you replace the rendering of any “labelled<br>
+display slot” — the name shown at the top of <code>look</code>, the contents list, the<br>
+exit line, the WHO row, the @ps row, and more — without rewriting the command.</p>
+<h3>The eight engine-known slots</h3>
+<table>
+<thead>
+<tr>
+<th>Slot</th>
+<th>Used by</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>NAMEFORMAT</code></td>
+<td>Header line of <code>look</code> / <code>examine</code></td>
+</tr>
+<tr>
+<td><code>DESCFORMAT</code></td>
+<td>Description block of <code>look</code></td>
+</tr>
+<tr>
+<td><code>CONFORMAT</code></td>
+<td>The “Contents:” list in <code>look</code></td>
+</tr>
+<tr>
+<td><code>EXITFORMAT</code></td>
+<td>The “Exits:” list in <code>look</code></td>
+</tr>
+<tr>
+<td><code>WHOFORMAT</code></td>
+<td>Outer wrapper of the <code>who</code> command</td>
+</tr>
+<tr>
+<td><code>WHOROWFORMAT</code></td>
+<td>One row of <code>who</code></td>
+</tr>
+<tr>
+<td><code>PSFORMAT</code></td>
+<td>Outer wrapper of <code>@ps</code></td>
+</tr>
+<tr>
+<td><code>PSROWFORMAT</code></td>
+<td>One row of <code>@ps</code></td>
+</tr>
+</tbody>
+</table>
+<p>Plugins can also register handlers for any uppercase slot name they invent<br>
+(e.g. <code>MAILFORMAT</code>, <code>BBROWFORMAT</code>) and resolve them from their own commands.</p>
+<h3>Resolution priority</h3>
+<p>For any slot, the engine resolves in this order:</p>
+<ol>
+<li>A stored <code>&amp;SLOTNAME</code> softcode attribute on the target object (or, for<br>
+global-list slots, on <code>#0</code>).</li>
+<li>The most recently registered plugin format handler for that slot.</li>
+<li><code>null</code> (caller falls back to its default rendering).</li>
 </ol>
+<p>This means builders can override a single object’s display with <code>&amp;NAMEFORMAT</code><br>
+in-game <strong>without</strong> the plugin needing to know they exist.</p>
+<h3>Register a TypeScript handler</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFormatHandler } from "jsr:@ursamu/mush";
+
+registerFormatHandler("NAMEFORMAT", (target, viewer) =&gt; {
+  const star = target.flags.has("admin") ? "%ch%cy*%cn " : "";
+  return `${star}%ch${target.state.name}%cn`;
+});
+</code></pre>
+<p>The handler receives the target, the viewer, and optional slot-specific<br>
+extras (for row-format slots, the row data). Return <code>null</code> to fall through<br>
+to the default.</p>
+<h3>Register a MUSH-softcode template (v2.4.0)</h3>
+<p>If your handler is just a softcode string, use <code>registerFormatTemplate</code> —<br>
+the shortcut compiles the source once and wraps it in a TS handler for you.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerFormatTemplate } from "jsr:@ursamu/mush";
+
+registerFormatTemplate(
+  "EXITFORMAT",
+  "[ansi(hy,&lt;)] [name(%0)] [ansi(hy,&gt;)]"
+);
+</code></pre>
+<h3>Unregister</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { unregisterFormatHandler } from "jsr:@ursamu/mush";
+unregisterFormatHandler("NAMEFORMAT");
+</code></pre>
+<h3>Resolving from a script</h3>
+<h2>Scripts use <code>u.util.resolveFormat[Or]</code> and <code>u.util.resolveGlobalFormat[Or]</code><br>
+to render through the pipeline. See the<br>
+<a href="/ursamu/guides/sdk-cookbook/#resolveformat--resolveformator">SDK Cookbook</a>.</h2>
+<h2>External Integrations</h2>
+<h3>Fetching data in a command</h3>
+<p>Deno has native <code>fetch()</code> — no extra packages needed.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">addCmd({
+  name: "+weather",
+  pattern: /^\+weather\s+(.+)/i,
+  lock: "connected",
+  exec: async (u: IUrsamuSDK) =&gt; {
+    const city = encodeURIComponent(u.cmd.args[0]);
+    try {
+      const resp = await fetch(`https://wttr.in/${city}?format=3`);
+      const text = await resp.text();
+      u.send(`%chWEATHER:%cn ${text.trim()}`);
+    } catch {
+      u.send("%chWEATHER:%cn Could not retrieve weather.");
+    }
+  },
+  help: "+weather &lt;city&gt;\nFetches current weather for a city.",
+});
+</code></pre>
+<h3>Fetching in <code>init()</code></h3>
+<p>If your plugin needs to pre-fetch data or connect to an external service, do<br>
+it in <code>init()</code> so it’s ready before players arrive:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">let motdText = "Welcome!";
+
+export const plugin: IPlugin = {
+  name: "motd-fetcher",
+  version: "1.0.0",
+  init: async () =&gt; {
+    try {
+      const resp = await fetch("https://your-api.example.com/motd");
+      motdText = (await resp.json()).message;
+    } catch {
+      // keep default
+    }
+    return true;
+  },
+};
+
+// In a command handler:
+addCmd({
+  name: "+motd",
+  pattern: /^\+motd$/i,
+  lock: "connected",
+  exec: (u: IUrsamuSDK) =&gt; { u.send(motdText); },
+});
+</code></pre>
+<h3>Discord bridge</h3>
+<p>For a Discord bridge plugin, use the built-in <code>u.chan</code> SDK methods alongside<br>
+a Discord WebSocket client in your plugin’s <code>init()</code>. See the Discord plugin<br>
+in <code>src/plugins/discord/</code> as a reference implementation.</p>
 
       </article>
 
@@ -490,11 +803,53 @@ game.hooks.on("startup", () =&gt; {
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -529,16 +884,16 @@ game.hooks.on("startup", () =&gt; {
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/admin-guide/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/commands/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">Admin Guide</span>
+            <span class="page-nav-title">Command Reference</span>
           </a>
         
 
         
-          <a href="/ursamu/guides/first-script/" class="page-nav-btn next">
+          <a href="/ursamu/guides/debugging/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">Build Your First Script</span>
+            <span class="page-nav-title">Debugging Scripts</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/debugging/index.html
+++ b/docs/_site/guides/debugging/index.html
@@ -1,0 +1,795 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Debugging Scripts | UrsaMU Documentation</title>
+  <meta name="description" content="How to diagnose and fix issues in UrsaMU scripts and plugins.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/debugging/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Debugging Scripts</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Debugging Scripts</h1>
+<h2>Scripts run in isolated Web Workers. This means you can’t use the browser<br>
+console, Deno’s <code>--inspect</code> flag, or filesystem access. Here’s how to diagnose<br>
+and fix issues.</h2>
+<h2>Overview</h2>
+<p>When a script fails, the error is:</p>
+<ol>
+<li>Caught by the sandbox</li>
+<li>Sent back as an <code>error</code> message from the worker</li>
+<li>Logged to the server console with <code>[Sandbox] error:</code></li>
+<li>Not shown to the player (the script simply produces no output)</li>
+</ol>
+<h2>So a script that silently does nothing is often one that <strong>threw an exception</strong>.</h2>
+<h2>Common Mistakes</h2>
+<h3>1. Missing <code>await</code> on async methods</h3>
+<p><strong>Wrong:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const gold = u.me.state.gold as number || 0;
+u.db.modify(u.me.id, "$set", { "data.gold": gold + 10 });  // ← missing await!
+u.send(`Gold updated.`);
+</code></pre>
+<p><strong>Correct:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const gold = u.me.state.gold as number || 0;
+await u.db.modify(u.me.id, "$set", { "data.gold": gold + 10 });
+u.send(`Gold updated.`);
+</code></pre>
+<p>Missing <code>await</code> means the DB write starts but the script may exit before it<br>
+completes. In practice you’ll often see partial results or no effect.</p>
+<h3>2. Wrong <code>u.db.modify()</code> operator</h3>
+<p><strong>Wrong:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.db.modify(u.me.id, "state", { gold: 100 });    // "state" is not a valid op
+await u.db.modify(u.me.id, "name", "Alice");            // "name" is not a valid op
+</code></pre>
+<p><strong>Correct:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
+await u.db.modify(u.me.id, "$set", { name: "Alice" });
+</code></pre>
+<p>Valid ops: <code>"$set"</code>, <code>"$unset"</code>, <code>"$inc"</code>. Any other string is silently rejected.</p>
+<h3>3. Missing <code>await</code> on <code>u.canEdit()</code></h3>
+<p><strong>Wrong:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (!u.canEdit(u.me, target)) {   // ← returns Promise, not boolean!
+  u.send("Permission denied.");
+  return;
+}
+</code></pre>
+<p><strong>Correct:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (!(await u.canEdit(u.me, target))) {
+  u.send("Permission denied.");
+  return;
+}
+</code></pre>
+<h3>4. Clobbering state on modify</h3>
+<p><strong>Wrong:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// This wipes all other fields in data!
+await u.db.modify(u.me.id, "$set", { data: { gold: 100 } });
+</code></pre>
+<p><strong>Correct:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Spread to preserve existing fields
+await u.db.modify(u.me.id, "$set", { data: { ...u.me.state, gold: 100 } });
+// Or use dot-notation to target one field:
+await u.db.modify(u.me.id, "$set", { "data.gold": 100 });
+</code></pre>
+<h3>5. ESM import that doesn’t work in workers</h3>
+<p><strong>Wrong:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { sprintf } from "jsr:@std/fmt/printf";  // ← JSR sub-path, won't resolve
+</code></pre>
+<p><strong>Correct:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Use u.util.sprintf instead — it's already in the sandbox
+u.util.sprintf("%-10s %5d", "Score", 100);
+</code></pre>
+<p>Standard ESM imports (<code>import X from "https://..."</code>) work, but <code>jsr:</code> package<br>
+sub-paths do not resolve in Web Worker context. Use <code>u.util</code> helpers instead.</p>
+<h3>6. Assuming <code>u.db.search()</code> returns one item</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const player = await u.db.search({ "data.name": /alice/i });
+// player is IDBObj[], not IDBObj!
+if (!player) { ... }  // wrong — an empty array is truthy
+
+// Correct:
+const results = await u.db.search({ "data.name": /alice/i });
+if (!results.length) { u.send("Not found."); return; }
+const player = results[0];
+</code></pre>
+<h3>7. Not checking for null from <code>u.util.target()</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const target = await u.util.target(u.me, u.cmd.args[0]);
+u.send(`Target: ${target.name}`);  // throws if target is undefined!
+
+// Correct:
+const target = await u.util.target(u.me, u.cmd.args[0]);
+if (!target) { u.send("I don't see that."); return; }
+u.send(`Target: ${target.name}`);
+</code></pre>
+<hr>
+<h2>Script Errors</h2>
+<h3>Script produces no output</h3>
+<p><strong>Causes:</strong></p>
+<ul>
+<li>Unhandled exception (check server console for <code>[Sandbox] error:</code>)</li>
+<li>Script returned early due to a condition check</li>
+<li><code>u.send()</code> called with undefined/null message</li>
+</ul>
+<p><strong>Diagnose:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Add a breadcrumb at the start to verify the script is running
+u.send("DEBUG: script started");
+
+// Check every early return
+const target = await u.util.target(u.me, u.cmd.args[0]);
+u.send(`DEBUG: target = ${target?.id ?? "null"}`);
+if (!target) { u.send("Not found."); return; }
+</code></pre>
+<h3>Script times out</h3>
+<p>Scripts have a 5-second execution timeout. If your script makes many DB<br>
+calls in a loop, it may time out.</p>
+<p><strong>Signs:</strong> Server logs <code>Script execution timed out</code></p>
+<p><strong>Fix:</strong> Batch queries instead of looping:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Bad: N sequential queries
+for (const id of playerIds) {
+  const p = await u.db.search({ id });  // one query per player
+}
+
+// Better: one query
+const players = await u.db.search({ location: u.here.id, flags: /player/i });
+</code></pre>
+<h3>Worker crashes silently</h3>
+<p>If the worker throws before any <code>u.send()</code>, the player sees nothing. The server<br>
+console will show the error.</p>
+<p><strong>Watch for:</strong></p>
+<ul>
+<li><code>ReferenceError: X is not defined</code> — JSR import that failed to resolve</li>
+<li><code>TypeError: Cannot read properties of undefined</code> — null/undefined not checked</li>
+<li><code>SyntaxError</code> — TypeScript that failed to transpile</li>
+</ul>
+<hr>
+<h2>Debugging Techniques</h2>
+<h3>Use <code>think</code> to echo values</h3>
+<p>The <code>think</code> command (<code>system/scripts/think.ts</code>) sends output to you without<br>
+broadcasting. Use it as a debug probe:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">think [output of a long expression]
+</code></pre>
+<h3>Add temporary <code>u.send()</code> breadcrumbs</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">export default async (u: IUrsamuSDK) =&gt; {
+  u.send("[DEBUG 1] entering script");
+  const target = await u.util.target(u.me, u.cmd.args[0]);
+  u.send(`[DEBUG 2] target = ${target?.id ?? "null"}`);
+  if (!target) return;
+
+  const gold = (target.state.gold as number) || 0;
+  u.send(`[DEBUG 3] gold = ${gold}`);
+
+  await u.db.modify(target.id, "$set", { "data.gold": gold + 10 });
+  u.send("[DEBUG 4] db.modify done");
+};
+</code></pre>
+<p>Remove the debug lines before committing.</p>
+<h3>Check the server console</h3>
+<p>The server logs all sandbox errors. Look for lines like:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">[Sandbox] error: TypeError: Cannot read properties of undefined (reading 'id')
+</code></pre>
+<h3>Use <code>@js</code> for quick experiments (wizard/admin only)</h3>
+<p>The <code>@js</code> command runs a JavaScript expression directly (no sandbox — full<br>
+server access). Useful for testing DB queries:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@js await dbojs.queryOne({ id: "1" })
+</code></pre>
+<hr>
+<h2>Testing Scripts Manually</h2>
+<h3>Run the test suite</h3>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task test
+</code></pre>
+<p>This runs tests in <code>tests/</code>, <code>src/services/Intents/</code>, <code>src/services/Sandbox/</code>,<br>
+and <code>src/plugins/events/</code>.</p>
+<h3>Write a script test</h3>
+<p>Tests for scripts follow this pattern — read the file, strip the <code>export</code>,<br>
+inject a stub <code>u</code> object, and run the code:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { assertEquals } from "jsr:@std/assert";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("greet script sends a message", OPTS, async () =&gt; {
+  const sent: string[] = [];
+
+  const u = {
+    me: { id: "1", name: "Alice", flags: new Set(["player"]), state: {}, contents: [] },
+    here: { id: "2", name: "Hall", state: {}, contents: [], flags: new Set(["room"]),
+      broadcast: () =&gt; {} },
+    cmd: { name: "greet", args: ["Bob"], switches: [] },
+    state: {},
+    send: (msg: string) =&gt; { sent.push(msg); },
+    util: {
+      target: async () =&gt; ({ id: "3", name: "Bob", flags: new Set(["player"]),
+        state: {}, contents: [] }),
+      displayName: (obj: { name?: string }) =&gt; obj.name ?? "Unknown",
+    },
+    db: {
+      search: async () =&gt; [],
+      modify: async () =&gt; {},
+    },
+  } as unknown;
+
+  // Load and run the script
+  const src = await Deno.readTextFile("system/scripts/greet.ts");
+  const fn = new Function("u", src.replace(/^export default/, "return"));
+  await fn(u)(u);
+
+  assertEquals(sent[0], "You wave to Bob.");
+});
+</code></pre>
+<hr>
+<h2>Plugin Debugging</h2>
+<h3>Check if your plugin loaded</h3>
+<p>Look for your plugin’s init log in the server console:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">[myplugin] Plugin initialized — +myplugin commands active
+</code></pre>
+<p>If missing, the plugin file wasn’t found or threw during import.</p>
+<h3>Verify <code>addCmd</code> was called</h3>
+<p>Add a console.log to your <code>commands.ts</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">console.log("[myplugin] registering commands");
+addCmd({ ... });
+</code></pre>
+<p>This should appear at startup before <code>Plugin initialized</code>.</p>
+<h3>Route not responding</h3>
+<p>If your <code>registerPluginRoute</code> handler isn’t called:</p>
+<ul>
+<li>Verify the path starts with <code>/api/v1/</code></li>
+<li>Check that <code>registerPluginRoute</code> is called inside <code>init()</code>, not at module level</li>
+<li>Confirm the auth header is present (<code>Authorization: Bearer &lt;jwt&gt;</code>)</li>
+</ul>
+<h3>GameHooks not firing</h3>
+<p>If <code>gameHooks.on()</code> isn’t triggering:</p>
+<ul>
+<li>Verify you’re calling <code>on()</code> in <code>init()</code> and storing the handler reference</li>
+<li>Check that <code>off()</code> isn’t being called before the event fires</li>
+<li>Confirm the event name matches exactly (case-sensitive)</li>
+</ul>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/customization/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Customization Guide</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/deployment/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Production Deployment</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/deployment/index.html
+++ b/docs/_site/guides/deployment/index.html
@@ -1,0 +1,862 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Production Deployment | UrsaMU Documentation</title>
+  <meta name="description" content="How to run UrsaMU in production — environment setup, daemon management, nginx reverse proxy, TLS, and updates.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/deployment/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Production Deployment</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Production Deployment</h1>
+<h2>This guide covers running UrsaMU on a Linux VPS or dedicated server. The<br>
+examples use Ubuntu/Debian and nginx, but the approach works on any Linux<br>
+distribution.</h2>
+<h2>Before You Start</h2>
+<p>You need:</p>
+<ul>
+<li><strong>Deno</strong> — <a href="https://deno.land/">deno.land</a> v1.40+</li>
+<li>A <strong>domain name</strong> pointed at your server’s IP (for TLS)</li>
+<li>Ports <code>4201</code>, <code>4203</code> reachable from the internet (or whatever you configure)</li>
+<li>A strong value ready for <code>JWT_SECRET</code></li>
+</ul>
+<p>Install Deno if you haven’t:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -fsSL https://deno.land/install.sh | sh
+# Add to PATH — follow the printed instructions, then:
+source ~/.bashrc
+</code></pre>
+<hr>
+<h2>Environment Variables</h2>
+<p>Set these before starting the server. The simplest approach is a <code>.env</code> file in<br>
+your game project root — UrsaMU loads it via <code>dotenv/load</code> at the top of<br>
+<code>src/main.ts</code>, so anything defined there is visible to the engine before any<br>
+config is read. Scaffolded projects (<code>ursamu create</code>) write a fresh<br>
+<code>JWT_SECRET</code> into <code>.env</code> automatically.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># .env  — DO NOT commit this file
+JWT_SECRET=replace-this-with-a-long-random-string
+</code></pre>
+<p>Generate a strong secret:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">openssl rand -base64 48
+</code></pre>
+<blockquote>
+<p><strong>Why this matters:</strong> If <code>JWT_SECRET</code> is not set, a random secret is<br>
+generated at startup — meaning every restart logs all players out. Set it<br>
+once and keep it stable.</p>
+</blockquote>
+<p>You can also override the default ports via environment variables:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">URSAMU_HTTP_PORT=4203    # HTTP + WebSocket hub (default: 4203)
+URSAMU_TELNET_PORT=4201  # Telnet sidecar (default: 4201)
+</code></pre>
+<p>Or set ports in your game’s <code>config/config.json</code>:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "server": {
+    "http": 4203,
+    "telnet": 4201,
+    "ws": 4202
+  }
+}
+</code></pre>
+<hr>
+<h2>First Run</h2>
+<p>On a fresh server with an empty database, start the server interactively once<br>
+to complete first-run setup:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task server
+</code></pre>
+<p>The server prints:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">Fresh database detected — no players exist yet.
+
+Connect via telnet and run:
+  create &lt;name&gt; &lt;password&gt;
+
+The first player created is automatically given superuser access.
+</code></pre>
+<p>Connect with a telnet client (<code>telnet localhost 4201</code>) and create your account.<br>
+The first player created receives the <code>superuser</code> flag automatically.</p>
+<h2>After that, switch to daemon mode for normal operation.</h2>
+<h2>Supervised Daemon Mode</h2>
+<p>Game projects scaffolded with <code>ursamu create</code> ship four shell wrappers in<br>
+<code>scripts/</code> that run the server as a supervised background process. They use<br>
+the engine’s signal-driven restart loop so <code>@reboot</code> and config reloads do<br>
+<strong>not</strong> disconnect Telnet sidecar clients.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">bash scripts/daemon.sh    # Start the supervisor in the background
+bash scripts/status.sh    # Show pid + uptime
+bash scripts/restart.sh   # No-disconnect restart of the main process
+bash scripts/stop.sh      # Graceful stop (disconnects everyone)
+</code></pre>
+<p>What happens:</p>
+<ol>
+<li><code>daemon.sh</code> spawns <code>deno task start</code> under a supervisor loop. The<br>
+supervisor PID is written to <code>.ursamu.pid</code>; the running <code>deno</code> child PID<br>
+is written to <code>.ursamu-deno.pid</code>.</li>
+<li>The supervisor watches the deno exit code:
+<ul>
+<li><code>75</code> → restart (default after <code>@reboot</code>, <code>@update</code>, crash)</li>
+<li><code>0</code> → clean stop (<code>@shutdown</code>)</li>
+<li>other → unexpected crash; the supervisor stops and logs</li>
+</ul>
+</li>
+<li><code>restart.sh</code> sends <strong>SIGUSR2</strong> to the main process. The engine catches<br>
+it, finishes in-flight handlers, and restarts the main loop <strong>without<br>
+disconnecting the Telnet sidecar</strong>. Clients keep their JWT and auto-<br>
+reauthenticate on the new main.</li>
+<li><code>stop.sh</code> sends SIGTERM and waits for clean shutdown.</li>
+</ol>
+<p>The same restart semantics back the in-game <code>@reboot</code> and <code>@update</code> commands.</p>
+<blockquote>
+<p><strong>Development vs production:</strong> Use <code>deno task dev</code> during development — it<br>
+enables file watching so the main server restarts on code changes. Use<br>
+<code>bash scripts/daemon.sh</code> in production.</p>
+</blockquote>
+<hr>
+<h2>systemd</h2>
+<p>For tighter OS integration (automatic restart on crash, start on boot), run<br>
+UrsaMU as a systemd service instead of using the daemon scripts.</p>
+<p>Create <code>/etc/systemd/system/ursamu-main.service</code>:</p>
+<pre class="language-ini" tabindex="0"><code class="language-ini">[Unit]
+Description=UrsaMU Main Server
+After=network.target
+Wants=ursamu-telnet.service
+
+[Service]
+Type=simple
+User=ursamu
+WorkingDirectory=/home/ursamu/my-game
+EnvironmentFile=/home/ursamu/my-game/.env
+ExecStart=/home/ursamu/.deno/bin/deno run --allow-all --unstable-detect-cjs --unstable-kv src/main.ts
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/home/ursamu/my-game/logs/main.log
+StandardError=append:/home/ursamu/my-game/logs/main.log
+
+[Install]
+WantedBy=multi-user.target
+</code></pre>
+<p>Create <code>/etc/systemd/system/ursamu-telnet.service</code>:</p>
+<pre class="language-ini" tabindex="0"><code class="language-ini">[Unit]
+Description=UrsaMU Telnet Sidecar
+After=network.target
+
+[Service]
+Type=simple
+User=ursamu
+WorkingDirectory=/home/ursamu/my-game
+EnvironmentFile=/home/ursamu/my-game/.env
+ExecStart=/home/ursamu/.deno/bin/deno run --allow-all --unstable-detect-cjs --unstable-kv src/telnet.ts
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/home/ursamu/my-game/logs/telnet.log
+StandardError=append:/home/ursamu/my-game/logs/telnet.log
+
+[Install]
+WantedBy=multi-user.target
+</code></pre>
+<p>Enable and start:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">sudo systemctl daemon-reload
+sudo systemctl enable ursamu-main ursamu-telnet
+sudo systemctl start ursamu-main ursamu-telnet
+sudo systemctl status ursamu-main ursamu-telnet
+</code></pre>
+<p>Adjust <code>User</code>, <code>WorkingDirectory</code>, and <code>EnvironmentFile</code> paths to match your<br>
+setup. Run UrsaMU as a dedicated non-root user — create one with:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">sudo useradd -m -s /bin/bash ursamu
+</code></pre>
+<hr>
+<h2>Nginx and TLS</h2>
+<p>Place nginx in front of the Hub to terminate TLS. This lets your game use<br>
+<code>wss://</code> (secure WebSocket) and <code>https://</code> without modifying UrsaMU itself.</p>
+<h3>Install nginx and Certbot</h3>
+<pre class="language-bash" tabindex="0"><code class="language-bash">sudo apt install nginx certbot python3-certbot-nginx
+sudo certbot --nginx -d yourgame.example.com
+</code></pre>
+<h3>nginx configuration</h3>
+<p>Create <code>/etc/nginx/sites-available/ursamu</code>:</p>
+<pre class="language-nginx" tabindex="0"><code class="language-nginx">server {
+    listen 443 ssl http2;
+    server_name yourgame.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/yourgame.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/yourgame.example.com/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    # HTTP REST API
+    location /api/ {
+        proxy_pass         http://127.0.0.1:4203;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # Health check
+    location /health {
+        proxy_pass http://127.0.0.1:4203;
+    }
+
+    # WebSocket
+    location /ws {
+        proxy_pass         http://127.0.0.1:4203;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
+
+# Redirect HTTP → HTTPS
+server {
+    listen 80;
+    server_name yourgame.example.com;
+    return 301 https://$host$request_uri;
+}
+</code></pre>
+<p>Enable and reload:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">sudo ln -s /etc/nginx/sites-available/ursamu /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+</code></pre>
+<h3>WebSocket connection URL with TLS</h3>
+<p>Clients connecting through the nginx proxy use:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">wss://yourgame.example.com/ws?token=&lt;jwt&gt;&amp;client=web
+</code></pre>
+<p>The proxy forwards the WebSocket upgrade to port 4203. The <code>X-Forwarded-For</code><br>
+header is passed through, so brute-force rate limiting still sees the real<br>
+client IP.</p>
+<h3>Telnet and TLS</h3>
+<h2>Standard Telnet (<code>telnet:4201</code>) does not support TLS. For encrypted Telnet<br>
+connections, clients should use a TLS-capable MU* client (e.g. Mudlet with SSL<br>
+enabled) pointed directly at port 4201, with nginx/stunnel wrapping that port.<br>
+Most game operators leave Telnet unencrypted and direct players to use the<br>
+WebSocket connection for sensitive operations.</h2>
+<h2>Firewall</h2>
+<p>Open only the ports you need. With nginx handling TLS:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># UFW example
+sudo ufw allow 22/tcp    # SSH
+sudo ufw allow 80/tcp    # HTTP (nginx, for redirect + Certbot)
+sudo ufw allow 443/tcp   # HTTPS (nginx)
+sudo ufw allow 4201/tcp  # Telnet (direct)
+sudo ufw enable
+</code></pre>
+<h2>Port <code>4203</code> should <strong>not</strong> be exposed directly — all HTTP/WS traffic should<br>
+flow through nginx on 443. Only Telnet needs a public port of its own.</h2>
+<h2>Logs</h2>
+<p>UrsaMU writes three log files to <code>logs/</code>:</p>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Contents</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>logs/main.log</code></td>
+<td>Hub stdout/stderr — server events, errors</td>
+</tr>
+<tr>
+<td><code>logs/telnet.log</code></td>
+<td>Telnet sidecar stdout/stderr</td>
+</tr>
+<tr>
+<td><code>logs/error.log</code></td>
+<td>Unhandled errors logged by <code>logError()</code></td>
+</tr>
+<tr>
+<td><code>logs/security.log</code></td>
+<td>Auth events — login failures, resets, admin actions</td>
+</tr>
+</tbody>
+</table>
+<p>Follow live:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">tail -f logs/main.log logs/telnet.log
+tail -f logs/security.log
+</code></pre>
+<h3>Log rotation</h3>
+<p>Prevent unbounded growth with <code>logrotate</code>. Create<br>
+<code>/etc/logrotate.d/ursamu</code>:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">/home/ursamu/my-game/logs/*.log {
+    daily
+    rotate 14
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+</code></pre>
+<h2><code>copytruncate</code> truncates the file in place rather than moving it, so the<br>
+running server keeps writing without needing a restart.</h2>
+<h2>Updates</h2>
+<p>UrsaMU is a JSR package — your game project depends on a version pinned in<br>
+<code>deno.json</code>. To update to the latest engine:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Preview what would change
+deno run -A jsr:@ursamu/cli@0.1.2/update --dry-run
+
+# Apply the update
+deno run -A jsr:@ursamu/cli@0.1.2/update
+</code></pre>
+<p>After updating, restart the servers:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">bash scripts/restart.sh                              # if using the daemon scaffold
+sudo systemctl restart ursamu-main ursamu-telnet     # if using systemd
+</code></pre>
+<p>Check the <a href="https://github.com/ursamu/ursamu/releases">changelog</a> before<br>
+updating on a live game to catch any breaking changes.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/debugging/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Debugging Scripts</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/docker/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Docker</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/docker/index.html
+++ b/docs/_site/guides/docker/index.html
@@ -1,0 +1,820 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Docker | UrsaMU Documentation</title>
+  <meta name="description" content="Running UrsaMU with Docker and Docker Compose.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/docker/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Docker</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Docker</h1>
+<h2>UrsaMU ships a <code>Dockerfile</code> and <code>docker-compose.yaml</code> for containerized deployments.<br>
+Docker is the recommended way to run UrsaMU in production on any VPS or cloud host.</h2>
+<h2>Prerequisites</h2>
+<ul>
+<li><a href="https://docs.docker.com/get-docker/">Docker</a> 24+</li>
+<li><a href="https://docs.docker.com/compose/install/">Docker Compose</a> v2 (ships with Docker Desktop)</li>
+</ul>
+<hr>
+<h2>Quick Start</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Clone the repo (or use your game project)
+git clone https://github.com/UrsaMU/ursamu.git
+cd ursamu
+
+# Create your .env file
+echo "JWT_SECRET=$(openssl rand -hex 32)" &gt; .env
+
+# Build and start
+docker compose up -d
+
+# Watch the logs
+docker compose logs -f
+</code></pre>
+<p>On first startup the server initializes the database and prints a one-time<br>
+message inviting you to create the first player via Telnet:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">Fresh database detected — no players exist yet.
+
+Connect via telnet and run:
+  create &lt;name&gt; &lt;password&gt;
+
+The first player created is automatically given superuser access.
+</code></pre>
+<p>Connect with <code>telnet localhost 4201</code> and run <code>create &lt;name&gt; &lt;password&gt;</code> —<br>
+that first account is granted the <code>superuser</code> flag automatically. After<br>
+that, all subsequent <code>create</code> calls produce regular players.</p>
+<hr>
+<h2>Ports</h2>
+<table>
+<thead>
+<tr>
+<th>Container port</th>
+<th>Host port</th>
+<th>Protocol</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>4201</code></td>
+<td><code>4201</code></td>
+<td>Telnet</td>
+<td>Legacy MU* clients</td>
+</tr>
+<tr>
+<td><code>4202</code></td>
+<td><code>4202</code></td>
+<td>WebSocket</td>
+<td>Raw WebSocket connections</td>
+</tr>
+<tr>
+<td><code>4203</code></td>
+<td><code>4203</code></td>
+<td>HTTP / WS</td>
+<td>REST API + JWT WebSocket</td>
+</tr>
+</tbody>
+</table>
+<p>Connect with a Telnet client:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">telnet localhost 4201
+</code></pre>
+<p>Or point a web client at:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">ws://localhost:4203?token=&lt;jwt&gt;&amp;client=web
+</code></pre>
+<hr>
+<h2>docker-compose.yaml</h2>
+<p>The file is included in the project root. Full contents for reference:</p>
+<pre class="language-yaml" tabindex="0"><code class="language-yaml">services:
+  ursamu:
+    build: .
+    ports:
+      - "4201:4201"
+      - "4202:4202"
+      - "4203:4203"
+    volumes:
+      - ./data:/app/data       # Deno KV database files
+      - ./config:/app/config   # config.json
+      - ./logs:/app/logs       # main.log, telnet.log, error.log
+    environment:
+      - NODE_ENV=production
+    env_file:
+      - .env
+    restart: unless-stopped
+</code></pre>
+<h3>Volumes</h3>
+<table>
+<thead>
+<tr>
+<th>Mount</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>./data:/app/data</code></td>
+<td>Deno KV database — <strong>must be persisted</strong> or data is lost on container restart</td>
+</tr>
+<tr>
+<td><code>./config:/app/config</code></td>
+<td><code>config.json</code> — edit game settings without rebuilding</td>
+</tr>
+<tr>
+<td><code>./logs:/app/logs</code></td>
+<td>Server logs — useful for debugging and monitoring</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Environment Variables</h2>
+<p>Create a <code>.env</code> file in the project root before starting:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Required — long random string; changing this logs out all players
+JWT_SECRET=replace-with-a-long-random-string
+
+# Optional overrides
+URSAMU_HTTP_PORT=4203
+URSAMU_TELNET_PORT=4201
+</code></pre>
+<p>Generate a secure secret:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">openssl rand -hex 32
+</code></pre>
+<hr>
+<h2>Configuration</h2>
+<p>Edit <code>config/config.json</code> to change game settings — the volume mount means<br>
+changes take effect on the next restart with no image rebuild needed:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "server": {
+    "telnet": 4201,
+    "ws": 4202,
+    "http": 4203,
+    "db": "data/ursamu.db"
+  },
+  "game": {
+    "name": "My Game",
+    "description": "A UrsaMU-powered MUSH.",
+    "version": "0.0.1",
+    "playerStart": "1"
+  }
+}
+</code></pre>
+<hr>
+<h2>Common Commands</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Start (detached)
+docker compose up -d
+
+# Stop
+docker compose down
+
+# Restart
+docker compose restart
+
+# Tail logs
+docker compose logs -f
+
+# Rebuild after code changes
+docker compose up -d --build
+
+# Open a shell in the running container
+docker compose exec ursamu sh
+
+# Inspect the database volume
+ls ./data/
+</code></pre>
+<hr>
+<h2>Changing Ports</h2>
+<p>To run on different host ports (e.g. behind a firewall that blocks 4201), edit<br>
+the <code>ports</code> section in <code>docker-compose.yaml</code>:</p>
+<pre class="language-yaml" tabindex="0"><code class="language-yaml">ports:
+  - "2323:4201"   # expose Telnet on host port 2323
+  - "4202:4202"
+  - "443:4203"    # expose HTTP/WS directly on 443 (no nginx needed)
+</code></pre>
+<p>The container-internal ports (<code>4201</code>, <code>4202</code>, <code>4203</code>) stay the same —<br>
+only the host-side mappings change.</p>
+<hr>
+<h2>Behind a Reverse Proxy</h2>
+<p>For TLS termination with nginx, expose only port <code>4203</code> to nginx and keep<br>
+<code>4201</code> open directly for Telnet clients:</p>
+<pre class="language-yaml" tabindex="0"><code class="language-yaml">ports:
+  - "4201:4201"     # Telnet — direct
+  # 4202 and 4203 not exposed; nginx handles 443 → 4203
+</code></pre>
+<p>nginx config:</p>
+<pre class="language-nginx" tabindex="0"><code class="language-nginx">server {
+    listen 443 ssl;
+    server_name yourdomain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/yourdomain.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:4203;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}
+</code></pre>
+<hr>
+<h2>Updating</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Pull latest image / rebuild
+git pull
+docker compose up -d --build
+</code></pre>
+<p>Or trigger an in-game update from the admin prompt:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@update
+</code></pre>
+<p>This runs <code>git pull</code> inside the container and restarts the server process.<br>
+The container itself stays running.</p>
+<hr>
+<h2>Troubleshooting</h2>
+<h3>Container exits immediately</h3>
+<p>Check the logs:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">docker compose logs ursamu
+</code></pre>
+<p>Common causes:</p>
+<ul>
+<li><strong><code>JWT_SECRET</code> not set</strong> — the server will warn but continue; check logs for<br>
+<code>[security] JWT_SECRET not set</code> and add it to <code>.env</code></li>
+<li><strong>Port already in use</strong> — another process is listening on <code>4201</code>, <code>4202</code>, or<br>
+<code>4203</code>. Stop it or remap the port.</li>
+<li><strong>Missing config</strong> — <code>config/config.json</code> not found. Copy <code>config.sample.json</code><br>
+to <code>config/config.json</code>.</li>
+</ul>
+<h3>Data lost after restart</h3>
+<p>Make sure the <code>./data</code> directory exists and is mounted:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">mkdir -p data logs
+docker compose up -d
+</code></pre>
+<p>If the volume is missing from <code>docker-compose.yaml</code>, data is written inside the<br>
+container and lost on every <code>down</code>.</p>
+<h3>Can’t connect on Telnet</h3>
+<p>Verify the container is running and the port is mapped:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">docker compose ps
+docker compose port ursamu 4201
+</code></pre>
+<p>If running behind a firewall, open port <code>4201</code>:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># UFW
+sudo ufw allow 4201/tcp
+</code></pre>
+<h3>Permission errors on ./data or ./logs</h3>
+<pre class="language-bash" tabindex="0"><code class="language-bash">chmod 777 data logs
+</code></pre>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/deployment/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Production Deployment</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/first-script/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Build Your First Script</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/first-script/index.html
+++ b/docs/_site/guides/first-script/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -269,8 +269,7 @@
       <article class="prose">
         <h1>Build Your First Script</h1>
 <p>This guide walks you through writing a real script from scratch — starting with “hello world” and building up to something useful that reads player data and sends formatted output.</p>
-<p><strong>Prerequisites:</strong> UrsaMU running locally, a text editor, basic TypeScript familiarity.</p>
-<hr>
+<h2><strong>Prerequisites:</strong> UrsaMU running locally, a text editor, basic TypeScript familiarity.</h2>
 <h2>Step 1 — Hello World</h2>
 <p>Create a new file at <code>system/scripts/hello.ts</code>:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { IUrsamuSDK } from "../../src/@types/UrsamuSDK.ts";
@@ -299,8 +298,7 @@ export default (u: IUrsamuSDK) =&gt; {
   u.send(`Hello, ${name}! You are in room #${u.me.location}.`);
 };
 </code></pre>
-<p><code>u.util.displayName(obj, viewer)</code> returns the moniker if set, otherwise the name.</p>
-<hr>
+<h2><code>u.util.displayName(obj, viewer)</code> returns the moniker if set, otherwise the name.</h2>
 <h2>Step 3 — Read Arguments</h2>
 <p>Players can pass text after the command name. It’s available in <code>u.cmd.args[0]</code>:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { IUrsamuSDK } from "../../src/@types/UrsamuSDK.ts";
@@ -316,8 +314,7 @@ export default (u: IUrsamuSDK) =&gt; {
   u.send(`Hello, ${arg}!`);
 };
 </code></pre>
-<p>Type <code>hello Alice</code> → <code>Hello, Alice!</code></p>
-<hr>
+<h2>Type <code>hello Alice</code> → <code>Hello, Alice!</code></h2>
 <h2>Step 4 — Find Another Player</h2>
 <p>Use <code>u.util.target()</code> to resolve a name, ID, alias, <code>me</code>, or <code>here</code>:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { IUrsamuSDK } from "../../src/@types/UrsamuSDK.ts";
@@ -377,10 +374,9 @@ export default async (u: IUrsamuSDK) =&gt; {
 <p><strong>Always spread <code>u.me.state</code></strong> when writing back. If you omit the spread, you’ll<br>
 overwrite all other fields on the object.</p>
 </blockquote>
-<p>Type <code>wave</code> → <code>You have waved 1 time.</code><br>
+<h2>Type <code>wave</code> → <code>You have waved 1 time.</code><br>
 Type <code>wave</code> again → <code>You have waved 2 times.</code><br>
-Type <code>@wave/reset</code> (as admin) → <code>Wave count reset.</code></p>
-<hr>
+Type <code>@wave/reset</code> (as admin) → <code>Wave count reset.</code></h2>
 <h2>Step 6 — Format a Table</h2>
 <p>Use <code>u.util.ljust()</code>, <code>u.util.rjust()</code>, and <code>u.util.center()</code> to align columns:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { IUrsamuSDK } from "../../src/@types/UrsamuSDK.ts";
@@ -424,8 +420,7 @@ export default (u: IUrsamuSDK) =&gt; {
   // ... your script
 };
 </code></pre>
-<p>Now <code>sheet</code>, <code>sc</code>, <code>@sheet</code>, and <code>@sc</code> all trigger this script.</p>
-<hr>
+<h2>Now <code>sheet</code>, <code>sc</code>, <code>@sheet</code>, and <code>@sc</code> all trigger this script.</h2>
 <h2>Next Steps</h2>
 <ul>
 <li>Read the <a href="/ursamu/guides/scripting/">SDK Reference</a> for every available method</li>
@@ -489,11 +484,59 @@ export default (u: IUrsamuSDK) =&gt; {
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -526,16 +569,16 @@ export default (u: IUrsamuSDK) =&gt; {
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/customization/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/docker/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">Customization Guide</span>
+            <span class="page-nav-title">Docker</span>
           </a>
         
 
         
-          <a href="/ursamu/guides/installation/" class="page-nav-btn next">
+          <a href="/ursamu/guides/gameclock/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">Installation Guide</span>
+            <span class="page-nav-title">Game Clock</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/gameclock/index.html
+++ b/docs/_site/guides/gameclock/index.html
@@ -1,0 +1,809 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Game Clock | UrsaMU Documentation</title>
+  <meta name="description" content="UrsaMU's persistent in-game time system — calendar, configuration, and scripting patterns.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/gameclock/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Game Clock</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Game Clock</h1>
+<h2>UrsaMU includes a persistent in-game time system called GameClock. It runs<br>
+independently from the real-world clock and can advance faster or slower than<br>
+real time. This lets you run a fantasy calendar, track seasons, and write<br>
+time-aware scripts.</h2>
+<h2>Overview</h2>
+<p>The GameClock stores time as a single integer — <strong>game-minutes</strong> elapsed since<br>
+the fictional epoch (Year 1, Month 1, Day 1, 00:00). Each real-world minute,<br>
+the clock advances by <code>game.timeMultiplier</code> game-minutes. At the default<br>
+multiplier of <code>1.0</code>, game time and real time pass at the same rate.</p>
+<h2>The clock persists across server reboots. Its state is stored in the database<br>
+under the key <code>server.gameclock</code>.</h2>
+<h2>Calendar System</h2>
+<table>
+<thead>
+<tr>
+<th>Unit</th>
+<th>Range</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Year</td>
+<td>1 +</td>
+<td>No upper limit</td>
+</tr>
+<tr>
+<td>Month</td>
+<td>1–12</td>
+<td>12 months per year</td>
+</tr>
+<tr>
+<td>Day</td>
+<td>1–28</td>
+<td>28 days per month</td>
+</tr>
+<tr>
+<td>Hour</td>
+<td>0–23</td>
+<td>24-hour clock</td>
+</tr>
+<tr>
+<td>Minute</td>
+<td>0–59</td>
+<td>60 minutes per hour</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Constants:</strong></p>
+<ul>
+<li>60 minutes per hour</li>
+<li>1,440 minutes per day</li>
+<li>40,320 minutes per month</li>
+<li>483,840 minutes per year</li>
+</ul>
+<h2>Month and day names are not built in — you define them in your game’s scripts.</h2>
+<h2>Configuration</h2>
+<p>Set the time multiplier in <code>config/game.json</code> (or your config file):</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "game": {
+    "timeMultiplier": 2.0
+  }
+}
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Multiplier</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>0.5</code></td>
+<td>1 game-minute per 2 real minutes (half speed)</td>
+</tr>
+<tr>
+<td><code>1.0</code></td>
+<td>1 game-minute per 1 real minute (real time)</td>
+</tr>
+<tr>
+<td><code>2.0</code></td>
+<td>2 game-minutes per real minute (double speed)</td>
+</tr>
+<tr>
+<td><code>24.0</code></td>
+<td>1 game-day per real hour</td>
+</tr>
+<tr>
+<td><code>336.0</code></td>
+<td>1 game-year per real day</td>
+</tr>
+</tbody>
+</table>
+<p>The multiplier can also be changed at runtime from an admin script:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.sys.setConfig("game.timeMultiplier", 2.0);
+</code></pre>
+<hr>
+<h2>Reading Game Time</h2>
+<p>Use <code>u.sys.gameTime()</code> in any script or command handler.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+// t.year:   number (1, 2, 3, …)
+// t.month:  1–12
+// t.day:    1–28
+// t.hour:   0–23
+// t.minute: 0–59
+
+// Simple formatted string
+const hh = String(t.hour).padStart(2, "0");
+const mm = String(t.minute).padStart(2, "0");
+u.send(`It is Year ${t.year}, Month ${t.month}, Day ${t.day}, ${hh}:${mm}.`);
+</code></pre>
+<h3>Custom calendar names</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const MONTHS = [
+  "", "Frostmonth", "Snowmelt", "Seedsown", "Bloomtide",
+  "Highsun", "Harvestmoon", "Goldleaf", "Ashfall",
+  "Dimming", "Winterset", "Coldwatch", "Longnight"
+];
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const t = await u.sys.gameTime();
+const dayOfWeek = ((t.day - 1) % 7);  // 0-based, repeating
+const hh = String(t.hour).padStart(2, "0");
+const mm = String(t.minute).padStart(2, "0");
+
+u.send(`${DAYS[dayOfWeek]}, ${MONTHS[t.month]} ${t.day}, Year ${t.year} — ${hh}:${mm}`);
+// → "Tue, Bloomtide 15, Year 340 — 08:00"
+</code></pre>
+<h3>In native plugin commands</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameClock } from "../../services/GameClock/index.ts";
+
+const t = gameClock.now();
+const formatted = gameClock.format();   // "Year 340, Month 4, Day 15, 08:00"
+</code></pre>
+<hr>
+<h2>Setting Game Time</h2>
+<p>Requires wizard or admin. <strong>The SDK does not enforce this</strong> — check flags in<br>
+your script.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Guard
+if (!u.me.flags.has("wizard") &amp;&amp; !u.me.flags.has("admin") &amp;&amp; !u.me.flags.has("superuser")) {
+  u.send("Permission denied.");
+  return;
+}
+
+// Set the full date/time
+await u.sys.setGameTime({
+  year:   340,
+  month:  6,
+  day:    1,
+  hour:   8,
+  minute: 0,
+});
+
+u.broadcast("The calendar has been reset to Midsummer, Year 340.");
+</code></pre>
+<p>You can set partial fields by reading the current time first:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+
+// Jump to the next day, same time
+await u.sys.setGameTime({
+  ...t,
+  day: t.day + 1 &gt; 28 ? 1 : t.day + 1,
+  month: t.day + 1 &gt; 28 ? t.month + 1 : t.month,
+});
+</code></pre>
+<hr>
+<h2>Scripting Patterns</h2>
+<h3>Display time in a score sheet</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+const hh = String(t.hour).padStart(2, "0");
+const mm = String(t.minute).padStart(2, "0");
+const dateLine = u.util.sprintf(
+  "%-20s %s",
+  "In-Game Date:",
+  `Month ${t.month}, Day ${t.day}, Year ${t.year} — ${hh}:${mm}`
+);
+u.send(dateLine);
+</code></pre>
+<h3>Seasonal check</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+
+// Months 12, 1, 2 = Winter; 3-5 = Spring; 6-8 = Summer; 9-11 = Autumn
+function getSeason(month: number): string {
+  if (month === 12 || month &lt;= 2) return "Winter";
+  if (month &lt;= 5) return "Spring";
+  if (month &lt;= 8) return "Summer";
+  return "Autumn";
+}
+
+const season = getSeason(t.month);
+u.send(`It is currently ${season}.`);
+</code></pre>
+<h3>Night vs. day</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+const isNight = t.hour &lt; 6 || t.hour &gt;= 20;
+
+if (isNight) {
+  u.send("The room is lit only by moonlight.");
+} else {
+  u.send("Sunlight streams through the windows.");
+}
+</code></pre>
+<h3>Store a timestamp on an object</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const t = await u.sys.gameTime();
+// Store as a simple object in state
+await u.db.modify(u.me.id, "$set", {
+  "data.lastSeen": { year: t.year, month: t.month, day: t.day }
+});
+</code></pre>
+<h3>Read a stored timestamp</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const ts = u.me.state.lastSeen as { year: number; month: number; day: number } | undefined;
+if (ts) {
+  u.send(`You were last seen on Month ${ts.month}, Day ${ts.day}, Year ${ts.year}.`);
+}
+</code></pre>
+<hr>
+<h2>The +time Command</h2>
+<p>Players can check the current game time with:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">+time
+</code></pre>
+<p>Output example:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">The current in-game time is:
+  Year 340, Month 4, Day 15, 08:32
+</code></pre>
+<h2>The system script is at <code>system/scripts/time.ts</code>. To customize the output<br>
+format or add a custom calendar, copy the script and modify it.</h2>
+<h2>Notes</h2>
+<ul>
+<li>The clock only advances while the server is running. It does not catch up<br>
+after downtime.</li>
+<li>Setting <code>game.timeMultiplier</code> to <code>0</code> freezes time.</li>
+<li>The epoch is stored as a single floating-point number, so fractional minutes<br>
+are tracked internally but the <code>IGameTime</code> fields are always integers.</li>
+<li>There is no built-in alarm or cron system — use <code>u.events.emit</code> to trigger<br>
+events at specific game times if you need that behavior.</li>
+</ul>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/first-script/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Build Your First Script</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/help-authoring/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Writing Help Files</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/help-authoring/index.html
+++ b/docs/_site/guides/help-authoring/index.html
@@ -1,0 +1,879 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Writing Help Files | UrsaMU Documentation</title>
+  <meta name="description" content="How to create and organize in-game help files for UrsaMU players using the help-plugin.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/help-authoring/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Writing Help Files</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Writing Help Files</h1>
+<p>The <code>help</code> command is provided by the <strong><a href="https://github.com/UrsaMU/help-plugin">help-plugin</a></strong>, which<br>
+is bundled in the default <code>plugins.manifest.json</code> and installed automatically on first run. It replaces<br>
+the former built-in help command.</p>
+<h2>The plugin reads Markdown (<code>.md</code>) and plain text (<code>.txt</code>) files from the <code>help/</code> directory, merges<br>
+them with any DB-stored entries and inline command help, then renders everything with MUSH color codes<br>
+word-wrapped to 78 characters.</h2>
+<h2>Overview</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">help/
+├── mail/
+│   ├── index.md       ← shown for "help mail"
+│   ├── send.md        ← shown for "help mail/send" or "help send"
+│   └── reply.md
+├── building/
+│   ├── @dig.md        ← shown for "help dig" (@ stripped from lookup)
+│   └── @lock.md
+└── _admin/
+    └── reboot.md      ← shown for "help reboot"
+</code></pre>
+<hr>
+<h2>Directory Structure</h2>
+<p>Each subdirectory of <code>help/</code> becomes a <strong>category</strong> listed on the help index.<br>
+Players can type <code>help &lt;category&gt;</code> to see all topics in that category.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">help/
+  social/     ← "help social" lists subtopics
+  building/   ← "help building" lists subtopics
+  mail/       ← "help mail" shows index.md + subtopics
+  info/
+  comsys/
+  chargen/
+  _admin/     ← visible category, underscore is cosmetic only
+</code></pre>
+<h3>Category index file</h3>
+<p>If a directory contains <code>index.md</code> (or <code>readme.md</code>), that file’s content is<br>
+shown when a player types <code>help &lt;category&gt;</code>. Topics in the directory are<br>
+listed automatically below it as sub-topics.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">help/mail/index.md  →  shown for "help mail"
+</code></pre>
+<h2>You don’t need to manually list subtopics — they appear automatically.</h2>
+<h2>File Naming</h2>
+<h3>Basic names</h3>
+<p>Any <code>.md</code> or <code>.txt</code> file in <code>help/</code> or a subdirectory becomes a help topic.<br>
+The filename (without extension) is the topic name.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">help/social/say.md      →  "help say"  or  "help social/say"
+help/building/link.md   →  "help link" or  "help building/link"
+</code></pre>
+<h3><code>@</code> prefix</h3>
+<p>Files named <code>@command.md</code> are accessible as both <code>help @command</code> and<br>
+<code>help command</code> — the <code>@</code> is stripped automatically. Use this for commands<br>
+whose in-game name starts with <code>@</code>.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">help/building/@dig.md   →  "help dig"  or  "help @dig"
+help/building/@lock.md  →  "help lock" or  "help @lock"
+</code></pre>
+<h3><code>help_</code> and <code>topic_</code> prefixes</h3>
+<p>These prefixes are also stripped. <code>help_say.md</code> is the same as <code>say.md</code>.<br>
+Prefer bare names — the prefixes exist for legacy compatibility only.</p>
+<h3>Global vs. scoped lookup</h3>
+<h2>When a player types <code>help send</code>, the system finds the first matching file<br>
+anywhere in the hierarchy. To force a scoped lookup they type <code>help mail/send</code>.<br>
+If two files in different categories share a name, only the first match is<br>
+returned — use scoped paths to avoid ambiguity.</h2>
+<h2>Markdown Support</h2>
+<p>Help files are valid Markdown. The following elements are rendered with MUSH<br>
+color codes before display:</p>
+<h3>Headers</h3>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown"># COMMAND NAME        ← bold cyan — use for the top-level title
+## Section heading    ← bold yellow
+### Subsection        ← bold white
+</code></pre>
+<h3>Inline code and code blocks</h3>
+<p>Inline code (<code>`code`</code>) renders in <strong>green</strong>. Use it for command syntax,<br>
+flag names, and exact strings players should type.</p>
+<p>Fenced code blocks (<code>```</code>) render as an indented green block — ideal for<br>
+multi-line examples:</p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">```
+&gt; mail Bob
+Draft started.
+&gt; mail send
+Message sent.
+```
+</code></pre>
+<h3>Lists</h3>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">- First item
+- Second item
+</code></pre>
+<p>Renders as:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">  • First item
+  • Second item
+</code></pre>
+<h3>Bold and italic</h3>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">**important thing**   ← bold white
+*emphasized*          ← italic
+</code></pre>
+<h3>Word wrap</h3>
+<h2>All text is automatically word-wrapped at <strong>78 characters</strong>. You do not need<br>
+to manually break lines — write prose naturally and the renderer handles it.<br>
+Indentation on list items is preserved across wrapped lines.</h2>
+<h2>Tables</h2>
+<p>Markdown tables are fully supported and are formatted to fit within 78<br>
+characters. Write them in standard Markdown syntax:</p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">| Command | Description |
+|---------|-------------|
+| `mail &lt;player&gt;` | Start a draft to a player |
+| `mail send` | Send the current draft |
+| `mail delete &lt;#&gt;` | Delete a message by number |
+</code></pre>
+<p>The renderer:</p>
+<ul>
+<li>Colors the header row bold yellow</li>
+<li>Colors inline code in cells green</li>
+<li>Distributes column widths proportionally if the natural widths exceed 78 chars</li>
+<li>Word-wraps individual cells that overflow their column</li>
+</ul>
+<h2>For tables with many columns or long content, prefer two-column layouts — they<br>
+give the most readable result at 78 characters.</h2>
+<h2>Color Codes</h2>
+<p>You can use MUSH color codes directly in help files for custom styling:</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>%ch</code></td>
+<td>Bold / bright</td>
+</tr>
+<tr>
+<td><code>%cn</code></td>
+<td>Reset to default</td>
+</tr>
+<tr>
+<td><code>%cr</code></td>
+<td>Red</td>
+</tr>
+<tr>
+<td><code>%cg</code></td>
+<td>Green</td>
+</tr>
+<tr>
+<td><code>%cy</code></td>
+<td>Yellow</td>
+</tr>
+<tr>
+<td><code>%cb</code></td>
+<td>Blue</td>
+</tr>
+<tr>
+<td><code>%cm</code></td>
+<td>Magenta</td>
+</tr>
+<tr>
+<td><code>%cc</code></td>
+<td>Cyan</td>
+</tr>
+<tr>
+<td><code>%cw</code></td>
+<td>White</td>
+</tr>
+<tr>
+<td><code>%ci</code></td>
+<td>Italic</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example:</strong></p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">%ch%cyWARNING:%cn This destroys the object permanently.
+</code></pre>
+<p>Renders as bold yellow “WARNING:” followed by normal text.</p>
+<blockquote>
+<p><strong>Tip:</strong> Use color sparingly. The Markdown renderer already styles headers,<br>
+code, and lists consistently. Reserve manual color codes for callouts and<br>
+warnings.</p>
+</blockquote>
+<hr>
+<h2>How Players Access Help</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">help                  ← shows all topics in a 4-column index
+help mail             ← shows mail/index.md + subtopic list
+help mail/send        ← shows mail/send.md directly
+help send             ← finds the first file named "send" anywhere
+help @dig             ← finds building/@dig.md
+help dig              ← same result (@ stripped on lookup)
+help/section mail     ← lists all topics in the mail section
+</code></pre>
+<hr>
+<h2>Admin Commands</h2>
+<p>Admins and wizards can create, update, and delete help entries at runtime<br>
+without touching the filesystem. DB entries take priority over file-based<br>
+entries (priority 100 vs 50).</p>
+<pre class="language-none" tabindex="0"><code class="language-none">+help/set &lt;topic&gt;=&lt;text&gt;   ← create or update a DB help entry
++help/del &lt;topic&gt;          ← delete a DB help entry
++help/reload               ← bust the file cache (pick up new files)
+</code></pre>
+<h2><code>&lt;text&gt;</code> supports the same Markdown syntax as file-based entries. Use <code>\n</code><br>
+for line breaks when typing multi-line content in-game.</h2>
+<h2>REST API</h2>
+<p>The plugin exposes a REST API for reading and managing help entries externally.</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Path</th>
+<th>Auth</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/help</code></td>
+<td>public</td>
+<td>List all sections and topics</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/help/:topic</code></td>
+<td>public</td>
+<td>Fetch a single topic (<code>?format=md</code> for raw)</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/help/:topic</code></td>
+<td>admin</td>
+<td>Create or update an entry</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/help/:topic</code></td>
+<td>admin</td>
+<td>Delete an entry</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example — fetch a topic as Markdown:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/help/dig?format=md
+Authorization: Bearer &lt;token&gt;
+</code></pre>
+<hr>
+<h2>Per-Plugin Help Folders</h2>
+<p>Plugins can register their own help directories so their topics appear in the<br>
+global index without copying files into the game’s <code>help/</code> folder. Call<br>
+<code>registerHelpDir()</code> inside your plugin’s <code>init()</code>:</p>
+<pre class="language-ts" tabindex="0"><code class="language-ts">import { registerHelpDir } from "jsr:@ursamu/help-plugin";
+import { fromFileUrl } from "@std/path";
+
+export default {
+  name: "my-plugin",
+  async init() {
+    registerHelpDir(fromFileUrl(new URL("../help", import.meta.url)));
+  }
+} satisfies IPlugin;
+</code></pre>
+<h2>The directory is scanned on startup (and on <code>+help/reload</code>). Files follow the<br>
+same naming conventions as the main <code>help/</code> folder.</h2>
+<h2>Tips</h2>
+<h3>Structure for commands</h3>
+<p>Follow this pattern for individual command topics — it keeps help consistent<br>
+across the game:</p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown"># COMMAND NAME
+
+One-sentence description of what the command does.
+
+## Syntax
+
+`command &lt;required&gt; [optional]`
+
+## Description
+
+Longer explanation. What it does, when to use it, any caveats.
+
+## Examples
+
+</code></pre>
+<blockquote>
+<p>command argument<br>
+Result shown here.</p>
+</blockquote>
+<pre class="language-none" tabindex="0"><code class="language-none">
+## See Also
+
+- `related-command` — brief note on why it's related
+</code></pre>
+<h3>Keep the title uppercase</h3>
+<p>By convention, top-level <code>#</code> headers are ALL CAPS (<code># MAIL SEND</code>, <code># @DIG</code>).<br>
+This matches classic MUSH help style and looks correct after the cyan coloring<br>
+is applied.</p>
+<h3>Avoid deep nesting</h3>
+<p>Two levels of directories (<code>help/category/topic.md</code>) is the practical maximum.<br>
+Three or more levels are not surfaced cleanly in the subtopic listing.</p>
+<h3>Admin-only topics</h3>
+<p>Put topics that should only be visible to staff in a directory prefixed with<br>
+<code>_</code> (e.g., <code>help/_admin/</code>). The underscore is cosmetic — the files are still<br>
+accessible to anyone who knows the topic name. If you need truly restricted<br>
+help, use <code>+help/set</code> to store the entry in the DB and gate display logic via<br>
+a plugin hook on <code>help:lookup</code>.</p>
+<h3>Test your file</h3>
+<p>Connect as a player and type <code>help &lt;yourtopic&gt;</code>. Check that:</p>
+<ul>
+<li>Line lengths fit within 78 characters</li>
+<li>Tables align properly</li>
+<li>Code blocks are indented and green</li>
+<li>No raw Markdown syntax leaks through</li>
+</ul>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/gameclock/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Game Clock</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/installation/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Installation Guide</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/index.html
+++ b/docs/_site/guides/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,57 +268,56 @@
       <!-- Page content -->
       <article class="prose">
         <h1>UrsaMU Guides</h1>
-<p>This section contains comprehensive guides and tutorials to help you get started<br>
-with UrsaMU, whether you’re installing it for the first time, learning how to<br>
-use it as a player, or administering your own server.</p>
-<h2>Installation Guide</h2>
-<p>Learn how to install and set up UrsaMU on your system:</p>
+<p>User guides and tutorials for UrsaMU v2.6.0 — installation, day-to-day play,<br>
+admin operations, plugin development, and softcoding.</p>
+<h2>Getting Started</h2>
 <ul>
-<li><a href="/ursamu/guides/installation/#prerequisites">Prerequisites</a></li>
-<li><a href="/ursamu/guides/installation/#installation-methods">Installation Methods</a></li>
-<li><a href="/ursamu/guides/installation/#configuration">Configuration</a></li>
-<li><a href="/ursamu/guides/installation/#running-the-server">Running the Server</a></li>
+<li><a href="/ursamu/guides/installation/"><strong>Installation</strong></a> — Prerequisites, install methods,<br>
+first-run setup, and connecting.</li>
+<li><a href="/ursamu/guides/user-guide/"><strong>User Guide</strong></a> — Connecting and playing as a player.</li>
+<li><a href="/ursamu/guides/cli/"><strong>CLI Reference</strong></a> — <code>ursamu create</code>, <code>plugin</code>, <code>update</code>, <code>scripts</code>.</li>
 </ul>
-<h2>User Guide</h2>
-<p>Learn how to use UrsaMU as a player:</p>
+<h2>Operating a Server</h2>
 <ul>
-<li><a href="/ursamu/guides/user-guide/#getting-started">Getting Started</a></li>
-<li><a href="/ursamu/guides/user-guide/#basic-commands">Basic Commands</a></li>
-<li><a href="/ursamu/guides/user-guide/#character-creation">Character Creation</a></li>
-<li><a href="/ursamu/guides/user-guide/#communication">Communication</a></li>
+<li><a href="/ursamu/guides/admin-guide/"><strong>Admin Guide</strong></a> — Permissions, user management,<br>
+configuration, <code>@reload</code>, plugin install behavior, security.</li>
+<li><a href="/ursamu/guides/deployment/"><strong>Production Deployment</strong></a> — <code>.env</code> and <code>JWT_SECRET</code>,<br>
+<code>scripts/daemon.sh</code>, systemd, nginx + TLS, log rotation, updates.</li>
+<li><a href="/ursamu/guides/docker/"><strong>Docker</strong></a> — Containerized deployment with <code>docker compose</code>.</li>
+<li><a href="/ursamu/guides/password-reset/"><strong>Password Reset</strong></a> — Admin tokens, player flow,<br>
+REST API.</li>
+<li><a href="/ursamu/guides/debugging/"><strong>Debugging</strong></a> — Common runtime errors and how to fix them.</li>
 </ul>
-<h2>Admin Guide</h2>
-<p>Learn how to administer an UrsaMU server:</p>
+<h2>Customizing the Game</h2>
 <ul>
-<li><a href="/ursamu/guides/admin-guide/#user-management">User Management</a></li>
-<li><a href="/ursamu/guides/admin-guide/#server-configuration">Server Configuration</a></li>
-<li><a href="/ursamu/guides/admin-guide/#backup-and-restore">Backup and Restore</a></li>
-<li><a href="/ursamu/guides/admin-guide/#troubleshooting">Troubleshooting</a></li>
+<li><a href="/ursamu/guides/customization/"><strong>Customization</strong></a> — Color codes, custom commands,<br>
+attributes, plugins, REST routes, format handlers, external integrations.</li>
+<li><a href="/ursamu/guides/lock-expressions/"><strong>Lock Expressions</strong></a> — Lockfunc syntax, boolean<br>
+operators, custom lockfuncs via <code>registerLockFunc</code>.</li>
+<li><a href="/ursamu/guides/commands/"><strong>Command Reference</strong></a> — All built-in commands.</li>
+<li><a href="/ursamu/guides/help-authoring/"><strong>Help Authoring</strong></a> — Writing help files, directory<br>
+structure, conventions.</li>
 </ul>
-<h2>Scripting Guide</h2>
-<p>Write TypeScript/JS scripts that run in the sandboxed SDK:</p>
+<h2>Writing Code</h2>
 <ul>
-<li><a href="/ursamu/guides/scripting/#how-scripting-works">How scripting works</a></li>
-<li><a href="/ursamu/guides/scripting/#the-sdk-u">The SDK (<code>u</code>)</a></li>
-<li><a href="/ursamu/guides/scripting/#writing-a-script">Writing a script</a></li>
-<li><a href="/ursamu/guides/scripting/#testing-scripts">Testing scripts</a></li>
+<li><a href="/ursamu/guides/scripting/"><strong>Scripting</strong></a> — Sandbox model, the <code>u</code> SDK, ESM vs legacy<br>
+blocks, aliases and switches.</li>
+<li><a href="/ursamu/guides/first-script/"><strong>Build Your First Script</strong></a> — Step-by-step walkthrough.</li>
+<li><a href="/ursamu/guides/sdk-cookbook/"><strong>SDK Cookbook</strong></a> — Every <code>u.*</code> namespace with examples.</li>
+<li><a href="/ursamu/guides/softcoding/"><strong>Soft-Coding</strong></a> — Storing scripts in attributes, parent<br>
+inheritance, <code>@trigger</code> / <code>u.trigger</code> / <code>u.eval</code>.</li>
+<li><a href="/ursamu/guides/recipes/"><strong>Recipes</strong></a> — Copy-paste patterns for common tasks.</li>
+<li><a href="/ursamu/guides/gameclock/"><strong>Game Clock</strong></a> — <code>u.sys.gameTime</code> and the in-game calendar.</li>
+</ul>
+<h2>Game Systems</h2>
+<ul>
+<li><a href="/ursamu/guides/scenes/"><strong>Scenes</strong></a> — Collaborative RP logs: create, pose, export.</li>
+<li><a href="/ursamu/guides/wiki/"><strong>Wiki</strong></a> — File-based Markdown wiki with frontmatter and REST.</li>
 </ul>
 <h2>MUSH Compatibility</h2>
-<p>Coming from PennMUSH, TinyMUSH, or MUX2? See what works today and what’s planned:</p>
-<ul>
-<li><a href="../mush_compatibility/#what-works-today">What works today</a></li>
-<li><a href="../mush_compatibility/#whats-different-from-traditional-mush">What’s different</a></li>
-<li><a href="../mush_compatibility/#planned-enhancements">Planned enhancements</a></li>
-<li><a href="../mush_compatibility/#connecting-with-a-traditional-mu-client">Connecting with MU* clients</a></li>
-</ul>
-<h2>Customization</h2>
-<p>Learn how to customize your UrsaMU server:</p>
-<ul>
-<li><a href="/ursamu/guides/customization/#themes">Themes</a></li>
-<li><a href="/ursamu/guides/customization/#commands">Commands</a></li>
-<li><a href="/ursamu/guides/customization/#game-mechanics">Game Mechanics</a></li>
-<li><a href="/ursamu/guides/customization/#integration">Integration</a></li>
-</ul>
+<p>Coming from PennMUSH, TinyMUSH, or MUX2? See<br>
+<a href="/ursamu/mush_compatibility/">mush compatibility</a> for what works today, what<br>
+differs, and how to connect with traditional MU* clients.</p>
 
       </article>
 
@@ -363,11 +362,49 @@ use it as a player, or administering your own server.</p>
       
         
           
+        
+      
+        
           
         
       
         
           
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         

--- a/docs/_site/guides/installation/index.html
+++ b/docs/_site/guides/installation/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,185 +268,171 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Installation Guide</h1>
-<p>This guide will walk you through the process of installing and setting up UrsaMU<br>
-on your system.</p>
+<p>Install Deno 2.x, scaffold a game with the CLI, start the server, then<br>
+claim the first staff account on the web portal.</p>
 <h2>Prerequisites</h2>
-<p>Before installing UrsaMU, ensure you have the following:</p>
 <ul>
-<li><a href="https://deno.land/"><strong>Deno</strong></a> version 1.32.0 or higher</li>
-<li>Git (for cloning the repository)</li>
+<li><a href="https://deno.land/"><strong>Deno</strong></a> v2.x</li>
+<li>Git (optional — for cloning the monorepo or git-based plugins)</li>
 </ul>
-<h2>Installation Methods</h2>
-<p>UrsaMU can be installed in multiple ways. Choose the method that works best for<br>
-your environment.</p>
-<h3>⚡ The UrsaMU DX Experience (Recommended)</h3>
-<p>The easiest way to set up and manage your UrsaMU world is using the <strong>UrsaMU<br>
-DX</strong> one-liner. This interactive wizard will walk you through naming your<br>
-project, configuring ports, and setting up your first administrator account.</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">deno install -A --global -n deno-x jsr:@dx/dx
-deno x --install-alias
-dx jsr:@ursamu/ursamu init
-</code></pre>
-<hr>
-<h3>Method 1: Direct from GitHub</h3>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Clone the repository
-git clone https://github.com/ursamu/ursamu.git
-
-# Navigate to the project directory
-cd ursamu
-
-# Set up configuration
-deno task setup-config
-</code></pre>
-<h3>Method 2: Using the UrsaMU CLI</h3>
-<p>UrsaMU provides a CLI tool for creating new projects:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Install the UrsaMU CLI
-deno task install-cli
-
-# Create a new project
-ursamu create my-game
+<h2>Method 1: Scaffold from JSR (recommended)</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/create my-game
 cd my-game
-</code></pre>
-<h3>Method 3: Using Docker</h3>
-<p>UrsaMU provides a Docker image for easy deployment:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Clone the repository
-git clone https://github.com/ursamu/ursamu.git
-cd ursamu
-
-# Start the server with Docker Compose
-docker-compose up -d
-</code></pre>
-<p>The game databases will be exported to the <code>data/</code> directory, and configuration<br>
-will be stored in the <code>config/</code> directory.</p>
-<h2>Configuration</h2>
-<p>UrsaMU uses a flexible configuration system stored in JSON format:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Show the entire configuration
-deno task config
-
-# Get a specific configuration value
-deno task config --get server.ws
-
-# Set a configuration value
-deno task config --set server.ws 4202
-</code></pre>
-<p>The configuration is stored in <code>config/config.json</code> and includes:</p>
-<ul>
-<li>Server ports and database paths</li>
-<li>Game name, description, and version</li>
-<li>Text file locations</li>
-<li>Plugin settings</li>
-</ul>
-<p>For detailed information on all available configuration options, see the<br>
-<a href="../configuration/">Configuration Guide</a>.</p>
-<h2>Running the Server</h2>
-<p>UrsaMU uses a dual-server architecture with the main server and telnet server<br>
-running as separate processes:</p>
-<h3>Starting Both Servers</h3>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Start both main and telnet servers with watch mode
 deno task start
 </code></pre>
-<p>This will:</p>
+<p>The scaffold writes a supervised game project with:</p>
 <ul>
-<li>Start both the main server and telnet server as separate processes</li>
-<li>Enable watch mode for automatic reloading when files change</li>
-<li>Allow each server to restart independently</li>
+<li><code>deno.json</code> — tasks (<code>start</code>, <code>dev</code>, <code>daemon</code>, …)</li>
+<li><code>config/config.json</code> — ports, plugins, optional site nav</li>
+<li><code>.env</code> — fresh <code>JWT_SECRET</code></li>
+<li><code>scripts/</code> — <code>daemon.sh</code>, <code>stop.sh</code>, <code>restart.sh</code>, <code>status.sh</code></li>
+<li>Default <strong>portal stack</strong>: builder, channels, help, bbs, mail, wiki,<br>
+<code>@ursamu/web</code> (staff), <code>@ursamu/site</code> (public FE + <code>/play</code>)</li>
 </ul>
-<h3>Development Mode</h3>
-<p>For development with individual servers:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash"># Main server only with watch mode
-deno task server
-
-# Telnet server only with watch mode
-deno task telnet
+<p>When <code>@ursamu/site</code> is selected, config sets<br>
+<code>plugins.site.serveRoot: true</code> so the public site is served at <code>/</code>.</p>
+<p>Optional: interactive menu and package picker:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/ursamu
 </code></pre>
+<p>Engine-dev mode (link imports to a local monorepo checkout):</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/create my-game --local
+</code></pre>
+<blockquote>
+<p><strong>Imports:</strong> game code uses <code>jsr:@ursamu/mush</code>. The legacy package<br>
+<code>jsr:@ursamu/ursamu</code> re-exports the same surface.</p>
+</blockquote>
+<h2>Method 2: From the monorepo</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">git clone https://github.com/ursamu/ursamu.git
+cd ursamu
+deno run -A packages/cli/src/create.ts my-game --local
+cd my-game
+deno task start
+</code></pre>
+<p>Use this when contributing to the engine or testing unreleased packages.</p>
+<h2>Default ports</h2>
+<table>
+<thead>
+<tr>
+<th>Port</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>4201</code></td>
+<td>Telnet (sidecar)</td>
+</tr>
+<tr>
+<td><code>4202</code></td>
+<td>WebSocket game hub</td>
+</tr>
+<tr>
+<td><code>4203</code></td>
+<td>HTTP — REST API, <code>/admin</code>, public site, static assets</td>
+</tr>
+</tbody>
+</table>
+<p>Override with <code>URSAMU_HTTP_PORT</code> / <code>URSAMU_TELNET_PORT</code> or edit<br>
+<code>config/config.json</code> (<code>server.telnet</code>, <code>server.wsPort</code>, <code>server.apiPort</code>).</p>
 <h2>Connecting</h2>
-<h3>MU* Clients (Recommended for most players)</h3>
-<p>The easiest way to connect is with a standard MU* client over Telnet (port <code>4201</code>):</p>
+<h3>Web portal (default stack)</h3>
+<table>
+<thead>
+<tr>
+<th>URL</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>http://localhost:4203/</code></td>
+<td>Public site home</td>
+</tr>
+<tr>
+<td><code>http://localhost:4203/play</code></td>
+<td>Browser play client (sign-in)</td>
+</tr>
+<tr>
+<td><code>http://localhost:4203/admin/</code></td>
+<td>Staff console</td>
+</tr>
+<tr>
+<td><code>http://localhost:4203/wiki/</code></td>
+<td>Wiki (when installed)</td>
+</tr>
+</tbody>
+</table>
+<h3>MU* clients (Telnet)</h3>
 <table>
 <thead>
 <tr>
 <th>Client</th>
 <th>Platform</th>
-<th>Download</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><strong>Mudlet</strong></td>
-<td>Windows / Mac / Linux</td>
-<td><a href="https://www.mudlet.org/">mudlet.org</a></td>
+<td><a href="https://www.mudlet.org/">Mudlet</a></td>
+<td>Win / Mac / Linux</td>
 </tr>
 <tr>
-<td><strong>MUSHclient</strong></td>
+<td><a href="https://www.mushclient.com/">MUSHclient</a></td>
 <td>Windows</td>
-<td><a href="https://mushclient.com/">mushclient.com</a></td>
 </tr>
 <tr>
-<td><strong>Potato</strong></td>
-<td>Windows / Mac / Linux</td>
-<td><a href="https://www.potatomushclient.com/">potatomushclient.com</a></td>
+<td><a href="https://www.potatomushclient.com/">Potato</a></td>
+<td>Win / Mac / Linux</td>
 </tr>
 <tr>
-<td>Any terminal</td>
-<td>Any</td>
 <td><code>telnet localhost 4201</code></td>
+<td>Any terminal</td>
 </tr>
 </tbody>
 </table>
-<p>In your client, add a new connection profile with:</p>
+<h3>WebSocket (custom clients)</h3>
+<p>Connect to <code>ws://localhost:4202</code> (game hub) with a JWT from<br>
+<code>POST /api/v1/auth/login</code>, or use the site play client which handles<br>
+auth for you.</p>
+<h2>First admin / superuser</h2>
+<p>With an <strong>empty database</strong>:</p>
+<ol>
+<li>Prefer the web path: open <code>/register</code> (or site login → register).</li>
+<li>The <strong>first web registrant</strong> is granted <code>superuser</code>.</li>
+<li>Telnet still works: <code>create &lt;name&gt; &lt;password&gt;</code> when no players<br>
+exist also promotes the first character.</li>
+</ol>
+<p>After that, grant staff with in-game flags (<code>@set &lt;player&gt;=admin</code>) or<br>
+the staff console. The <code>superuser</code> flag is only auto-granted on the<br>
+empty-DB first-account flow.</p>
+<h2>Configuration</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># From a scaffolded game project
+deno task config
+deno task config --get server.apiPort
+deno task config --set game.name "My MUSH"
+</code></pre>
+<p>Config lives in <code>config/config.json</code>. Common keys:</p>
 <ul>
-<li><strong>Host</strong>: <code>localhost</code> (or your server’s hostname/IP)</li>
-<li><strong>Port</strong>: <code>4201</code></li>
+<li><code>server.telnet</code> / <code>server.wsPort</code> / <code>server.apiPort</code></li>
+<li><code>server.plugins</code> — JSR package list loaded at boot</li>
+<li><code>plugins.site</code> — public shell (<code>serveRoot</code>, <code>skin</code>, <code>nav</code>, …)</li>
+<li><code>game.name</code>, <code>game.playerStart</code>, layout templates</li>
 </ul>
-<p>Once connected, type <code>create YourName YourPassword</code> to create a character, or<br>
-<code>connect YourName YourPassword</code> to log in.</p>
-<h3>Web Client</h3>
-<p>UrsaMU ships with an optional browser-based client. To start it:</p>
-<pre class="language-bash" tabindex="0"><code class="language-bash">cd src/web-client
-deno task start
+<p>See the <a href="../configuration/">Configuration Guide</a>.</p>
+<h2>Running the server</h2>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno task start     # supervised foreground (game + telnet)
+deno task dev       # development / live logs
+deno task daemon    # background supervisor
+deno task status    # pid / health
+deno task stop      # graceful shutdown
+deno task restart   # SIGUSR2 no-disconnect restart
 </code></pre>
-<p>Then open <a href="http://localhost:8000">http://localhost:8000</a> in your browser.</p>
-<h3>WebSocket (Developer / Custom Client)</h3>
-<p>For direct WebSocket access, connect to <code>ws://localhost:4203</code> and send JSON:</p>
-<pre class="language-javascript" tabindex="0"><code class="language-javascript"><span class="token keyword">const</span> socket <span class="token operator">=</span> <span class="token keyword">new</span> <span class="token class-name">WebSocket</span><span class="token punctuation">(</span><span class="token string">"ws://localhost:4203"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-
-<span class="token comment">// Create a character</span>
-socket<span class="token punctuation">.</span><span class="token function">send</span><span class="token punctuation">(</span><span class="token constant">JSON</span><span class="token punctuation">.</span><span class="token function">stringify</span><span class="token punctuation">(</span><span class="token punctuation">{</span> <span class="token literal-property property">msg</span><span class="token operator">:</span> <span class="token string">"create NewCharacter Password"</span><span class="token punctuation">,</span> <span class="token literal-property property">data</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span> <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-
-<span class="token comment">// Connect as a player</span>
-socket<span class="token punctuation">.</span><span class="token function">send</span><span class="token punctuation">(</span><span class="token constant">JSON</span><span class="token punctuation">.</span><span class="token function">stringify</span><span class="token punctuation">(</span><span class="token punctuation">{</span> <span class="token literal-property property">msg</span><span class="token operator">:</span> <span class="token string">"connect PlayerName Password"</span><span class="token punctuation">,</span> <span class="token literal-property property">data</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span> <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-
-<span class="token comment">// Send any command</span>
-socket<span class="token punctuation">.</span><span class="token function">send</span><span class="token punctuation">(</span><span class="token constant">JSON</span><span class="token punctuation">.</span><span class="token function">stringify</span><span class="token punctuation">(</span><span class="token punctuation">{</span> <span class="token literal-property property">msg</span><span class="token operator">:</span> <span class="token string">"look"</span><span class="token punctuation">,</span> <span class="token literal-property property">data</span><span class="token operator">:</span> <span class="token punctuation">{</span><span class="token punctuation">}</span> <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-</code></pre>
-<h2>First Admin</h2>
-<p>UrsaMU handles first-run setup automatically. On the very first <code>deno task start</code><br>
-when the database is empty, the server pauses and prompts you interactively:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">No players found in the database.
-Welcome! Let's set up your superuser account.
-
-Enter email address: admin@example.com
-Enter username: Admin
-Enter password: ••••••••
-</code></pre>
-<p>This creates your account with the <strong>superuser</strong> flag (level 10 — the highest<br>
-permission level). Once done, the Hub, Telnet, and web client all start.</p>
-<p>After that, use <code>@set &lt;player&gt;=admin</code> in-game to grant admin rights to other<br>
-trusted staff. The <code>superuser</code> flag itself can only be created at the database<br>
-level via this first-run flow — it cannot be granted from inside the game.</p>
-<blockquote>
-<p><strong>Tip</strong>: If you run <code>deno task start</code> non-interactively (e.g. inside a script<br>
-or Docker without a TTY), the prompt is skipped and you’ll see a message<br>
-suggesting you run <code>deno task server</code> directly to complete setup.</p>
-</blockquote>
-<h2>Next Steps</h2>
-<p>Now that you have UrsaMU installed and running, you might want to:</p>
+<p>Production notes: <a href="/ursamu/guides/deployment/">Deployment</a>.</p>
+<h2>Next steps</h2>
 <ul>
-<li><a href="./user-guide"><strong>User Guide</strong></a> - Learn how to use UrsaMU as a player</li>
-<li><a href="../configuration/"><strong>Configuration</strong></a> - Explore detailed configuration<br>
-options</li>
-<li><a href="/ursamu/plugins/"><strong>Plugin Development</strong></a> - Learn how to create plugins to<br>
-extend UrsaMU</li>
+<li><a href="/ursamu/guides/user-guide/">Player Guide</a></li>
+<li><a href="/ursamu/guides/admin-guide/">Admin Guide</a></li>
+<li><a href="/ursamu/guides/cli/">CLI Reference</a></li>
+<li><a href="/ursamu/plugins/">Plugin Development</a></li>
 </ul>
 
       </article>
@@ -508,11 +494,63 @@ extend UrsaMU</li>
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -543,16 +581,16 @@ extend UrsaMU</li>
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/first-script/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/help-authoring/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">Build Your First Script</span>
+            <span class="page-nav-title">Writing Help Files</span>
           </a>
         
 
         
-          <a href="/ursamu/guides/recipes/" class="page-nav-btn next">
+          <a href="/ursamu/guides/lock-expressions/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">Scripting Recipes</span>
+            <span class="page-nav-title">Lock Expressions</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/lock-expressions/index.html
+++ b/docs/_site/guides/lock-expressions/index.html
@@ -1,0 +1,828 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lock Expressions | UrsaMU Documentation</title>
+  <meta name="description" content="Reference guide for UrsaMU's lock expression syntax — built-in lockfuncs, boolean operators, indirect locks, and custom lockfunc registration.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/lock-expressions/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Lock Expressions</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Lock Expressions</h1>
+<p>Lock expressions control access to commands, exits, and objects. They appear in<br>
+three places:</p>
+<ul>
+<li>The <code>lock</code> field of a command definition: <code>lock: "connected &amp;&amp; perm(builder)"</code></li>
+<li>The in-game <code>@lock</code> command: <code>@lock north=flag(admin)</code></li>
+<li>The SDK <code>u.checkLock()</code> method in scripts</li>
+</ul>
+<h2>An empty or absent lock always passes. Locks are <strong>fail-closed</strong>: an unknown<br>
+lockfunc or a runtime error in a lockfunc evaluates to <code>false</code>. Maximum lock<br>
+string length is 4096 characters / 256 tokens.</h2>
+<h2>Quick Examples</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">"connected"                           -- any logged-in actor
+"flag(admin)"                         -- has the admin flag
+"connected &amp;&amp; perm(builder)"          -- logged in AND builder level or higher
+"flag(admin) || flag(wizard)"         -- admin OR wizard
+"!flag(dark)"                         -- does NOT have the dark flag
+"connected &amp;&amp; (flag(admin) || flag(builder))"
+"attr(tribe, glasswalker)"            -- state.tribe === "glasswalker"
+"is(#5)"                              -- actor is object #5
+"holds(#12)"                          -- actor's inventory includes #12
+</code></pre>
+<hr>
+<h2>Built-in Lockfuncs</h2>
+<p>Lockfuncs are functions called against the enactor. They take zero or more<br>
+arguments and return a boolean.</p>
+<table>
+<thead>
+<tr>
+<th>Lockfunc</th>
+<th>Example</th>
+<th>Passes when</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>flag(name)</code></td>
+<td><code>flag(wizard)</code></td>
+<td>enactor has the named flag</td>
+</tr>
+<tr>
+<td><code>attr(name)</code></td>
+<td><code>attr(tribe)</code></td>
+<td>enactor.state has own-property <code>name</code></td>
+</tr>
+<tr>
+<td><code>attr(name, value)</code></td>
+<td><code>attr(class, warrior)</code></td>
+<td><code>state[name] === value</code> (case-insensitive key)</td>
+</tr>
+<tr>
+<td><code>type(name)</code></td>
+<td><code>type(player)</code></td>
+<td>enactor has the type flag (player/room/thing/exit)</td>
+</tr>
+<tr>
+<td><code>is(#id)</code></td>
+<td><code>is(#5)</code></td>
+<td>enactor’s dbref is <code>#5</code></td>
+</tr>
+<tr>
+<td><code>holds(#id)</code></td>
+<td><code>holds(#12)</code></td>
+<td>enactor’s inventory includes <code>#12</code></td>
+</tr>
+<tr>
+<td><code>perm(level)</code></td>
+<td><code>perm(admin)</code></td>
+<td>enactor passes the privilege check for <code>level</code></td>
+</tr>
+</tbody>
+</table>
+<p>The legacy plain-flag form is still supported: <code>"admin"</code> is equivalent to<br>
+<code>flag(admin)</code>, and a trailing <code>+</code> (<code>builder+</code>) is equivalent to<br>
+<code>perm(builder)</code>.</p>
+<h3><code>perm()</code> levels</h3>
+<p><code>perm()</code> is the recommended way to check minimum permission level because it<br>
+walks the flag ladder. Higher levels satisfy lower-level checks.</p>
+<table>
+<thead>
+<tr>
+<th>Level</th>
+<th>Passes for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>perm(player)</code></td>
+<td>player, builder, storyteller, admin, wizard, superuser</td>
+</tr>
+<tr>
+<td><code>perm(builder)</code></td>
+<td>builder, storyteller, admin, wizard, superuser</td>
+</tr>
+<tr>
+<td><code>perm(admin)</code></td>
+<td>admin, wizard, superuser</td>
+</tr>
+<tr>
+<td><code>perm(wizard)</code></td>
+<td>wizard, superuser</td>
+</tr>
+<tr>
+<td><code>perm(superuser)</code></td>
+<td>superuser only</td>
+</tr>
+</tbody>
+</table>
+<h3>Special tokens</h3>
+<table>
+<thead>
+<tr>
+<th>Token</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>connected</code></td>
+<td>enactor is logged in (has the <code>connected</code> flag)</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Boolean Operators</h2>
+<p>Lock expressions support full boolean algebra. Precedence (highest first):</p>
+<ol>
+<li><code>!</code> — NOT (prefix)</li>
+<li><code>&amp;&amp;</code> — AND</li>
+<li><code>||</code> — OR</li>
+<li><code>( )</code> — Grouping (overrides precedence)</li>
+</ol>
+<pre class="language-none" tabindex="0"><code class="language-none">"!flag(superuser)"
+"connected &amp;&amp; perm(admin)"
+"flag(admin) || flag(wizard)"
+"connected &amp;&amp; (flag(admin) || flag(builder))"
+</code></pre>
+<h3>Legacy <code>&amp;</code> / <code>|</code></h3>
+<h2>The single-character operators <code>&amp;</code> (AND) and <code>|</code> (OR) from earlier UrsaMU<br>
+releases still work as aliases for <code>&amp;&amp;</code> / <code>||</code>. New code should prefer the<br>
+two-character forms — they are unambiguous around lockfunc names that contain<br>
+underscores or dashes.</h2>
+<h2>Indirect Locks</h2>
+<p>Prefix <code>@</code> to delegate the lock check to the lock stored on another object.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">"@#10"     -- evaluate the lock stored on object #10
+"@vault"   -- evaluate the lock on the object named "vault"
+</code></pre>
+<h2>Indirect locks are recursion-protected (maximum depth 10).</h2>
+<h2>Registering a Custom Lockfunc</h2>
+<p>Plugins can register their own lockfuncs via <code>registerLockFunc</code>. Built-in<br>
+names (<code>flag</code>, <code>attr</code>, <code>type</code>, <code>is</code>, <code>holds</code>, <code>perm</code>) are protected and cannot<br>
+be overwritten.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerLockFunc } from "jsr:@ursamu/mush";
+
+registerLockFunc("tribe", (enactor, _target, args) =&gt;
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+</code></pre>
+<p>Once registered, the function is available everywhere locks are evaluated:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">lock: "tribe(glasswalker)"
+lock: "perm(admin) || tribe(glasswalker)"
+lock: "connected &amp;&amp; !tribe(banished)"
+</code></pre>
+<p><strong>Signature:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerLockFunc(
+  name: string,
+  fn: (enactor: IDBObj, target: IDBObj | null, args: string[]) =&gt; boolean
+): void;
+</code></pre>
+<h2>Locks fail closed — return <code>false</code> on missing data or invalid input, and the<br>
+engine itself catches thrown errors.</h2>
+<h2>Using Locks in Scripts</h2>
+<p>The SDK exposes <code>u.checkLock()</code> to evaluate a lock expression from a script:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const canEnter = await u.checkLock(targetRoom, "connected &amp;&amp; perm(builder)");
+if (!canEnter) {
+  u.send("You don't have permission to enter.");
+  return;
+}
+</code></pre>
+<p><strong>Signature:</strong></p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.checkLock(target: string | IDBObj, lock: string): Promise&lt;boolean&gt;;
+</code></pre>
+<ul>
+<li><code>target</code> — the object whose perspective resolves <code>@indirect</code> locks</li>
+<li><code>lock</code> — any valid lock expression string</li>
+</ul>
+<hr>
+<h2>Quick Reference</h2>
+<table>
+<thead>
+<tr>
+<th>Expression</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>""</code></td>
+<td>Always passes (open)</td>
+</tr>
+<tr>
+<td><code>"connected"</code></td>
+<td>Actor is logged in</td>
+</tr>
+<tr>
+<td><code>"flag(admin)"</code></td>
+<td>Actor has the admin flag</td>
+</tr>
+<tr>
+<td><code>"perm(builder)"</code></td>
+<td>Builder level or higher</td>
+</tr>
+<tr>
+<td><code>"perm(admin)"</code></td>
+<td>Admin level or higher</td>
+</tr>
+<tr>
+<td><code>"!flag(dark)"</code></td>
+<td>Actor does NOT have the dark flag</td>
+</tr>
+<tr>
+<td><code>"flag(admin) || flag(wizard)"</code></td>
+<td>Admin or wizard</td>
+</tr>
+<tr>
+<td><code>"connected &amp;&amp; perm(admin)"</code></td>
+<td>Logged in AND admin or higher</td>
+</tr>
+<tr>
+<td><code>"connected &amp;&amp; (flag(admin) || flag(builder))"</code></td>
+<td>Logged in AND (admin or builder)</td>
+</tr>
+<tr>
+<td><code>"is(#5)"</code></td>
+<td>Actor is object #5</td>
+</tr>
+<tr>
+<td><code>"holds(#12)"</code></td>
+<td>Actor’s inventory includes #12</td>
+</tr>
+<tr>
+<td><code>"attr(class, warrior)"</code></td>
+<td>Actor’s <code>class</code> attribute is <code>warrior</code></td>
+</tr>
+<tr>
+<td><code>"@#10"</code></td>
+<td>Delegates to the lock on object #10</td>
+</tr>
+</tbody>
+</table>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/installation/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Installation Guide</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/password-reset/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Password Reset</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/password-reset/index.html
+++ b/docs/_site/guides/password-reset/index.html
@@ -1,0 +1,716 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Password Reset | UrsaMU Documentation</title>
+  <meta name="description" content="How to generate and consume password reset tokens in UrsaMU.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/password-reset/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Password Reset</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Password Reset</h1>
+<h2>UrsaMU does not have a self-service “forgot password” email flow — the server<br>
+has no email sending built in. Instead, password resets are a two-step process:<br>
+an admin generates a short-lived token in-game, then the player uses that token<br>
+to set a new password via the REST API.</h2>
+<h2>Overview</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">Admin (in-game)                   Player (out of band)
+─────────────────────────────     ─────────────────────────────────
+@resettoken PlayerName            Receives token from admin
+  → token printed in-game   ───▶  POST /api/v1/auth/reset-password
+                                    { token, newPassword }
+                                  ← 200 OK — password updated
+</code></pre>
+<h2>The token is a UUID, stored on the player object, and expires <strong>1 hour</strong> after<br>
+generation. It is single-use — it is deleted immediately on successful reset.</h2>
+<h2>Admin Steps</h2>
+<p>Any <strong>admin or wizard</strong> can generate a reset token for any player character.</p>
+<h3>In-game command</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@resettoken &lt;player&gt;
+</code></pre>
+<p><strong>Example:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">@resettoken Talia
+Reset token for Talia: 3f8a9b2c-1e4d-4f7a-8b6e-2a9c0d1e3f5a (expires in 1 hour)
+</code></pre>
+<p>The token is printed directly in your in-game session. You then pass it to the<br>
+player through any out-of-band channel — Discord, email, direct message, etc.</p>
+<blockquote>
+<p><strong>Security note:</strong> The token grants the ability to set a new password for that<br>
+account. Treat it like a temporary password and communicate it securely.<br>
+If the token is compromised before use, run <code>@resettoken</code> again — the new<br>
+token replaces the old one.</p>
+</blockquote>
+<hr>
+<h2>Player Steps</h2>
+<p>The player calls the REST endpoint with the token they received.</p>
+<h3><code>POST /api/v1/auth/reset-password</code></h3>
+<p><strong>No authentication header required.</strong></p>
+<p><strong>Request body:</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "token": "3f8a9b2c-1e4d-4f7a-8b6e-2a9c0d1e3f5a",
+  "newPassword": "my-new-secure-password"
+}
+</code></pre>
+<p><strong>Example with curl:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST https://yourgame.example.com/api/v1/auth/reset-password \
+  -H "Content-Type: application/json" \
+  -d '{"token":"3f8a9b2c-1e4d-4f7a-8b6e-2a9c0d1e3f5a","newPassword":"my-new-secure-password"}'
+</code></pre>
+<p><strong>Success response (<code>200 OK</code>):</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "message": "Password updated successfully." }
+</code></pre>
+<h2>After a successful reset the player can log in with their new password using the<br>
+normal <code>POST /api/v1/auth</code> endpoint.</h2>
+<h2>API Reference</h2>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>token</code></td>
+<td>string</td>
+<td>Yes</td>
+<td>UUID generated by <code>@resettoken</code></td>
+</tr>
+<tr>
+<td><code>newPassword</code></td>
+<td>string</td>
+<td>Yes</td>
+<td>Max 512 characters</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Outcome</th>
+<th>Status</th>
+<th>Body</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Success</td>
+<td><code>200</code></td>
+<td><code>{ "message": "Password updated successfully." }</code></td>
+</tr>
+<tr>
+<td>Missing fields</td>
+<td><code>400</code></td>
+<td><code>{ "error": "token and newPassword are required." }</code></td>
+</tr>
+<tr>
+<td>Password too long</td>
+<td><code>400</code></td>
+<td><code>{ "error": "Password must be 512 characters or fewer." }</code></td>
+</tr>
+<tr>
+<td>Bad or expired token</td>
+<td><code>400</code></td>
+<td><code>{ "error": "Invalid or expired reset token." }</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Error Responses</h2>
+<h3>Invalid or expired token</h3>
+<p>The token is invalid if:</p>
+<ul>
+<li>It was never generated (or the player name was wrong)</li>
+<li>More than 1 hour has passed since <code>@resettoken</code> was run</li>
+<li>It was already used successfully</li>
+</ul>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "error": "Invalid or expired reset token." }
+</code></pre>
+<p>Run <code>@resettoken &lt;player&gt;</code> again to generate a fresh token.</p>
+<h3>Password too long</h3>
+<p>Passwords are limited to 512 characters.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "error": "Password must be 512 characters or fewer." }
+</code></pre>
+<hr>
+<h2>Security Notes</h2>
+<ul>
+<li>Tokens are stored as plain UUIDs on the player object and are single-use.</li>
+<li>Both generation (<code>ADMIN_RESETTOKEN</code>) and consumption (<code>PASSWORD_RESET</code>) are<br>
+written to <code>logs/security.log</code> with the actor ID and client IP.</li>
+<li>Admins can reset their own token at any time by running <code>@resettoken</code> again —<br>
+the new token overwrites the old one.</li>
+<li>The <code>@newpassword &lt;player&gt;=&lt;pass&gt;</code> command is an alternative for admins who<br>
+want to set the password directly without involving the player.</li>
+</ul>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/lock-expressions/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Lock Expressions</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/recipes/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Scripting Recipes</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/recipes/index.html
+++ b/docs/_site/guides/recipes/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,8 +268,7 @@
       <!-- Page content -->
       <article class="prose">
         <h1>Scripting Recipes</h1>
-<p>Copy-paste patterns for the most common scripting tasks. Each recipe is a complete, working script.</p>
-<hr>
+<h2>Copy-paste patterns for the most common scripting tasks. Each recipe is a complete, working script.</h2>
 <h2>Room Description with Dynamic Content</h2>
 <p>A room object with an <code>&amp;DESC</code> attribute that shows different text based on time of day:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;DESC on a room object — run via @trigger or u.execute("look")
@@ -620,11 +619,67 @@ u.send(`${online.length} player${online.length === 1 ? "" : "s"} connected.`);
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -653,16 +708,16 @@ u.send(`${online.length} player${online.length === 1 ? "" : "s"} connected.`);
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/installation/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/password-reset/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">Installation Guide</span>
+            <span class="page-nav-title">Password Reset</span>
           </a>
         
 
         
-          <a href="/ursamu/guides/scripting/" class="page-nav-btn next">
+          <a href="/ursamu/guides/scenes/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">Scripting Guide</span>
+            <span class="page-nav-title">Scenes</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/scenes/index.html
+++ b/docs/_site/guides/scenes/index.html
@@ -1,0 +1,1093 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scenes | UrsaMU Documentation</title>
+  <meta name="description" content="How to create, join, write in, and export collaborative roleplay scenes in UrsaMU.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/scenes/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Scenes</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Scenes</h1>
+<p>Scenes are collaborative roleplay logs — structured writing sessions between<br>
+players. The scene system tracks who participated, what was written, and where<br>
+it happened, and lets you export the finished log as Markdown or JSON.</p>
+<h2>All scene endpoints require a <code>Bearer</code> JWT token in the <code>Authorization</code> header.</h2>
+<h2>Overview</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">Player A                   Player B                 Server
+────────                   ────────                 ──────
+POST /scenes               POST /scenes/:id/join
+  name, location      ──▶  (joins after creation)
+  ← 201 scene object
+
+POST /scenes/:id/pose ──▶                    ──▶  broadcasts to room
+  msg, type=pose
+
+                           POST /scenes/:id/pose
+                      ◀──  msg, type=pose      ──▶  broadcasts to room
+
+PATCH /scenes/:id          (close the scene)
+  status=closed
+
+GET /scenes/:id/export
+  ?format=markdown    ──▶  ← Markdown log file
+</code></pre>
+<hr>
+<h2>Creating a Scene</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">POST /api/v1/scenes
+Authorization: Bearer &lt;token&gt;
+Content-Type: application/json
+</code></pre>
+<p><strong>Request body:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td>string</td>
+<td>Yes</td>
+<td>Scene title</td>
+</tr>
+<tr>
+<td><code>location</code></td>
+<td>string</td>
+<td>Yes</td>
+<td>Room dbref (e.g. <code>#5</code>)</td>
+</tr>
+<tr>
+<td><code>desc</code></td>
+<td>string</td>
+<td>No</td>
+<td>Scene description or opening set</td>
+</tr>
+<tr>
+<td><code>sceneType</code></td>
+<td>string</td>
+<td>No</td>
+<td><code>social</code>, <code>event</code>, <code>vignette</code>, <code>plot</code>, <code>training</code>, <code>other</code> (default: <code>social</code>)</td>
+</tr>
+<tr>
+<td><code>private</code></td>
+<td>boolean</td>
+<td>No</td>
+<td>If <code>true</code>, only invited players can see or post (default: <code>false</code>)</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST https://yourgame.example.com/api/v1/scenes \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "A Meeting in the Rain",
+    "location": "#5",
+    "desc": "Two characters cross paths on a wet street corner.",
+    "sceneType": "social"
+  }'
+</code></pre>
+<p><strong>Response (<code>201 Created</code>):</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "id": "42",
+  "name": "A Meeting in the Rain",
+  "location": "#5",
+  "desc": "Two characters cross paths on a wet street corner.",
+  "owner": "#3",
+  "participants": ["#3"],
+  "allowed": ["#3"],
+  "private": false,
+  "poses": [],
+  "startTime": 1710000000000,
+  "status": "active",
+  "sceneType": "social"
+}
+</code></pre>
+<h2>The creator is automatically added as the first participant.</h2>
+<h2>Listing Scenes</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/scenes
+Authorization: Bearer &lt;token&gt;
+</code></pre>
+<p>Returns all scenes visible to the authenticated user, sorted newest first.<br>
+Private scenes are filtered — only scenes where you are the owner, a participant,<br>
+or in the <code>allowed</code> list are returned.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/scenes/locations
+Authorization: Bearer &lt;token&gt;
+</code></pre>
+<p>Returns all rooms you have permission to enter, sorted alphabetically. Useful<br>
+for scene creation UIs that let the player pick a location from a list.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "id": "#1", "name": "The Nexus", "type": "public" },
+  { "id": "#12", "name": "Staff Lounge", "type": "private" }
+]
+</code></pre>
+<h2><code>type</code> is <code>"private"</code> if the room has an enter lock set, <code>"public"</code> otherwise.</h2>
+<h2>Joining a Scene</h2>
+<p>Any player can join a public scene. Private scenes require an invitation first<br>
+(see <a href="#private-scenes">Private Scenes</a>).</p>
+<pre class="language-none" tabindex="0"><code class="language-none">POST /api/v1/scenes/:id/join
+Authorization: Bearer &lt;token&gt;
+</code></pre>
+<p>No body required. If successful, the player is added to <code>participants</code>.</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "success": true, "scene": { ... } }
+</code></pre>
+<hr>
+<h2>Writing Poses</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">POST /api/v1/scenes/:id/pose
+Authorization: Bearer &lt;token&gt;
+Content-Type: application/json
+</code></pre>
+<p><strong>Request body:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>msg</code></td>
+<td>string</td>
+<td>Yes (except <code>set</code>)</td>
+<td>The pose text</td>
+</tr>
+<tr>
+<td><code>type</code></td>
+<td>string</td>
+<td>No</td>
+<td><code>pose</code> (default), <code>ooc</code>, or <code>set</code></td>
+</tr>
+</tbody>
+</table>
+<p><strong>Pose types:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Use</th>
+<th>Broadcast format</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>pose</code></td>
+<td>In-character action or speech</td>
+<td><code>CharName &lt;msg&gt;</code></td>
+</tr>
+<tr>
+<td><code>ooc</code></td>
+<td>Out-of-character comment</td>
+<td><code>[OOC] CharName: &lt;msg&gt;</code></td>
+</tr>
+<tr>
+<td><code>set</code></td>
+<td>Scene description / setter (no <code>msg</code> required)</td>
+<td><code>[Scene Set] &lt;msg&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<p>Poses are broadcast to the scene’s room in real time so players in the grid<br>
+also see them. The maximum pose length is <strong>4000 characters</strong>.</p>
+<p><strong>Example — in-character pose:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST https://yourgame.example.com/api/v1/scenes/42/pose \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{"msg": "glances up as rain spatters her coat, then freezes.", "type": "pose"}'
+</code></pre>
+<p><strong>Example — scene setter:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST https://yourgame.example.com/api/v1/scenes/42/pose \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{"msg": "The street is empty except for the two of them.", "type": "set"}'
+</code></pre>
+<p><strong>Response (<code>201 Created</code>):</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "id": "a1b2c3d4-...",
+  "charId": "#3",
+  "charName": "Talia",
+  "moniker": "%ch%crT%cna%chl%cni%cra%cn",
+  "msg": "glances up as rain spatters her coat, then freezes.",
+  "type": "pose",
+  "timestamp": 1710000060000
+}
+</code></pre>
+<h2>Posting automatically adds you to <code>participants</code> if you weren’t already there.</h2>
+<h2>Editing a Pose</h2>
+<p>You can correct a pose after posting. Only the original author or the scene<br>
+owner can edit a pose.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">PATCH /api/v1/scenes/:id/pose/:poseId
+Authorization: Bearer &lt;token&gt;
+Content-Type: application/json
+</code></pre>
+<p><strong>Request body:</strong></p>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "msg": "corrected pose text" }
+</code></pre>
+<p>The <code>type</code> and <code>timestamp</code> cannot be changed after posting. Max 4000 characters.</p>
+<h2><strong>Response (<code>200 OK</code>):</strong> the updated pose object.</h2>
+<h2>Updating a Scene</h2>
+<p>The scene owner (or admin/wizard) can update metadata and status.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">PATCH /api/v1/scenes/:id
+Authorization: Bearer &lt;token&gt;
+Content-Type: application/json
+</code></pre>
+<p><strong>Updatable fields:</strong></p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td>string</td>
+<td>Scene title</td>
+</tr>
+<tr>
+<td><code>desc</code></td>
+<td>string</td>
+<td>Scene description</td>
+</tr>
+<tr>
+<td><code>status</code></td>
+<td>string</td>
+<td><code>active</code>, <code>paused</code>, or <code>closed</code></td>
+</tr>
+<tr>
+<td><code>sceneType</code></td>
+<td>string</td>
+<td><code>social</code>, <code>event</code>, <code>vignette</code>, <code>plot</code>, <code>training</code>, <code>other</code></td>
+</tr>
+<tr>
+<td><code>endTime</code></td>
+<td>number</td>
+<td>Unix timestamp (ms) when the scene ended</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example — close a scene:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X PATCH https://yourgame.example.com/api/v1/scenes/42 \
+  -H "Authorization: Bearer &lt;token&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "closed", "endTime": 1710003600000}'
+</code></pre>
+<hr>
+<h2>Private Scenes</h2>
+<p>Set <code>"private": true</code> when creating a scene to restrict access.</p>
+<table>
+<thead>
+<tr>
+<th>Action</th>
+<th>Who can do it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>View scene</td>
+<td>Owner, participants, <code>allowed</code> list, admin/wizard</td>
+</tr>
+<tr>
+<td>Post a pose</td>
+<td>Owner, participants, <code>allowed</code> list, admin/wizard</td>
+</tr>
+<tr>
+<td>Join</td>
+<td>Only if already in <code>allowed</code> list</td>
+</tr>
+<tr>
+<td>Invite</td>
+<td>Owner, anyone in <code>allowed</code> list, admin/wizard</td>
+</tr>
+</tbody>
+</table>
+<h3>Inviting a player</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">POST /api/v1/scenes/:id/invite
+Authorization: Bearer &lt;token&gt;
+Content-Type: application/json
+</code></pre>
+<pre class="language-json" tabindex="0"><code class="language-json">{ "target": "#7" }
+</code></pre>
+<h2><code>target</code> can be a dbref (<code>#7</code>) or a player name. The player is added to the<br>
+<code>allowed</code> list and can then join the scene.</h2>
+<h2>Exporting a Scene</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/scenes/:id/export
+Authorization: Bearer &lt;token&gt;
+</code></pre>
+<p>Optional query parameter <code>format</code>:</p>
+<table>
+<thead>
+<tr>
+<th><code>format</code></th>
+<th>Content-Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>markdown</code> <em>(default)</em></td>
+<td><code>text/markdown</code></td>
+<td>Formatted log with header and poses</td>
+</tr>
+<tr>
+<td><code>json</code></td>
+<td><code>application/json</code></td>
+<td>Full scene object</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Example:</strong></p>
+<pre class="language-bash" tabindex="0"><code class="language-bash"># Markdown log
+curl -H "Authorization: Bearer &lt;token&gt;" \
+     https://yourgame.example.com/api/v1/scenes/42/export
+
+# Raw JSON
+curl -H "Authorization: Bearer &lt;token&gt;" \
+     https://yourgame.example.com/api/v1/scenes/42/export?format=json
+</code></pre>
+<p><strong>Markdown export format:</strong></p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown"># A Meeting in the Rain
+
+**Type:** social | **Status:** closed
+**Location:** The Corner of Fifth and Ash
+**Started:** 2026-03-18
+**Ended:** 2026-03-18
+**Participants:** Talia, Marcus
+---
+
+**Talia** glances up as rain spatters her coat, then freezes.
+
+**Marcus** turns up his collar, not yet noticing her.
+
+*[OOC] Talia: great opener!*
+---
+*Exported 2026-03-18*
+</code></pre>
+<h2>MUSH color codes are stripped from all character names and pose content in the<br>
+export, so the output is clean plain text.</h2>
+<h2>Scene Hooks</h2>
+<p>Every scene mutation fires a typed event on <code>gameHooks</code>, allowing plugins<br>
+(AI GM assistants, logging systems, etc.) to react without touching the<br>
+scene REST router.</p>
+<p>Import <code>gameHooks</code> from <code>jsr:@ursamu/mush</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+import type { SceneSetEvent, SceneClearEvent } from "jsr:@ursamu/mush";
+</code></pre>
+<h3>Hook reference</h3>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>When it fires</th>
+<th>Key payload fields</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>scene:created</code></td>
+<td>New scene opened (<code>POST /scenes</code>)</td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>sceneType</code></td>
+</tr>
+<tr>
+<td><code>scene:pose</code></td>
+<td>Any pose posted (<code>POST /scenes/:id/pose</code>)</td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>msg</code>, <code>type</code></td>
+</tr>
+<tr>
+<td><code>scene:set</code></td>
+<td>Pose with <code>type: "set"</code> posted</td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>description</code></td>
+</tr>
+<tr>
+<td><code>scene:title</code></td>
+<td>Scene renamed (<code>PATCH /scenes/:id</code> with new <code>name</code>)</td>
+<td><code>sceneId</code>, <code>oldName</code>, <code>newName</code>, <code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>scene:clear</code></td>
+<td>Scene closed/finished/archived</td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>actorId</code>, <code>actorName</code>, <code>status</code></td>
+</tr>
+</tbody>
+</table>
+<p><code>scene:set</code> and <code>scene:pose</code> both fire when a <code>"set"</code> pose is posted —<br>
+<code>scene:pose</code> for anything that needs to see all pose types, <code>scene:set</code> for<br>
+handlers that only care about scene descriptions.</p>
+<h3>Example: AI GM assistant</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+import { send } from "../../services/broadcast/index.ts";
+import type { SceneSetEvent, SceneTitleEvent, SceneClearEvent } from "jsr:@ursamu/mush";
+
+// Narrate the new setting in the GM's voice
+gameHooks.on("scene:set", ({ roomId, description }: SceneSetEvent) =&gt; {
+  send([roomId], `%ch%cm[GM]%cn ${description}`, {});
+});
+
+// Announce title changes
+gameHooks.on("scene:title", ({ roomId, oldName, newName }: SceneTitleEvent) =&gt; {
+  // roomId is not in SceneTitleEvent — look it up from sceneId if needed
+  console.log(`[GM] Scene renamed: "${oldName}" → "${newName}"`);
+});
+
+// Wrap up when a scene closes
+gameHooks.on("scene:clear", ({ sceneName, status }: SceneClearEvent) =&gt; {
+  console.log(`[GM] Scene "${sceneName}" ${status}.`);
+});
+</code></pre>
+<h2>See <a href="/ursamu/plugins/hooks/">Plugin Hooks &amp; Events</a> for the complete GameHooks API.</h2>
+<h2>API Reference</h2>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Endpoint</th>
+<th>Auth</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Required</td>
+<td>List visible scenes</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Required</td>
+<td>Create a scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/locations</code></td>
+<td>Required</td>
+<td>List accessible rooms</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Required</td>
+<td>Scene detail with participants</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Required</td>
+<td>Update name, desc, status, sceneType, endTime</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id/export</code></td>
+<td>Required</td>
+<td>Export as <code>?format=markdown</code> or <code>?format=json</code></td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/pose</code></td>
+<td>Required</td>
+<td>Add a pose, ooc, or set entry</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id/pose/:poseId</code></td>
+<td>Required</td>
+<td>Edit a pose (author or scene owner)</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/join</code></td>
+<td>Required</td>
+<td>Join a scene</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/invite</code></td>
+<td>Required</td>
+<td>Add a player to the allowed list</td>
+</tr>
+</tbody>
+</table>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/recipes/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">Scripting Recipes</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/scripting/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Scripting Guide</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/scripting/index.html
+++ b/docs/_site/guides/scripting/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -278,8 +278,7 @@
 <li>Worker posts results/messages back to the server</li>
 <li>Worker terminates</li>
 </ol>
-<p>Scripts are fully isolated — they cannot crash the server, access the filesystem, or make network requests. All interaction happens through <code>u</code>.</p>
-<hr>
+<h2>Scripts are fully isolated — they cannot crash the server, access the filesystem, or make network requests. All interaction happens through <code>u</code>.</h2>
 <h2>The <code>u</code> Object</h2>
 <p>Every script has access to a global <code>u</code> object. It contains both the current execution context and all SDK methods.</p>
 <h3>Context Properties</h3>
@@ -369,7 +368,7 @@ u.me.flags.has("wizard")    // true/false
 u.me.flags.has("connected")
 
 // Check edit permission (owner, admin, wizard)
-if (!u.canEdit(u.me, target)) {
+if (!(await u.canEdit(u.me, target))) {
   u.send("Permission denied.");
   return;
 }
@@ -397,6 +396,31 @@ u.execute("say Hello, world!");
 
 // Force a command (bypasses some permission checks — use carefully)
 u.force("@set me=dark");
+</code></pre>
+<hr>
+<h2>Attributes (<code>u.attr</code>)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read a soft-coded &amp;ATTR from any object (case-insensitive)
+const bio  = await u.attr.get(u.me.id, "FINGER-INFO");    // null if not set
+const desc = await u.attr.get(objectId, "SHORT-DESC");
+
+if (bio) u.send(bio);
+</code></pre>
+<hr>
+<h2>Evaluate Attribute (<code>u.eval</code>)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Run &amp;ATTR on an object and capture its output as a string
+const result = await u.eval("#42", "SCORE-FORMULA");
+u.send(`Result: ${result}`);
+
+// Pass arguments
+const out = await u.eval(u.me.id, "CALC", ["10", "20"]);
+</code></pre>
+<hr>
+<h2>Force As (<code>u.forceAs</code>)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Execute a command as another object (wizard/admin only — check flags first)
+if (!u.me.flags.has("wizard") &amp;&amp; !u.me.flags.has("admin")) {
+  u.send("Permission denied."); return;
+}
+await u.forceAs(npcId, "say Greetings, traveler!");
 </code></pre>
 <hr>
 <h2>Text (<code>u.text</code>)</h2>
@@ -505,8 +529,29 @@ const ms = await u.sys.uptime();
 const minutes = Math.floor(ms / 60000);
 
 // Reboot or shut down
-await u.sys.reboot();    // exits with code 75 (restart signal)
-await u.sys.shutdown();  // exits with code 0
+await u.sys.reboot();    // exits with code 75 — daemon restart loop restarts the server
+await u.sys.shutdown();  // exits with code 0 — clean stop
+
+// Pull latest code from git and restart
+await u.sys.update();          // pull origin/main
+await u.sys.update("develop"); // pull a specific branch
+</code></pre>
+<h2>Exit code 75 is caught by <code>scripts/main-loop.sh</code> which restarts the process<br>
+with exponential backoff on rapid exits. Telnet connections survive reboots.</h2>
+<h2>Game Time (<code>u.sys.gameTime</code>)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read the in-game calendar
+const t = await u.sys.gameTime();
+// { year: number, month: 1-12, day: 1-28, hour: 0-23, minute: 0-59 }
+
+// Set the in-game calendar (wizard/admin only)
+await u.sys.setGameTime({ year: 1340, month: 6, day: 15, hour: 8, minute: 0 });
+</code></pre>
+<hr>
+<h2>Channel History (<code>u.chan.history</code>)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Get recent messages from a channel (default last 20)
+const history = await u.chan.history("public");
+const history = await u.chan.history("public", 50);
+// → [{ id, playerName, message, timestamp }, ...]
 </code></pre>
 <hr>
 <h2>Events (<code>u.events</code>)</h2>
@@ -538,8 +583,16 @@ u.util.template(
 
 // Strip MUSH color codes and ANSI escapes (for storage/validation)
 u.util.stripSubs("%chHello %cgWorld%cn")  // → "Hello World"
+
+// Resolve a format-attr through the format-handler pipeline (v2.3.2+)
+//   priority: stored &amp;NAMEFORMAT attribute → plugin handler → null
+const line = await u.util.resolveFormat(target, "NAMEFORMAT", u.me);
+const row  = await u.util.resolveGlobalFormat("WHOROWFORMAT", u.me, [player]);
 </code></pre>
-<hr>
+<h2>See the <a href="/ursamu/guides/sdk-cookbook/#resolveformat--resolveformator">SDK Cookbook</a> for the<br>
+full format-resolve API and the<br>
+<a href="/ursamu/guides/customization/#format-handlers">Customization guide</a> for the eight slots<br>
+and how to register handlers.</h2>
 <h2>Structured UI (<code>u.ui</code>)</h2>
 <p>For web client panels (JSON output, not text):</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// Layout — posts a structured result to the web client
@@ -654,8 +707,7 @@ if (switches.includes("edit")) {
 </tr>
 </tbody>
 </table>
-<p>Scripts run inside <code>Worker</code> with <code>/// &lt;reference no-default-lib="true" /&gt;</code>, which blocks <code>Deno</code>, <code>fetch</code>, <code>XMLHttpRequest</code>, and the filesystem.</p>
-<hr>
+<h2>Scripts run inside <code>Worker</code> with <code>/// &lt;reference no-default-lib="true" /&gt;</code>, which blocks <code>Deno</code>, <code>fetch</code>, <code>XMLHttpRequest</code>, and the filesystem.</h2>
 <h2>MUSH Color Codes</h2>
 <p>UrsaMU processes traditional MUSH substitution codes in all outgoing text:</p>
 <table>
@@ -792,11 +844,69 @@ u.send(`%ch%cr${u.util.ljust("ALERT", 10)}%cn Server restarting in 5 minutes.`);
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -823,9 +933,9 @@ u.send(`%ch%cr${u.util.ljust("ALERT", 10)}%cn Server restarting in 5 minutes.`);
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/recipes/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/scenes/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">Scripting Recipes</span>
+            <span class="page-nav-title">Scenes</span>
           </a>
         
 

--- a/docs/_site/guides/sdk-cookbook/index.html
+++ b/docs/_site/guides/sdk-cookbook/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -268,8 +268,7 @@
       <!-- Page content -->
       <article class="prose">
         <h1>SDK Cookbook</h1>
-<p>Every method available on the <code>u</code> object, organized by namespace, with working examples pulled from real system scripts.</p>
-<hr>
+<h2>Every method available on the <code>u</code> object, organized by namespace, with working examples pulled from real system scripts.</h2>
 <h2>Context Objects</h2>
 <p>These are injected automatically — you don’t call them, you read them.</p>
 <h3><code>u.me</code> — The Actor</h3>
@@ -448,14 +447,15 @@ await u.setFlags(u.me, "builder");
 </code></pre>
 <hr>
 <h2>Permission Check (<code>u.canEdit</code>)</h2>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (!u.canEdit(u.me, target)) {
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (!(await u.canEdit(u.me, target))) {
   u.send("Permission denied.");
   return;
 }
 // proceed with edit
 </code></pre>
-<p>Returns <code>true</code> if the actor owns the target, or is admin/wizard/superuser.</p>
-<hr>
+<h2>Returns <code>Promise&lt;boolean&gt;</code> — <code>true</code> if the actor owns the target, or is<br>
+admin / wizard / superuser. Always <code>await</code> the call; omitting <code>await</code><br>
+truthy-tests the Promise object and silently bypasses the check.</h2>
 <h2>Locks (<code>u.checkLock</code>)</h2>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// Evaluate a lock expression against the actor
 const canPass = await u.checkLock(target.id, "player+");
@@ -631,11 +631,15 @@ const h  = Math.floor(ms / 3600000);
 const m  = Math.floor((ms % 3600000) / 60000);
 u.send(`Uptime: ${h}h ${m}m`);
 
-// Reboot (exit code 75 — scripts/run.sh restarts on this code)
+// Reboot (exit code 75 — daemon restart loop restarts the server)
 await u.sys.reboot();
 
 // Shutdown (exit code 0)
 await u.sys.shutdown();
+
+// Pull latest code from git and restart (runs git pull, then exits 75)
+await u.sys.update();            // pull origin/main
+await u.sys.update("develop");   // pull a specific branch
 </code></pre>
 <hr>
 <h2>Events (<code>u.events</code>)</h2>
@@ -681,6 +685,30 @@ u.util.sprintf("%05d", 42)                   // "00042"
 );
 // → "[ 42] [Post title          ] Alice"
 </code></pre>
+<h3>resolveFormat / resolveFormatOr</h3>
+<p>Sandbox-accessible helpers (since v2.3.2) for looking up a format-attr value<br>
+on a target, walking the format-handler pipeline.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Look up a per-object NAMEFORMAT. Priority:
+//   1. Stored &amp;NAMEFORMAT attribute on the target
+//   2. Plugin-registered format handler for that slot
+//   3. null
+const formatted = await u.util.resolveFormat(target, "NAMEFORMAT", u.me);
+
+// With a fallback string if nothing returns
+const line = await u.util.resolveFormatOr(target, "EXITFORMAT", u.me, "[exit]");
+</code></pre>
+<h3>resolveGlobalFormat / resolveGlobalFormatOr</h3>
+<p>Two-tier lookup (since v2.3.3) for “global list” formats like WHO and @ps.<br>
+Checks <code>#0</code> (the master room object) first, then the enactor.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// e.g. inside a WHO script
+const row = await u.util.resolveGlobalFormat("WHOROWFORMAT", u.me, [player]);
+const fallback = await u.util.resolveGlobalFormatOr("WHOFORMAT", u.me, "");
+</code></pre>
+<p>The eight engine-known slots are <code>NAMEFORMAT</code>, <code>DESCFORMAT</code>, <code>CONFORMAT</code>,<br>
+<code>EXITFORMAT</code>, <code>WHOFORMAT</code>, <code>WHOROWFORMAT</code>, <code>PSFORMAT</code>, <code>PSROWFORMAT</code>.<br>
+Plugin authors can pass any uppercase slot name (e.g. <code>"MAILFORMAT"</code>,<br>
+<code>"BBROWFORMAT"</code>) without casting. See<br>
+<a href="/ursamu/guides/customization/#format-handlers">Customization → Format Handlers</a>.</p>
 <h3>stripSubs</h3>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// Remove all MUSH codes and ANSI escapes
 u.util.stripSubs("%ch%crDanger!%cn")   // → "Danger!"
@@ -694,6 +722,102 @@ if (!clean) { u.send("Value cannot be empty."); return; }
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// Returns moniker (if set) → name → "Unknown"
 u.util.displayName(u.me, u.me)       // "Alice" or moniker
 u.util.displayName(target, u.me)     // target's display name as seen by actor
+</code></pre>
+<hr>
+<h2>Attributes (<code>u.attr</code>)</h2>
+<h3><code>u.attr.get(id, name)</code></h3>
+<p>Reads a soft-coded <code>&amp;ATTR</code> value stored on any game object. Attribute names are<br>
+case-insensitive. Returns <code>null</code> if the attribute is not set.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read your own short description
+const shortDesc = await u.attr.get(u.me.id, "SHORT-DESC");
+if (shortDesc) u.send(`Short desc: ${shortDesc}`);
+
+// Read another object's attribute
+const bio = await u.attr.get(targetId, "FINGER-INFO");
+
+// Case-insensitive
+const val = await u.attr.get(objectId, "onenter");  // same as "ONENTER"
+</code></pre>
+<hr>
+<h2>Evaluate Attribute (<code>u.eval</code>)</h2>
+<h3><code>u.eval(targetId, attr, args?)</code></h3>
+<p>Evaluates a stored <code>&amp;ATTR</code> as a script and returns the output as a string.<br>
+This is the script equivalent of <code>@trigger</code> that also captures output.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Run &amp;FORMULA on object #42 with args
+const result = await u.eval("#42", "FORMULA", ["5", "10"]);
+u.send(`Formula result: ${result}`);
+
+// Run an attribute on the actor
+const score = await u.eval(u.me.id, "SCORE-FORMULA");
+u.send(`Your score: ${score}`);
+</code></pre>
+<hr>
+<h2>Force As Another Object (<code>u.forceAs</code>)</h2>
+<h3><code>u.forceAs(targetId, command)</code></h3>
+<p>Executes a command as another object (NPC, room, etc.). The SDK does not enforce<br>
+privilege — always check flags in your script before calling.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Guard: admin/wizard only
+const isAdmin = u.me.flags.has("admin") || u.me.flags.has("wizard") || u.me.flags.has("superuser");
+if (!isAdmin) { u.send("Permission denied."); return; }
+
+// Make an NPC speak
+await u.forceAs(npcId, "say Welcome to the Inn!");
+
+// Make a room run a command
+await u.forceAs(roomId, "@trigger me/ONRESET");
+</code></pre>
+<hr>
+<h2>Game Time (<code>u.sys.gameTime</code>)</h2>
+<h3><code>u.sys.gameTime()</code> / <code>u.sys.setGameTime(t)</code></h3>
+<p>Read and write the in-game calendar. Useful for seasonal events, timestamps,<br>
+and roleplay-relevant date display.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read current game time
+const t = await u.sys.gameTime();
+// t.year: number, t.month: 1-12, t.day: 1-28, t.hour: 0-23, t.minute: 0-59
+
+const monthNames = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+u.send(`Today is ${monthNames[t.month]} ${t.day}, Year ${t.year} — ${t.hour}:${String(t.minute).padStart(2,"0")}`);
+
+// Advance the calendar (admin only)
+if (!u.me.flags.has("wizard") &amp;&amp; !u.me.flags.has("admin")) {
+  u.send("Permission denied."); return;
+}
+await u.sys.setGameTime({ year: t.year + 1, month: 1, day: 1, hour: 0, minute: 0 });
+u.broadcast("A new year has begun!");
+</code></pre>
+<hr>
+<h2>Channel History (<code>u.chan.history</code>)</h2>
+<h3><code>u.chan.history(name, limit?)</code></h3>
+<p>Fetches recent messages from a channel. Default limit is 20.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Last 20 messages on the public channel
+const history = await u.chan.history("public");
+// → [{ id: string, playerName: string, message: string, timestamp: number }, ...]
+
+// Last 50 messages
+const history = await u.chan.history("staff", 50);
+
+// Display as a log
+const lines = history.map(e =&gt; {
+  const date = new Date(e.timestamp).toLocaleTimeString();
+  return `[${date}] ${e.playerName}: ${e.message}`;
+});
+u.send(lines.join("\r\n"));
+</code></pre>
+<hr>
+<h2>Mail — Modify (<code>u.mail.modify</code>)</h2>
+<h3><code>u.mail.modify(query, op, update)</code></h3>
+<p>Updates mail records matching <code>query</code>. Used for marking messages read/unread or<br>
+other bulk updates. Available in sandbox scripts only.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Mark a specific message as read
+await u.mail.modify({ id: messageId }, "$set", { read: true });
+
+// Mark all your messages as read
+await u.mail.modify(
+  { to: { $in: [`#${u.me.id}`] } },
+  "$set",
+  { read: true }
+);
 </code></pre>
 
       </article>
@@ -767,11 +891,69 @@ u.util.displayName(target, u.me)     // target's display name as seen by actor
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -803,9 +985,9 @@ u.util.displayName(target, u.me)     // target's display name as seen by actor
         
 
         
-          <a href="/ursamu/guides/user-guide/" class="page-nav-btn next">
+          <a href="/ursamu/guides/softcoding/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">User Guide</span>
+            <span class="page-nav-title">Soft-Coding Guide</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/softcoding/index.html
+++ b/docs/_site/guides/softcoding/index.html
@@ -1,0 +1,999 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Soft-Coding Guide | UrsaMU Documentation</title>
+  <meta name="description" content="How to store scripts and data in object attributes and trigger them with @trigger, u.trigger, and u.eval.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/softcoding/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Soft-Coding Guide</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Soft-Coding Guide</h1>
+<h2>Soft-coding is the practice of storing scripts and data directly on in-game<br>
+objects as <strong>attributes</strong>, rather than writing static files. It lets builders<br>
+and players customize room behavior, object interaction, and NPC responses<br>
+entirely from inside the game — no server restart required.</h2>
+<h2>What is Soft-Coding?</h2>
+<p>Every object in UrsaMU (rooms, players, things, exits) has a <code>data.attributes</code><br>
+array. Each entry is an <code>IAttribute</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface IAttribute {
+  name: string;    // e.g. "ONENTER"
+  value: string;   // the script (TypeScript/JS) or plain text
+  setter: string;  // dbref of whoever set it
+  type?: string;
+  hidden?: boolean;
+}
+</code></pre>
+<p>An attribute’s <code>value</code> is a full sandboxed script — the same format as files in<br>
+<code>system/scripts/</code>. When something fires the attribute (a hook, <code>@trigger</code>, or<br>
+<code>u.trigger()</code>), UrsaMU runs the script in a Web Worker with a fresh <code>u</code> object.</p>
+<p><strong>Why use soft-coding instead of a system script?</strong></p>
+<ul>
+<li>Changes take effect immediately — no restart, no redeploy.</li>
+<li>Any builder with edit permission can customize objects they own.</li>
+<li>Behavior stays attached to the object, so copying or moving the object brings<br>
+its behavior with it.</li>
+<li>Inheritance: if an attribute is not found on the object, UrsaMU walks up the<br>
+<code>data.parent</code> chain, allowing shared behavior from parent objects.</li>
+</ul>
+<hr>
+<h2>Setting Attributes In-Game</h2>
+<p>Use the <code>&amp;</code> command:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&amp;&lt;ATTR-NAME&gt; &lt;object&gt;=&lt;value&gt;
+</code></pre>
+<p><code>&lt;object&gt;</code> accepts anything the <code>target</code> utility understands: <code>me</code>, <code>here</code>, an<br>
+object name, or a dbref (<code>#42</code>). <code>&lt;ATTR-NAME&gt;</code> is case-insensitive and stored<br>
+as supplied (the lookup is case-insensitive).</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; &amp;ONENTER here=u.send("The door creaks as you enter.");
+Game&gt; Lobby's attribute ONENTER set.
+
+&gt; &amp;SHORT-DESC me=A tall woman in a grey cloak.
+Game&gt; Alice's attribute SHORT-DESC set.
+</code></pre>
+<p><strong>Clear an attribute</strong> by omitting the value:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; &amp;ONENTER here=
+Game&gt; Lobby's attribute ONENTER removed.
+</code></pre>
+<p>Constraints:</p>
+<ul>
+<li>You must be able to <strong>edit</strong> the target (be its owner, or have the <code>admin</code>,<br>
+<code>wizard</code>, or <code>superuser</code> flag).</li>
+<li>Attribute names are arbitrary — there is no enforced schema. Conventions are<br>
+listed in <a href="#common-attribute-names">Common Attribute Names</a>.</li>
+</ul>
+<h3>Alternative: <code>@set</code> attribute syntax</h3>
+<p><code>@set</code> also sets soft attributes using the <code>target/ATTR=value</code> form:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">@set &lt;object&gt;/&lt;ATTR&gt;=&lt;value&gt;    -- set attribute
+@set &lt;object&gt;/&lt;ATTR&gt;=           -- clear attribute
+</code></pre>
+<p>This is equivalent to <code>&amp;ATTR obj=value</code> for plain data storage (both write<br>
+to <code>data.ATTR</code>). Use whichever feels natural; <code>&amp;</code> is the traditional MUSH<br>
+syntax, while <code>@set obj/ATTR=value</code> is more explicit.</p>
+<blockquote>
+<p><strong>Note:</strong> <code>@set obj=&lt;FLAG&gt;</code> (without the <code>/</code>) sets or removes a <em>flag</em>, not<br>
+an attribute — see the <a href="/ursamu/guides/admin-guide#user-roles-and-permissions">Admin Guide</a>.</p>
+</blockquote>
+<hr>
+<h2>Setting Attributes via Scripts</h2>
+<p>From inside any script you can read and write the raw <code>data.attributes</code> array<br>
+directly using <code>u.db.modify</code>. Always spread the existing array to avoid<br>
+clobbering other attributes.</p>
+<h3>Add or replace a single attribute</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">export default async (u) =&gt; {
+  const me = u.me;
+  const existing = (me.state.attributes || []) as Array&lt;{ name: string; value: string; setter: string }&gt;;
+
+  // Remove any existing entry with the same name (case-insensitive)
+  const filtered = existing.filter(a =&gt; a.name.toLowerCase() !== "onenter");
+
+  await u.db.modify(me.id, "$set", {
+    data: {
+      ...me.state,
+      attributes: [
+        ...filtered,
+        { name: "ONENTER", value: `u.send("Welcome back!");`, setter: "#" + me.id },
+      ],
+    },
+  });
+  u.send("ONENTER set on yourself.");
+};
+</code></pre>
+<blockquote>
+<p><strong>Important:</strong> <code>u.db.modify</code> with <code>"$set"</code> and a <code>data:</code> key replaces the<br>
+whole data block. Always spread <code>me.state</code> (or the target’s state) so you<br>
+don’t wipe other fields. See the <a href="/ursamu/guides/scripting">Scripting Guide</a> for<br>
+the full <code>u.db.modify</code> pattern.</p>
+</blockquote>
+<h3>Read the raw array</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const attrs = (u.me.state.attributes || []) as Array&lt;{ name: string; value: string }&gt;;
+const found = attrs.find(a =&gt; a.name.toLowerCase() === "short-desc");
+if (found) u.send(`Your short-desc: ${found.value}`);
+</code></pre>
+<h2>For most use cases, prefer <code>u.attr.get()</code> (see below) — it handles<br>
+case-insensitivity and parent inheritance automatically.</h2>
+<h2>Reading Attributes</h2>
+<h3><code>u.attr.get(id, name): Promise&lt;string | null&gt;</code></h3>
+<p>Reads the value of a named attribute from an object. Returns <code>null</code> if not set.<br>
+The name is <strong>case-insensitive</strong>. If the attribute is not on the object itself,<br>
+UrsaMU walks up the <code>data.parent</code> chain.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">export default async (u) =&gt; {
+  const bio = await u.attr.get(u.me.id, "FINGER-INFO");
+  if (bio) {
+    u.send(bio);
+  } else {
+    u.send("No bio set. Use: &amp;finger-info me=&lt;text&gt;");
+  }
+};
+</code></pre>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read from any object by id
+const sd = await u.attr.get(someObjectId, "SHORT-DESC");
+</code></pre>
+<hr>
+<h2>Running Attributes</h2>
+<h3><code>u.trigger(id, attr, args?): Promise&lt;void&gt;</code></h3>
+<p>Runs the attribute as a script. The script executes in its own sandbox with the<br>
+targeted object as context. The actor who called <code>u.trigger</code> does <strong>not</strong> become<br>
+the script’s <code>u.me</code> — the object itself does. Returns when the script completes.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Fire the USE attribute on a chest the actor is looking at
+await u.trigger(chestId, "USE", [u.me.id]);
+</code></pre>
+<p>Args are available in the triggered script as <code>u.cmd.args</code>.</p>
+<h3><code>u.eval(id, attr, args?): Promise&lt;string&gt;</code></h3>
+<p>Like <code>u.trigger</code>, but captures and returns whatever the script sends as a<br>
+string. Useful for computed values.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const formula = await u.eval(u.me.id, "SCORE-FORMULA", ["str"]);
+u.send(`Your STR score: ${formula}`);
+</code></pre>
+<p>If the attribute is not found, <code>u.eval</code> returns <code>""</code>.</p>
+<h3><code>@trigger &lt;object&gt;/&lt;attr&gt;[=&lt;args&gt;]</code></h3>
+<p>The in-game command version of <code>u.trigger</code>. Fires an attribute on any object the<br>
+actor can see or edit.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; @trigger chest/USE
+Triggered script on chest/USE.
+
+&gt; @trigger here/ONENTER=Alice
+Triggered script on here/ONENTER.
+</code></pre>
+<p>Arguments after <code>=</code> are split on whitespace and available as <code>u.cmd.args</code> in<br>
+the triggered script.</p>
+<h3>Automatic hooks</h3>
+<p>Some attributes are fired automatically by the engine — no <code>@trigger</code> needed:</p>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Fired on</th>
+<th>Fired by</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>ACONNECT</code></td>
+<td>player or master room</td>
+<td>Player connects</td>
+</tr>
+<tr>
+<td><code>ADISCONNECT</code></td>
+<td>player or master room</td>
+<td>Player disconnects</td>
+</tr>
+</tbody>
+</table>
+<h2><code>ACONNECT</code> and <code>ADISCONNECT</code> fire on the connecting player’s own object first,<br>
+then on the master room (configured as <code>game.masterRoom</code>). The script runs with<br>
+the connected player as <code>u.me</code>.</h2>
+<h2>Common Attribute Names</h2>
+<p>These are conventions — UrsaMU does not enforce them (except <code>ACONNECT</code> and<br>
+<code>ADISCONNECT</code>, which are fired by the hooks system). Use them consistently so<br>
+other builders know what to expect.</p>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Set on</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>ACONNECT</code></td>
+<td>player, master room</td>
+<td>Script to run when the player connects</td>
+</tr>
+<tr>
+<td><code>ADISCONNECT</code></td>
+<td>player, master room</td>
+<td>Script to run when the player disconnects</td>
+</tr>
+<tr>
+<td><code>ONENTER</code></td>
+<td>room</td>
+<td>Fire when any player enters the room</td>
+</tr>
+<tr>
+<td><code>ONEXIT</code></td>
+<td>room</td>
+<td>Fire when any player leaves the room</td>
+</tr>
+<tr>
+<td><code>USE</code></td>
+<td>thing</td>
+<td>Fire when a player uses/activates the object</td>
+</tr>
+<tr>
+<td><code>OPEN</code></td>
+<td>container/exit</td>
+<td>Fire when the object is opened</td>
+</tr>
+<tr>
+<td><code>CLOSE</code></td>
+<td>container/exit</td>
+<td>Fire when the object is closed</td>
+</tr>
+<tr>
+<td><code>DROP</code></td>
+<td>thing</td>
+<td>Fire when the object is dropped</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td>thing</td>
+<td>Fire when the object is picked up</td>
+</tr>
+<tr>
+<td><code>SHORT-DESC</code></td>
+<td>player, thing</td>
+<td>One-line description for room display and +finger</td>
+</tr>
+<tr>
+<td><code>FINGER-INFO</code></td>
+<td>player</td>
+<td>Free-form bio shown in +finger</td>
+</tr>
+<tr>
+<td><code>SCORE-EXTRA</code></td>
+<td>player</td>
+<td>Extra stat block appended to score output</td>
+</tr>
+<tr>
+<td><code>ODESC</code></td>
+<td>thing</td>
+<td>Message broadcast to others when the thing is examined</td>
+</tr>
+<tr>
+<td><code>SCRIPT</code></td>
+<td>any</td>
+<td>Generic script slot — fired by the command parser when an object handles a command</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p><code>ONENTER</code>, <code>ONEXIT</code>, <code>USE</code>, <code>OPEN</code>, <code>CLOSE</code>, <code>DROP</code>, and <code>GET</code> are<br>
+<strong>not</strong> fired automatically by the core engine. They require either<br>
+<code>@trigger</code> from a system script, or your own plugin/script to call<br>
+<code>u.trigger()</code> at the right moment.</p>
+</blockquote>
+<hr>
+<h2>Scripting Inside Attributes</h2>
+<p>Attribute values are full JavaScript/TypeScript scripts. They run inside the<br>
+same Web Worker sandbox as any other UrsaMU script with the full <code>u</code> API<br>
+available.</p>
+<h3>Module format (recommended)</h3>
+<p>Export a default async function. This is the same format used in <code>system/scripts/</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">export default async (u) =&gt; {
+  u.send("Hello from an attribute!");
+};
+</code></pre>
+<h3>Legacy block format</h3>
+<p>If the value does not contain an <code>export</code> statement, UrsaMU runs it as a block<br>
+(the code is executed directly, with <code>u</code> in scope).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.send("Hello from a legacy block!");
+</code></pre>
+<p>Both formats have access to the full <code>u</code> API.</p>
+<h3>The <code>u</code> object in triggered attributes</h3>
+<p>When an attribute is fired via <code>u.trigger(id, attr)</code>:</p>
+<ul>
+<li><code>u.me</code> — the object the attribute is set on (not the actor who called<br>
+<code>u.trigger</code>)</li>
+<li><code>u.here</code> — the room that object is in</li>
+<li><code>u.cmd.name</code> — the attribute name in lowercase</li>
+<li><code>u.cmd.args</code> — the args array passed to <code>u.trigger</code> / <code>@trigger</code></li>
+</ul>
+<h2>When an attribute is fired via <code>u.eval(id, attr, args)</code>, the same rules apply<br>
+and the script’s output (via <code>u.send</code>) is captured as the return value.</h2>
+<h2>Practical Examples</h2>
+<h3>Room that greets players on entry</h3>
+<p>Set this on a room. Call <code>u.trigger(room.id, "ONENTER", [actorId])</code> from a<br>
+movement hook or a custom <code>look</code> script:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;ONENTER The Tavern=#...
+export default async (u) =&gt; {
+  const actorId = u.cmd.args[0];
+  const actor = actorId ? (await u.db.search(actorId))[0] : null;
+  const name = actor ? String(actor.state.moniker || actor.state.name || "Someone") : "Someone";
+  u.here.broadcast(`${name} pushes open the door and steps inside.`);
+  u.send("The warmth of the fire and the smell of roasting meat greet you.");
+};
+</code></pre>
+<h3>Object that does something when used</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;USE Ancient Lever=#...
+export default async (u) =&gt; {
+  const actorId = u.cmd.args[0];
+  u.here.broadcast("The lever grinds against stone with a horrible screech.");
+  await u.teleport("secret-door-id", "open-room-id");
+  u.send("You hear a door grinding open somewhere nearby.");
+};
+</code></pre>
+<h3>Greeting script on player connect</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;ACONNECT me=#...  (on a player)
+export default async (u) =&gt; {
+  const unread = (await u.mail.read({ to: { $in: [`#${u.me.id}`] } }))
+    .filter(m =&gt; !m.data?.read).length;
+  if (unread &gt; 0) u.send(`You have ${unread} unread message${unread === 1 ? "" : "s"}.`);
+};
+</code></pre>
+<h3>NPC that responds to being examined</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;ODESC Town Guard=#...  (plain text — broadcast when examined)
+// "snaps to attention and eyes you warily."
+// The look script broadcasts: "&lt;actor&gt; snaps to attention and eyes you warily."
+</code></pre>
+<h3>Computed score field</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;SCORE-FORMULA me=#...
+export default (u) =&gt; {
+  const str = Number(u.me.state.str) || 0;
+  const bonus = Math.floor((str - 10) / 2);
+  u.send(`${str} (${bonus &gt;= 0 ? "+" : ""}${bonus})`);
+};
+</code></pre>
+<p>Then from your score script or a <code>+sheet</code> command:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const strDisplay = await u.eval(u.me.id, "SCORE-FORMULA");
+u.send(`STR: ${strDisplay}`);
+</code></pre>
+<h3>Per-object data storage</h3>
+<p>Attributes don’t have to hold scripts — they can hold plain data strings that<br>
+other scripts read with <code>u.attr.get</code>:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// &amp;PRICE Healing Potion=#...  (value: "50")
+// &amp;USES Healing Potion=#...   (value: "3")
+
+export default async (u) =&gt; {
+  const price = await u.attr.get(u.target!.id, "PRICE") || "0";
+  const uses  = await u.attr.get(u.target!.id, "USES")  || "1";
+  u.send(`Price: ${price} credits  (${uses} use${uses === "1" ? "" : "s"} remaining)`);
+};
+</code></pre>
+<hr>
+<h2>Softcode Evaluator (TinyMUX Compatible)</h2>
+<p>As of v2.0.0, UrsaMU ships a full TinyMUX 2.x-compatible softcode evaluator. Any attribute flagged <code>/softcode</code> is run through the evaluator rather than executed as TypeScript.</p>
+<h3>Enabling softcode on an attribute</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">&amp;GREET/softcode me=[name(%#)] greets you!
+</code></pre>
+<p>The <code>/softcode</code> switch tells the engine to evaluate the value as MUSH softcode rather than TypeScript. It persists on the attribute — you only need to specify it when first setting the attribute.</p>
+<p>Attributes that contain MUX substitution syntax (<code>%N</code>, <code>[func()]</code>) and no TypeScript keywords are also auto-detected as softcode.</p>
+<h3>Action commands</h3>
+<table>
+<thead>
+<tr>
+<th>Command</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@switch &lt;expr&gt;=&lt;case&gt;,&lt;action&gt;[,&lt;default&gt;]</code></td>
+<td>Branch on value</td>
+</tr>
+<tr>
+<td><code>@dolist &lt;list&gt;=&lt;action&gt;</code></td>
+<td>Iterate over space-delimited list (<code>##</code> = item, <code>#@</code> = index)</td>
+</tr>
+<tr>
+<td><code>@if &lt;expr&gt;=&lt;true&gt;[,&lt;false&gt;]</code></td>
+<td>Conditional execution</td>
+</tr>
+<tr>
+<td><code>@while &lt;expr&gt;=&lt;action&gt;</code></td>
+<td>Loop while true (100ms wall-clock timeout enforced)</td>
+</tr>
+<tr>
+<td><code>@break</code></td>
+<td>Exit the current <code>@dolist</code> or <code>@while</code></td>
+</tr>
+<tr>
+<td><code>@trigger &lt;obj&gt;/&lt;attr&gt;[=&lt;args&gt;]</code></td>
+<td>Fire an attribute as a trigger</td>
+</tr>
+<tr>
+<td><code>@wait &lt;seconds&gt;=&lt;action&gt;</code></td>
+<td>Delay an action</td>
+</tr>
+</tbody>
+</table>
+<h3>$-pattern dispatch</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">&amp;CMD_GREET object=$greet *:@pemit %#=Hello, %0!
+</code></pre>
+<p>Attributes beginning with <code>$</code> fire when their glob pattern matches a typed command. <code>%0</code>–<code>%9</code> are capture groups. Objects in the same room as the player, or in the master room, or in the player’s zone master are checked.</p>
+<h3>^-pattern listeners (monitors)</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">&amp;LISTEN_HELLO object=^*hello*:@pemit %#=I heard a hello!
+</code></pre>
+<p>Attributes beginning with <code>^</code> fire when their pattern matches anything broadcast in the room. The object must have the <code>MONITOR</code> flag set.</p>
+<h3>Softcode function reference</h3>
+<p>See <a href="/ursamu/mush_compatibility/">MUSH Compatibility</a> for the full list of ~250 supported functions, substitutions, and compatibility stubs.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/sdk-cookbook/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">SDK Cookbook</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/guides/user-guide/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">User Guide</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/guides/user-guide/index.html
+++ b/docs/_site/guides/user-guide/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -278,7 +278,7 @@ everything from basic commands to advanced features.</p>
 through your browser.</li>
 <li><strong>Telnet Client</strong>: You can use a telnet client to connect to the server’s<br>
 port.</li>
-<li><em><em>MU</em> Client</em>*: Specialized clients like Mudlet, TinTin++, or MUSHclient can<br>
+<li><strong>MU* Client</strong>: Specialized clients like Mudlet, TinTin++, or MUSHclient can<br>
 provide enhanced features.</li>
 </ol>
 <h3>Creating an Account</h3>
@@ -312,9 +312,29 @@ you started:</p>
 <h3>Examining Objects</h3>
 <ul>
 <li><code>look [&lt;object&gt;]</code> — Look at the room or a specific object</li>
-<li><code>examine &lt;object&gt;</code> — Inspect an object’s full details (owner, flags, contents)</li>
+<li><code>examine &lt;object&gt;</code> — Inspect an object’s full technical details (requires edit permission or the <code>visual</code> flag on the target)</li>
+<li><code>examine</code> — Examine the current room (no argument)</li>
 <li><code>doing</code> — Show your current activity/status line</li>
 </ul>
+<p><code>examine</code> output includes:</p>
+<ul>
+<li><strong>Type</strong> — Room, Player, Exit, or Thing</li>
+<li><strong>Flags</strong> — all flags set on the object</li>
+<li><strong>Owner</strong> — resolved to the owner’s name and dbref</li>
+<li><strong>Lock</strong> — the object’s current lock expression</li>
+<li><strong>Location / Home</strong> — resolved to room names and dbrefs</li>
+<li><strong>Description</strong> — the object’s description text</li>
+<li><strong>Exits</strong> — exits in the room (for Room objects)</li>
+<li><strong>Contents</strong> — things and players currently present</li>
+<li><strong>Attributes</strong> — any custom <code>@set</code> attributes on the object</li>
+</ul>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; examine me
+===== Admin (#5) [Player] ===========================
+Flags:    player wizard connected
+Owner:    Admin (#5)
+Location: The Hub (#1)
+...
+</code></pre>
 <h2>Bulletin Boards</h2>
 <p>Bulletin boards are persistent message boards, organized by topic.</p>
 <ul>
@@ -356,6 +376,26 @@ room</li>
 <li><code>@channel/leave &lt;alias&gt;</code> — Leave a channel</li>
 <li><code>&lt;alias&gt; &lt;message&gt;</code> — Send a message on a joined channel (using your alias)</li>
 </ul>
+<h2>Wiki</h2>
+<p>The wiki is a shared knowledge base for lore, news, fiction, and game<br>
+information. All connected players can read and search it from in-game.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">+wiki                         -- List top-level pages and directories
++wiki &lt;path&gt;                  -- Read a page or list a directory
++wiki/search &lt;query&gt;          -- Search all pages by title, body, or tag
+</code></pre>
+<p><strong>Examples:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">+wiki                         -- Show the wiki index
++wiki news                    -- List all pages under news/
++wiki news/patch-notes        -- Read a specific page
++wiki/search dragon           -- Find all pages mentioning "dragon"
+</code></pre>
+<p>Paths mirror the folder structure exactly. A page at <code>lore/factions/iron-circle</code><br>
+is read with <code>+wiki lore/factions/iron-circle</code>.</p>
+<blockquote>
+<p>Staff members can create, edit, and fetch images with <code>@wiki</code> commands —<br>
+see the <a href="/ursamu/guides/admin-guide/#wiki-administration">Admin Guide</a> for details.</p>
+</blockquote>
+<hr>
 <h2>Object Interaction</h2>
 <p>You can pick up, drop, and exchange objects with other players:</p>
 <ul>
@@ -474,11 +514,71 @@ in-game.</p>
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
         
       
         
@@ -501,16 +601,16 @@ in-game.</p>
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/sdk-cookbook/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/softcoding/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">SDK Cookbook</span>
+            <span class="page-nav-title">Soft-Coding Guide</span>
           </a>
         
 
         
-          <a href="/ursamu/mush_compatibility/" class="page-nav-btn next">
+          <a href="/ursamu/guides/wiki/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title">MUSH Compatibility</span>
+            <span class="page-nav-title">Wiki</span>
           </a>
         
       </nav>

--- a/docs/_site/guides/wiki/index.html
+++ b/docs/_site/guides/wiki/index.html
@@ -1,0 +1,863 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wiki | UrsaMU Documentation</title>
+  <meta name="description" content="How to create, organize, and manage your game wiki in UrsaMU.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/guides/wiki/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link active">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Wiki</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Wiki</h1>
+<h2>Every UrsaMU game project includes a <code>wiki/</code> directory at the project root.<br>
+Files placed here are immediately available to players via in-game commands and<br>
+to external tools via the REST API. No database setup is required — the wiki is<br>
+file-based Markdown.</h2>
+<h2>Overview</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">wiki/
+├── home.md              ← shown for +wiki home
+├── lore/
+│   ├── index.md         ← shown for +wiki lore
+│   └── factions.md      ← shown for +wiki lore/factions
+├── rules.md
+└── images/
+    └── banner.png       ← served at GET /api/v1/wiki/images/banner.png
+</code></pre>
+<h2>Players read pages with <code>+wiki</code>. Admins and wizards write and edit pages with<br>
+<code>@wiki</code>. All write operations require the <code>admin</code>, <code>wizard</code>, or <code>superuser</code><br>
+flag.</h2>
+<h2>Directory Structure</h2>
+<p>Subdirectories become sections. A directory with an <code>index.md</code> shows that file<br>
+when listed; otherwise the directory listing is shown directly.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">wiki/lore/index.md   →  +wiki lore         (section overview)
+wiki/lore/factions.md →  +wiki lore/factions
+wiki/rules.md         →  +wiki rules
+</code></pre>
+<h2><code>README.md</code> files at any level are ignored by the wiki system — they are for<br>
+human readers of the repository only.</h2>
+<h2>Frontmatter</h2>
+<p>Pages support YAML-ish frontmatter for metadata. The parser supports strings,<br>
+numbers, booleans, and inline arrays.</p>
+<pre class="language-markdown" tabindex="0"><code class="language-markdown">---
+title: The Iron Pact
+author: Storyteller
+date: 2026-03-18
+tags: [lore, factions, politics]
+---
+
+The Iron Pact was forged in the aftermath of the Sundering...
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>title</code></td>
+<td>string</td>
+<td>Display name shown in listings and page headers</td>
+</tr>
+<tr>
+<td><code>author</code></td>
+<td>string</td>
+<td>Who wrote the page</td>
+</tr>
+<tr>
+<td><code>date</code></td>
+<td>string</td>
+<td>Publication date (any format)</td>
+</tr>
+<tr>
+<td><code>tags</code></td>
+<td>array</td>
+<td>Searchable keywords</td>
+</tr>
+</tbody>
+</table>
+<h2>Any additional keys are stored and returned by the API — use them freely for<br>
+custom metadata.</h2>
+<h2>In-Game Commands</h2>
+<h3>Reading: <code>+wiki</code></h3>
+<pre class="language-none" tabindex="0"><code class="language-none">+wiki                       list root-level pages and directories
++wiki &lt;path&gt;                read a page or list a directory
++wiki/search &lt;query&gt;        full-text search (title, body, tags)
+</code></pre>
+<p><strong>Examples:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">+wiki                       → root listing
++wiki lore                  → lore/index.md or directory listing
++wiki lore/factions         → lore/factions.md
++wiki/search iron pact      → all pages mentioning "iron pact"
+</code></pre>
+<h3>Writing: <code>@wiki</code> (admin/wizard only)</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@wiki/create &lt;path&gt;=&lt;title&gt;/&lt;body&gt;   create a new page
+@wiki/edit   &lt;path&gt;=&lt;new body&gt;       replace the body of an existing page
+@wiki/fetch  &lt;url&gt;=&lt;wiki-path&gt;       download a remote image into wiki/
+</code></pre>
+<p><strong>Examples:</strong></p>
+<pre class="language-none" tabindex="0"><code class="language-none">@wiki/create lore/factions=The Iron Pact/The Iron Pact was forged...
+@wiki/edit lore/factions=Updated text about the Iron Pact...
+@wiki/fetch https://example.com/banner.png=images/banner.png
+</code></pre>
+<h2><code>@wiki/create</code> sets <code>author</code> and <code>date</code> automatically from the acting player.<br>
+<code>@wiki/edit</code> preserves all existing frontmatter and replaces only the body.<br>
+<code>@wiki/fetch</code> blocks private/loopback URLs and enforces a 10 MB limit.</h2>
+<h2>REST API</h2>
+<p>The wiki is exposed at <code>/api/v1/wiki</code>. Write operations (<code>POST</code>, <code>PATCH</code>,<br>
+<code>DELETE</code>, <code>PUT</code>) require a valid session token.</p>
+<h3>List all pages</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/wiki
+</code></pre>
+<p>Returns an array of page stubs:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  { "path": "home",           "title": "Home",         "type": "page" },
+  { "path": "lore/factions",  "title": "The Iron Pact","type": "page" }
+]
+</code></pre>
+<h3>Search</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/wiki?q=iron+pact
+</code></pre>
+<p>Returns matching stubs (title, body, and tag matches).</p>
+<h3>Read a page</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/wiki/&lt;path&gt;
+</code></pre>
+<p>Returns the page’s frontmatter fields merged with a <code>body</code> key:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "path":   "lore/factions",
+  "title":  "The Iron Pact",
+  "author": "Storyteller",
+  "date":   "2026-03-18",
+  "tags":   ["lore", "factions"],
+  "body":   "The Iron Pact was forged..."
+}
+</code></pre>
+<p>If <code>&lt;path&gt;</code> is a directory, a listing is returned:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "path": "lore",
+  "type": "directory",
+  "children": [
+    { "path": "lore/factions", "title": "The Iron Pact", "type": "page" }
+  ]
+}
+</code></pre>
+<h3>Create a page</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">POST /api/v1/wiki
+Content-Type: application/json
+
+{
+  "path":   "lore/factions",
+  "title":  "The Iron Pact",
+  "tags":   ["lore", "factions"],
+  "body":   "The Iron Pact was forged..."
+}
+</code></pre>
+<p>Returns <code>201</code> on success, <code>409</code> if the page already exists.</p>
+<h3>Update a page</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">PATCH /api/v1/wiki/&lt;path&gt;
+Content-Type: application/json
+
+{ "body": "Revised text..." }
+</code></pre>
+<p>Only the fields included in the request are changed. Omit <code>body</code> to update<br>
+metadata only.</p>
+<h3>Delete a page</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">DELETE /api/v1/wiki/&lt;path&gt;
+</code></pre>
+<h2>Removes <code>&lt;path&gt;.md</code> or <code>&lt;path&gt;/index.md</code>. Returns <code>{ "deleted": true }</code>.</h2>
+<h2>Static Assets</h2>
+<p>Images and PDFs can be stored in the wiki directory and served over HTTP.</p>
+<h3>Upload via API</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">PUT /api/v1/wiki/images/banner.png
+Content-Type: image/png
+&lt;binary body&gt;
+</code></pre>
+<p>Maximum upload size is <strong>10 MB</strong>. Supported types:</p>
+<table>
+<thead>
+<tr>
+<th>Extension</th>
+<th>MIME type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>.jpg</code> / <code>.jpeg</code></td>
+<td><code>image/jpeg</code></td>
+</tr>
+<tr>
+<td><code>.png</code></td>
+<td><code>image/png</code></td>
+</tr>
+<tr>
+<td><code>.gif</code></td>
+<td><code>image/gif</code></td>
+</tr>
+<tr>
+<td><code>.webp</code></td>
+<td><code>image/webp</code></td>
+</tr>
+<tr>
+<td><code>.svg</code></td>
+<td><code>image/svg+xml</code></td>
+</tr>
+<tr>
+<td><code>.pdf</code></td>
+<td><code>application/pdf</code></td>
+</tr>
+</tbody>
+</table>
+<h3>Upload via in-game command</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@wiki/fetch https://example.com/banner.png=images/banner.png
+</code></pre>
+<p>Fetches the remote URL and saves it at <code>wiki/images/banner.png</code>. Private and<br>
+loopback addresses are blocked.</p>
+<h3>Retrieve</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">GET /api/v1/wiki/images/banner.png
+</code></pre>
+<h2>Returns the raw file with the appropriate <code>Content-Type</code> header and a<br>
+<code>Cache-Control: public, max-age=3600</code> header.</h2>
+<h2>Hooks</h2>
+<p>Plugins can react to wiki changes by subscribing to <code>wikiHooks</code>:</p>
+<pre class="language-ts" tabindex="0"><code class="language-ts">import { wikiHooks } from "ursamu/plugins/wiki";
+
+wikiHooks.on("wiki:created", (page) =&gt; {
+  console.log(`New page: ${page.path} — "${page.meta.title}"`);
+});
+
+wikiHooks.on("wiki:edited", (page) =&gt; {
+  console.log(`Updated: ${page.path}`);
+});
+
+wikiHooks.on("wiki:deleted", (page) =&gt; {
+  console.log(`Deleted: ${page.path}`);
+});
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Fires when</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>wiki:created</code></td>
+<td>A new page is written (REST or in-game)</td>
+</tr>
+<tr>
+<td><code>wiki:edited</code></td>
+<td>A page’s body or metadata is updated</td>
+</tr>
+<tr>
+<td><code>wiki:deleted</code></td>
+<td>A page or asset is removed</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Tips</h2>
+<h3>Use subdirectories to organize content</h3>
+<p>Flat listings become unwieldy quickly. Group pages by topic:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">wiki/lore/          world background, factions, history
+wiki/rules/         policies, chargen rules, house rules
+wiki/staff/         internal notes, plot threads, NPC rosters
+wiki/news/          IC announcements, session recaps
+</code></pre>
+<h3>Use frontmatter tags for cross-cutting search</h3>
+<p>Tags are searched alongside title and body, so <code>+wiki/search faction</code> finds<br>
+every page tagged <code>factions</code> even if the word doesn’t appear in the body.</p>
+<h3>Version your wiki with git</h3>
+<p>Because the wiki is plain files, it is automatically tracked by git. Staff can<br>
+edit pages in their editor and push; the changes are live immediately after the<br>
+server reloads.</p>
+<h3>The <code>home.md</code> convention</h3>
+<p>The file <code>wiki/home.md</code> is created automatically when you scaffold a new<br>
+project. Treat it as the entry point — link from it to your major sections so<br>
+that <code>+wiki home</code> gives new players an orientation.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/guides/user-guide/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title">User Guide</span>
+          </a>
+        
+
+        
+          <a href="/ursamu/mush_compatibility/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">MUSH Compatibility</span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/index.html
+++ b/docs/_site/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -86,164 +86,235 @@
 <main class="animate-in">
   <!-- ── HERO ───────────────────────────────────────────────────────── -->
 <div class="home-hero animate-in">
-  <div class="version-badge" style="cursor:default">
-    <svg width="10" height="10" viewbox="0 0 10 10" fill="var(--primary-light)"><circle cx="5" cy="5" r="5"></circle></svg>
-    v1.3.0 &nbsp;•&nbsp; MIT License
-  </div>
+  <p class="home-hero__chip">mush 1.0.30 · cli 0.1.2 · MIT</p>
   <h1>A Modern MUSH Server</h1>
-  <p>
-    High-performance, modular MU* engine built with <strong style="color:var(--text)">TypeScript</strong>
-    and <strong style="color:var(--text)">Deno</strong>.<br>
-    WebSocket-native • Sandbox scripting • Plugin architecture • Discord bridge.
+  <p class="home-hero__lede">
+    High-performance MU* engine in <strong>TypeScript</strong> and
+    <strong>Deno</strong>. WebSocket hub, public portal, staff console,
+    sandboxed scripts, JSR plugins.
   </p>
   <div class="home-actions">
-    <a href="/ursamu/guides/installation/" class="btn-primary">
-      <svg width="14" height="14" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
-      Get Started
-    </a>
-    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary">
-      <svg width="14" height="14" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.834 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
-      View on GitHub
-    </a>
-    <a href="/ursamu/guides/user-guide/" class="btn-secondary">
-      <svg width="14" height="14" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
-      Read the Docs
-    </a>
+    <a href="/ursamu/guides/installation/" class="btn-primary">Get Started</a>
+    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary">GitHub</a>
+    <a href="/ursamu/guides/user-guide/" class="btn-secondary">Read the Docs</a>
   </div>
 </div>
 <!-- ── QUICK INSTALL ──────────────────────────────────────────────── -->
-<div class="quickstart-block" style="animation-delay:0.1s">
-  <div class="quickstart-inner">
-    <div class="quickstart-bar">
-      <span class="quickstart-dot" style="background:#ff5f57"></span>
-      <span class="quickstart-dot" style="background:#febc2e"></span>
-      <span class="quickstart-dot" style="background:#28c840"></span>
-      <span style="margin-left:auto;font-size:0.7rem;color:var(--text-dim);font-family:'JetBrains Mono',monospace">terminal</span>
-    </div>
-    <pre class="quickstart-code"><span class="comment"># Install the UrsaMU DX bootstrapper</span>
-<span class="cmd">deno install -A --global -n deno-x jsr:@dx/dx</span>
-<span class="cmd">deno x --install-alias</span>
-<span class="comment"># Initialize a new world</span>
-<span class="cmd">dx jsr:@ursamu/ursamu init</span></pre>
+<section class="home-stack">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Install</p>
+    <h2 class="home-stack__title">Quick start</h2>
+  </header>
+  <div class="home-stack__code">
+    <div class="home-stack__code-bar">Terminal</div>
+    <pre class="home-stack__pre"><span class="cmt"># Scaffold a game (engine + portal stack)</span>
+<span class="cmd">deno run -A jsr:@ursamu/cli@0.1.2/create my-game</span>
+<span class="cmd">cd my-game</span>
+<span class="cmd">deno task start</span>
+<span class="cmt"># http://localhost:4203/  ·  /play  ·  /admin/</span></pre>
   </div>
-</div>
-<!-- ── FEATURE CARDS ─────────────────────────────────────────────── -->
-<div class="feature-grid" style="animation-delay:0.15s">
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"></path></svg>
+</section>
+<!-- ── CAPABILITIES ──────────────────────────────────────────────── -->
+<section class="home-stack" aria-label="Capabilities">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Product</p>
+    <h2 class="home-stack__title">Capabilities</h2>
+  </header>
+  <dl class="home-stack__list">
+    <div class="home-stack__row">
+      <dt>Transport</dt>
+      <dd>WebSocket hub with rate limits — browser play, custom clients, or Telnet</dd>
     </div>
-    <h3>WebSocket Native</h3>
-    <p>First-class WebSocket interface with a 10 cmd/sec rate limiter. Connect from any browser or MU* client.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+    <div class="home-stack__row">
+      <dt>Runtime</dt>
+      <dd>Scripts in Web Workers with the full SDK — a bad attr cannot crash the host</dd>
     </div>
-    <h3>Sandboxed Scripting</h3>
-    <p>Scripts run in Web Workers with a rich SDK — database access, messaging, rooms, and channels — without touching the host.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+    <div class="home-stack__row">
+      <dt>Plugins</dt>
+      <dd>Typed packages: commands, hooks, flags, routes, namespaced DBO</dd>
     </div>
-    <h3>Plugin Architecture</h3>
-    <p>Extend the engine with typed plugins. Add commands, hooks, flags, routes, and custom database services.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+    <div class="home-stack__row">
+      <dt>Front ends</dt>
+      <dd><code>@ursamu/site</code> (/play) and <code>@ursamu/web</code> (/admin) on one HTTP port</dd>
     </div>
-    <h3>Discord Bridge</h3>
-    <p>Built-in Discord integration with exponential-backoff reconnect — relay in-game chat to Discord channels and back.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+    <div class="home-stack__row">
+      <dt>Database</dt>
+      <dd>TypeGraph/PGlite by default, Deno KV fallback — query by flags, owner, data</dd>
     </div>
-    <h3>Flexible Database</h3>
-    <p>Pluggable database layer (dbojs) for game objects, channels, mail, and bulletin boards. Query by flags, owner, or custom data.</p>
-  </div>
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewbox="0 0 24 24"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+    <div class="home-stack__row">
+      <dt>Softcode</dt>
+      <dd>TinyMUX 2.x evaluator — 250+ functions, ANSI, format handler pipeline</dd>
     </div>
-    <h3>Scene Archive</h3>
-    <p>Collaborative roleplay scene tracking with REST export endpoints — download logs as Markdown or JSON.</p>
-  </div>
-</div>
-<!-- ── SECTION GRID ───────────────────────────────────────────────── -->
-<div style="max-width:900px;margin:0 auto 1rem;padding:0 1rem">
-  <p style="text-align:center;font-size:0.8rem;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);margin-bottom:1.25rem">Jump to a section</p>
-</div>
-<div class="home-section-grid">
-  <a href="/ursamu/guides/installation/" class="home-section-card">
-    <h4>Installation</h4>
-    <p>Get UrsaMU running in minutes with the DX wizard, Docker, or from source.</p>
-  </a>
-  <a href="/ursamu/guides/user-guide/" class="home-section-card">
-    <h4>Player Guide</h4>
-    <p>Commands, movement, communication, building, and object interaction.</p>
-  </a>
-  <a href="/ursamu/guides/admin-guide/" class="home-section-card">
-    <h4>Admin Guide</h4>
-    <p>User management, channels, scene export, rate limiting, and security.</p>
-  </a>
-  <a href="/ursamu/api/" class="home-section-card">
-    <h4>API Reference</h4>
-    <p>Core, database, command, flag, hook, and utility APIs documented in full.</p>
-  </a>
-  <a href="/ursamu/plugins/" class="home-section-card">
-    <h4>Plugin Dev</h4>
-    <p>Build plugins that add commands, hooks, flags, and custom services.</p>
-  </a>
-  <a href="/ursamu/development/contributing/" class="home-section-card">
-    <h4>Contributing</h4>
-    <p>Help shape UrsaMU — from bug reports to PRs and new features.</p>
-  </a>
-</div>
-<!-- ── ARCHITECTURE OVERVIEW ─────────────────────────────────────── -->
-<div style="max-width:900px;margin:0 auto 4rem;padding:0 1rem">
-  <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:2rem;backdrop-filter:blur(8px)">
-    <p style="font-size:0.68rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:var(--primary-light);margin-bottom:1rem">Architecture at a Glance</p>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;font-size:0.82rem;color:var(--text-muted)">
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Runtime</div>
-        Deno (TypeScript) • ESM modules • Web Workers for sandboxing
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Transport</div>
-        WebSocket hub (4202) • HTTP REST (4203) • Telnet sidecar (4201)
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Persistence</div>
-        dbojs (game objects) • chans • mail • bboard • counters
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Integrations</div>
-        Discord gateway • Scene REST API • Plugin SDK
-      </div>
+    <div class="home-stack__row">
+      <dt>Events</dt>
+      <dd>Typed GameHooks bus for login, say, move, scenes, and plugin events</dd>
     </div>
-  </div>
-</div>
+    <div class="home-stack__row">
+      <dt>Integrations</dt>
+      <dd>Optional Discord bridge with reconnect/backoff via JSR</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Installs</dt>
+      <dd>Fail-fast manifests with semver checks and whole-run rollback</dd>
+    </div>
+  </dl>
+</section>
+<!-- ── DOCS DIRECTORY ─────────────────────────────────────────────── -->
+<nav class="home-stack" aria-label="Documentation sections">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Documentation</p>
+    <h2 class="home-stack__title">Where to go next</h2>
+  </header>
+  <ul class="home-stack__list home-stack__list--links">
+    <li>
+      <a href="/ursamu/guides/installation/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Installation</span>
+          <span class="home-stack__desc">Scaffold, start, claim superuser</span>
+        </span>
+        <span class="home-stack__path">/guides/installation/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/guides/user-guide/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Player guide</span>
+          <span class="home-stack__desc">Commands, movement, building</span>
+        </span>
+        <span class="home-stack__path">/guides/user-guide/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/guides/admin-guide/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Admin guide</span>
+          <span class="home-stack__desc">Staff tools, security, channels</span>
+        </span>
+        <span class="home-stack__path">/guides/admin-guide/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/api/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">API reference</span>
+          <span class="home-stack__desc">SDK, REST, hooks, database</span>
+        </span>
+        <span class="home-stack__path">/api/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/plugins/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Plugin development</span>
+          <span class="home-stack__desc">addCmd, hooks, routes, DBO</span>
+        </span>
+        <span class="home-stack__path">/plugins/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/development/contributing/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Contributing</span>
+          <span class="home-stack__desc">Tests, PRs, conventions</span>
+        </span>
+        <span class="home-stack__path">/development/contributing/</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+<!-- ── ARCHITECTURE ──────────────────────────────────────────────── -->
+<section class="home-stack" aria-label="Architecture">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">System</p>
+    <h2 class="home-stack__title">Architecture</h2>
+    <p class="home-stack__lede">
+      One Deno process stack: game hub, HTTP portal, and Telnet sidecar.
+    </p>
+  </header>
+  <dl class="home-stack__list">
+    <div class="home-stack__row">
+      <dt>Runtime</dt>
+      <dd>Deno · TypeScript · ESM · sandboxed Web Workers</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Transport</dt>
+      <dd>
+        <code>4201</code> telnet ·
+        <code>4202</code> ws hub ·
+        <code>4203</code> http api + site
+      </dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Engine</dt>
+      <dd><code>@ursamu/mush</code> on <code>@ursamu/core</code></dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Public FE</dt>
+      <dd><code>@ursamu/site</code> — portal, skins, <code>/play</code></dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Staff FE</dt>
+      <dd><code>@ursamu/web</code> — console at <code>/admin/</code></dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Persistence</dt>
+      <dd>TypeGraph / PGlite (default) or Deno KV · namespaced DBO</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Plugins</dt>
+      <dd>JSR packages · help, bbs, mail, wiki, jobs, discord, …</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Events</dt>
+      <dd>GameHooks bus · supervised restart (<code>exit 75</code>)</dd>
+    </div>
+  </dl>
+</section>
 <!-- ── COMMUNITY ─────────────────────────────────────────────────── -->
-<div style="max-width:680px;margin:0 auto 5rem;text-align:center;padding:0 1rem">
-  <p style="font-size:0.68rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:var(--text-dim);margin-bottom:1.5rem">Community &amp; Links</p>
-  <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap">
-    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
-      GitHub
-    </a>
-    <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
-      Discord
-    </a>
-    <a href="/ursamu/guides/installation/" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
-      Quick Start
-    </a>
-  </div>
-</div>
+<section class="home-stack home-stack--end" aria-label="Community">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Community</p>
+    <h2 class="home-stack__title">Get involved</h2>
+  </header>
+  <ul class="home-stack__list home-stack__list--links">
+    <li>
+      <a href="https://github.com/ursamu/ursamu" class="home-stack__link" target="_blank" rel="noopener">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">GitHub</span>
+          <span class="home-stack__desc">Source, issues, and releases</span>
+        </span>
+        <span class="home-stack__path">github.com/ursamu/ursamu</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://discord.gg/ursamu" class="home-stack__link" target="_blank" rel="noopener">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Discord</span>
+          <span class="home-stack__desc">Chat with operators and builders</span>
+        </span>
+        <span class="home-stack__path">discord.gg/ursamu</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/guides/installation/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Install a game</span>
+          <span class="home-stack__desc">Scaffold with the CLI and go live</span>
+        </span>
+        <span class="home-stack__path">/guides/installation/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/ursamu/development/contributing/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Contribute</span>
+          <span class="home-stack__desc">Tests, PRs, and coding conventions</span>
+        </span>
+        <span class="home-stack__path">/development/contributing/</span>
+      </a>
+    </li>
+  </ul>
+</section>
 
 </main>
 

--- a/docs/_site/llms/index.html
+++ b/docs/_site/llms/index.html
@@ -1,0 +1,1004 @@
+<!DOCTYPE html>
+<html><head><meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/llms/">
+<meta name="twitter:card" content="summary">
+</head><body><h1>UrsaMU — AI Reference</h1>
+<blockquote>
+<p>Machine-optimized reference for code generation. Covers all public APIs,<br>
+types, patterns, and conventions. For human-readable guides see docs/guides/.<br>
+<strong>Current version: v2.6.0.</strong> Authoritative API surface lives at<br>
+<code>src/@types/UrsamuSDK.ts</code> and is mirrored in<br>
+<code>.claude/skills/ursamu-dev/references/api-reference.md</code>.</p>
+</blockquote>
+<hr>
+<h2>Overview</h2>
+<p>UrsaMU is a TypeScript/Deno MUSH-style multiplayer game server. Key characteristics:</p>
+<ul>
+<li>Runtime: <strong>Deno</strong> with Deno KV storage</li>
+<li>Public package: <strong><code>jsr:@ursamu/mush</code></strong></li>
+<li>Scripts run in isolated <strong>Web Workers</strong> (no Deno APIs, no network, no filesystem)</li>
+<li>Commands registered with <code>addCmd()</code> run in native Deno context (full APIs available)</li>
+<li>Configuration in <code>config/</code> — JSON or TOML</li>
+<li>Plugins in <code>src/plugins/&lt;name&gt;/</code> — auto-discovered at startup</li>
+<li>System scripts in <code>system/scripts/</code> — one file per command, auto-registered</li>
+</ul>
+<hr>
+<h2>Import Paths</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// All public APIs (v2.6.0)
+import {
+  addCmd, cmds, registerScript, registerCmdMiddleware,
+  registerPluginRoute, registerUIComponent, unregisterUIComponent,
+  getRegisteredUIComponents,
+  mu, createObj, DBO, dbojs, gameHooks, send, joinSocketToRoom,
+  softcodeService, registerSoftcodeFunc, registerSoftcodeSub,
+  evaluateLock, validateLock, registerLockFunc,
+  registerFormatHandler, registerFormatTemplate, unregisterFormatHandler,
+  resolveFormat, resolveFormatOr, resolveGlobalFormat, resolveGlobalFormatOr,
+  header, divider, footer,
+  registerStatSystem, getStatSystem, getDefaultStatSystem, getStatSystemNames,
+  // Stdlib (v2.5.1+): Noise, PRNG, physics, spatial, interpolation, vector
+  Noise, createNoise, seedNoise, perlin1, perlin2, perlin3, simplex2,
+  worley2, fbm2, ridged2, noiseGrid, buildPerm,
+  Rng, createRng,
+  vreflect, pointInAabb, rayAabb,
+  dist2d, dist3d, distSq2d, distSq3d, manhattan, chebyshev, angle2d, bearing,
+  lerp, inverseLerp, remap, smoothstep, smootherstep, clamp,
+  vsize, vsizeSq, vdistance, vdistanceSq, vlerp, vclamp,
+} from "jsr:@ursamu/mush";
+
+// Types (zero runtime cost)
+import type {
+  ICmd, IPlugin, IDBObj, IUrsamuSDK,
+  SayEvent, PoseEvent, PageEvent, MoveEvent, SessionEvent,
+  ChannelMessageEvent, SceneCreatedEvent, ScenePoseEvent,
+  SceneSetEvent, SceneTitleEvent, SceneClearEvent,
+} from "jsr:@ursamu/mush";
+</code></pre>
+<p>Internal plugin imports (use only within src/plugins/):</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "../../services/commands/cmdParser.ts";
+import type { IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
+</code></pre>
+<hr>
+<h2>IDBObj — Game Object</h2>
+<p>Every room, player, exit, and item in the database.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface IDBObj {
+  id: string;                        // Numeric string: "1", "42"
+  name?: string;                     // Display name (shortcut to state.name)
+  flags: Set&lt;string&gt;;                // e.g. Set { "player", "connected" }
+  location?: string;                 // ID of containing room/object
+  state: Record&lt;string, unknown&gt;;    // All stored data (desc, stats, attrs)
+  contents: IDBObj[];                // Objects contained by this object
+}
+</code></pre>
+<p>Common flags:</p>
+<ul>
+<li><code>"superuser"</code> — first player created; highest privilege</li>
+<li><code>"admin"</code> / <code>"wizard"</code> — staff level 9; <code>wizard</code> requires <code>superuser</code> to grant</li>
+<li><code>"builder"</code> — can build rooms/objects</li>
+<li><code>"player"</code> — is a player character</li>
+<li><code>"connected"</code> — currently online</li>
+<li><code>"room"</code> — is a room</li>
+<li><code>"exit"</code> — is an exit</li>
+<li><code>"thing"</code> — is an item</li>
+<li><code>"dark"</code> — hidden from lists</li>
+<li><code>"visual"</code> — others can examine without ownership</li>
+</ul>
+<hr>
+<h2>IUrsamuSDK — The <code>u</code> Object</h2>
+<p>Injected into every command’s <code>exec()</code> and into every sandbox script.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface IUrsamuSDK {
+  // Context (read-only, injected)
+  state:    Record&lt;string, unknown&gt;;          // Per-execution scratch state
+  socketId?: string;                          // Caller's WebSocket ID
+  me:       IDBObj;                           // The actor
+  here:     IDBObj &amp; { broadcast(msg: string, opts?: Record&lt;string,unknown&gt;): void };
+  target?:  IDBObj &amp; { broadcast(msg: string, opts?: Record&lt;string,unknown&gt;): void };
+  cmd:      {
+    name:      string;      // matched command name
+    original?: string;      // raw input string
+    args:      string[];    // regex capture groups
+    switches?: string[];    // ["edit"] from "@cmd/edit ..."
+  };
+
+  // Messaging
+  send(message: string, target?: string, options?: Record&lt;string,unknown&gt;): void;
+  broadcast(message: string, options?: Record&lt;string,unknown&gt;): void;
+
+  // Navigation / execution
+  teleport(target: string, destination: string): void;
+  execute(command: string): void;         // as actor, full pipeline
+  force(command: string): void;           // as actor, bypasses some checks
+  forceAs(targetId: string, command: string): Promise&lt;void&gt;;  // as another object
+
+  // Permissions
+  canEdit(actor: IDBObj, target: IDBObj): Promise&lt;boolean&gt;;
+  checkLock(target: string | IDBObj, lock: string): Promise&lt;boolean&gt;;
+  setFlags(target: string | IDBObj, flags: string): Promise&lt;void&gt;;
+  trigger(target: string, attr: string, args?: string[]): Promise&lt;void&gt;;
+  eval(targetId: string, attr: string, args?: string[]): Promise&lt;string&gt;;
+
+  // Namespaces (all methods async)
+  db:     IUrsamuDB;
+  util:   IUrsamuUtil;
+  auth:   IUrsamuAuth;
+  sys:    IUrsamuSys;
+  chan:   IUrsamuChan;
+  bb:     IUrsamuBB;
+  text:   IUrsamuText;
+  attr:   IUrsamuAttr;
+  events: IUrsamuEvents;
+  mail:   IUrsamuMail;   // sandbox scripts only (not in native addCmd)
+  ui:     IUrsamuUI;     // web client only
+}
+</code></pre>
+<hr>
+<h2>u.db — Database</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Search — returns IDBObj[]
+await u.db.search({ flags: /player/i })           // by flag regex
+await u.db.search({ flags: /connected/i })         // connected players
+await u.db.search({ location: u.here.id })         // objects in room
+await u.db.search({ location: u.here.id, flags: /player/i })
+await u.db.search({ "data.name": /alice/i })       // by name (case-insensitive)
+await u.db.search({ $or: [{ "data.name": /a/i }, { "data.alias": /a/i }] })
+await u.db.search("partial name")                  // string search
+
+// Create — returns IDBObj
+const obj = await u.db.create({
+  flags: new Set(["thing"]),
+  location: u.me.id,          // in actor's inventory
+  state: { name: "Sword", damage: 5 },
+  contents: [],
+});
+
+// Modify — op must be "$set", "$unset", or "$inc"
+await u.db.modify(u.me.id, "$set", { "data.gold": 100 });           // one field
+await u.db.modify(u.me.id, "$set", { data: { ...u.me.state, gold: 100 } }); // full state
+await u.db.modify(u.me.id, "$inc", { "data.score": 10 });           // increment
+await u.db.modify(u.me.id, "$unset", { "data.tempFlag": "" });      // remove field
+
+// Destroy
+await u.db.destroy(obj.id);
+</code></pre>
+<blockquote>
+<p><strong>IMPORTANT</strong>: <code>u.db.modify(id, op, data)</code> — <code>op</code> must be <code>"$set"</code>, <code>"$unset"</code>,<br>
+or <code>"$inc"</code>. Passing <code>"name"</code>, <code>"state"</code>, or any other string does nothing.</p>
+</blockquote>
+<hr>
+<h2>u.util — Utilities</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Target resolution (searches inventory → room → global if true)
+const obj = await u.util.target(u.me, "sword");       // by name
+const obj = await u.util.target(u.me, "#42");          // by ID
+const obj = await u.util.target(u.me, "alice", true);  // global search
+if (!obj) { u.send("Not found."); return; }
+
+// Display name (applies moniker if set)
+u.util.displayName(u.me, u.me)        // actor's own display name
+u.util.displayName(target, u.me)      // target's display name as seen by actor
+
+// Strip MUSH codes / ANSI (use before storing or measuring)
+u.util.stripSubs("%ch%crDanger!%cn")  // → "Danger!"
+
+// Text alignment (all honor MUSH color codes as zero-width)
+u.util.ljust("text", 20)              // "text                "
+u.util.rjust("100",  20)              // "                 100"
+u.util.center("TITLE", 40, "-")       // "-------------------TITLE------------------"
+u.util.center("TITLE", 40)            // "                 TITLE                  "
+
+// Block-style decorators (78-col default; %ch/%cn applied automatically)
+// Override via config game.layout.header / .divider / .footer (mushcode)
+u.util.header("Title")                // default or game.layout.header template
+u.util.divider("Section")             // default or game.layout.divider template
+u.util.footer("")                     // default or game.layout.footer template
+
+// Printf formatting
+u.util.sprintf("%-10s %5d", "Alice", 1200)   // "Alice       1200"
+u.util.sprintf("%05d", 42)                   // "00042"
+u.util.sprintf("%.2f%%", 98.6)              // "98.60%"
+
+// Column template
+u.util.template(
+  "[NNN] [TTTTTTTTTTTTTTTTTTTT]",
+  { N: { value: "42", align: "right" }, T: { value: "Title", align: "left" } }
+)  // → "[ 42] [Title               ]"
+
+// Map data (optional, may be undefined)
+u.util.getMapData?.(targetId, radius)
+u.util.parseDesc?.(desc, actor, target)  // async, optional
+</code></pre>
+<hr>
+<h2>u.auth — Authentication</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const ok = await u.auth.verify(name, password);     // boolean
+await u.auth.login(playerId);                         // connect player
+const hash = await u.auth.hash("plaintext");          // bcrypt hash
+await u.auth.setPassword(playerId, "newpassword");    // change password
+</code></pre>
+<hr>
+<h2>u.sys — Server Control</h2>
+<p>Admin/wizard-only. The SDK does NOT enforce privilege — scripts must check flags.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.sys.setConfig("game.masterRoom", "42");   // runtime config change
+await u.sys.disconnect(socketId);                   // kick a socket
+const ms = await u.sys.uptime();                    // uptime in milliseconds
+await u.sys.reboot();                               // exit 75 → daemon restarts
+await u.sys.shutdown();                             // exit 0 → clean stop
+await u.sys.update();                               // git pull origin/main + reboot
+await u.sys.update("develop");                      // pull specific branch
+
+// Game time (in-game calendar)
+const t: IGameTime = await u.sys.gameTime();        // { year, month, day, hour, minute }
+await u.sys.setGameTime({ year: 1340, month: 3, day: 15, hour: 8, minute: 0 });
+
+// IGameTime fields: year, month (1-12), day (1-28), hour (0-23), minute (0-59)
+</code></pre>
+<hr>
+<h2>u.chan — Channels</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.chan.join("public", "pub");                  // join by name, set alias
+await u.chan.leave("pub");                           // leave by alias
+const channels = await u.chan.list();               // all channel memberships
+
+// Admin only:
+await u.chan.create("events", {
+  header: "%ch[EVENTS]%cn",
+  lock: "player+",
+  hidden: false
+});
+await u.chan.destroy("events");
+await u.chan.set("public", {
+  header: "%ch[PUB]%cn",
+  masking: true,        // hide speaker names
+  logHistory: true,
+  historyLimit: 100,
+});
+
+// Get recent history (default 20 messages)
+const history = await u.chan.history("public");          // last 20
+const history = await u.chan.history("public", 50);      // last 50
+// → [{ id, playerName, message, timestamp }, ...]
+</code></pre>
+<hr>
+<h2>u.bb — Bulletin Boards</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Read
+const boards = await u.bb.listBoards();
+// → [{ id, name, description?, order, postCount, newCount }, ...]
+
+const posts = await u.bb.listPosts(boardId);
+// → [{ id, num, subject, authorName, date, edited? }, ...]
+
+const post = await u.bb.readPost(boardId, postNum);
+// → { id, subject, body, authorName, date, edited? } | null
+
+// Unread counts
+const n = await u.bb.newPostCount(boardId);
+const total = await u.bb.totalNewCount();
+await u.bb.markRead(boardId);
+
+// Write (player)
+await u.bb.post(boardId, "Subject", "Body text.");
+await u.bb.editPost(boardId, postNum, "Updated body.");
+await u.bb.deletePost(boardId, postNum);
+
+// Admin
+await u.bb.createBoard("General", { description: "General chat", order: 1 });
+await u.bb.destroyBoard(boardId);
+</code></pre>
+<hr>
+<h2>u.text — Named Text Blobs</h2>
+<p>Used for MOTD, help pages, templates.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const motd = await u.text.read("motd");           // → string (empty if not set)
+await u.text.set("motd", "Welcome to the game!");
+await u.text.set("motd", "");                     // clear
+</code></pre>
+<hr>
+<h2>u.attr — Object Attributes</h2>
+<p>Reads soft-coded <code>&amp;ATTR</code> values stored on objects.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const val: string | null = await u.attr.get(objectId, "SHORT-DESC");
+const val = await u.attr.get(u.me.id, "FINGER-INFO");
+// Attribute names are case-insensitive. Returns null if not set.
+</code></pre>
+<hr>
+<h2>u.mail — Player Mail (sandbox scripts only)</h2>
+<blockquote>
+<p><strong>Note:</strong> <code>u.mail</code> is only available in sandbox scripts (system/scripts/).<br>
+Native <code>addCmd</code> handlers should import <code>mail</code> from the database directly.</p>
+</blockquote>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Send
+await u.mail.send({
+  from: `#${u.me.id}`,          // dbref format: "#42"
+  to: [`#${recipientId}`],       // array of dbrefs
+  cc: [`#${ccId}`],              // optional
+  subject: "Meeting tonight",
+  message: "At 8pm in the hall.",
+  read: false,
+  date: Date.now(),
+});
+
+// Read inbox
+const inbox = await u.mail.read({ to: { $in: [`#${u.me.id}`] } });
+// → IMail[] — sorted manually by date if needed
+
+// Delete
+await u.mail.delete(messageId);
+
+// Mark read / modify
+await u.mail.modify({ id: messageId }, "$set", { read: true });
+
+// IMail shape:
+// { id?: string, from: string, to: string[], cc?: string[],
+//   bcc?: string[], subject: string, message: string,
+//   read: boolean, date: number }
+</code></pre>
+<hr>
+<h2>u.events — Server-Wide Pub/Sub</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Emit
+await u.events.emit("player.levelup", { id: u.me.id, level: 5 });
+
+// Subscribe a stored &amp;ATTR handler
+const subId = await u.events.on("player.levelup", "LEVELUP_HANDLER");
+// The attribute value is a script that receives event data
+</code></pre>
+<hr>
+<h2>u.ui — Web Client UI (web client only)</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Send structured layout to the web client
+u.ui.layout({
+  components: [
+    { type: "header", title: "Character Sheet" },
+    { type: "table", content: [["Name", u.me.name]] },
+  ],
+  meta: { command: "score" }
+});
+
+// Render a template string
+const html = u.ui.render("&lt;b&gt;{{name}}&lt;/b&gt;", { name: "Alice" });
+
+// Build a panel
+u.ui.panel({ type: "list", title: "Who's Online", content: players });
+</code></pre>
+<hr>
+<h2>u.trigger / u.eval</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Fire a stored &amp;ATTR as a script (fire-and-forget)
+await u.trigger(objectId, "ONENTER");
+await u.trigger(objectId, "USE", ["open"]);
+await u.trigger(u.me.id, "ACONNECT");
+
+// Evaluate an attribute and return its output as a string
+const result = await u.eval("#42", "FORMULA", ["arg1", "arg2"]);
+</code></pre>
+<hr>
+<h2>u.forceAs</h2>
+<p>Execute a command as another object (requires wizard/admin).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.forceAs(npcId, "say Welcome, traveler!");
+await u.forceAs(objectId, "look");
+</code></pre>
+<hr>
+<h2>ICmd — Command Registration</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface ICmd {
+  name:      string;                              // unique label
+  pattern:   string | RegExp;                     // matched against raw input
+  lock?:     string;                              // lock expression
+  exec:      (u: IUrsamuSDK) =&gt; void | Promise&lt;void&gt;;
+  help?:     string;                              // shown in `help &lt;name&gt;`
+  hidden?:   boolean;                             // hide from listings
+  category?: string;                              // group in help listings
+}
+
+addCmd({
+  name: "+greet",
+  pattern: /^\+greet\s+(.*)/i,
+  lock: "connected",
+  exec: async (u) =&gt; {
+    const target = await u.util.target(u.me, u.cmd.args[0]);
+    if (!target) { u.send("Who?"); return; }
+    const myName = u.util.displayName(u.me, u.me);
+    u.send(`You wave to ${u.util.displayName(target, u.me)}.`);
+    u.send(`${myName} waves to you.`, target.id);
+    u.here.broadcast(`${myName} waves to ${u.util.displayName(target, u.me)}.`);
+  },
+});
+</code></pre>
+<h3>Pattern conventions</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// No args:        /^inventory$/i
+// One arg:        /^look\s+(.*)/i          → args[0]
+// Switch + arg:   /^\+cmd(?:\/(\S+))?\s*(.*)/i  → args[0]=switch, args[1]=rest
+// Two parts:      /^@name\s+(.+)=(.+)/i    → args[0], args[1]
+</code></pre>
+<h3>Lock expressions</h3>
+<table>
+<thead>
+<tr>
+<th>Expression</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>""</code></td>
+<td>No restriction (login screen)</td>
+</tr>
+<tr>
+<td><code>"connected"</code></td>
+<td>Must be logged in</td>
+</tr>
+<tr>
+<td><code>"connected builder+"</code></td>
+<td>Logged in + builder or higher</td>
+</tr>
+<tr>
+<td><code>"connected admin+"</code></td>
+<td>Logged in + admin or higher</td>
+</tr>
+<tr>
+<td><code>"connected wizard"</code></td>
+<td>Logged in + wizard</td>
+</tr>
+<tr>
+<td><code>"#42"</code></td>
+<td>Must be object #42</td>
+</tr>
+<tr>
+<td><code>"player+"</code></td>
+<td>Has player flag or higher</td>
+</tr>
+<tr>
+<td><code>"!dark"</code></td>
+<td>Must NOT have dark flag</td>
+</tr>
+<tr>
+<td><code>"wizard|admin"</code></td>
+<td>wizard OR admin</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>IPlugin — Plugin Lifecycle</h2>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">interface IPluginDependency {
+  name:    string;   // must match another plugin's IPlugin.name exactly
+  version: string;   // semver range, e.g. "^1.0.0", "&gt;=2.1.0"
+}
+
+interface IPlugin {
+  name:          string;
+  version:       string;
+  description?:  string;
+  dependencies?: IPluginDependency[];  // see Plugin Coupling Patterns below
+  init?:         () =&gt; boolean | Promise&lt;boolean&gt;;  // return false to abort
+  remove?:       () =&gt; void | Promise&lt;void&gt;;
+}
+
+// index.ts
+import "./commands.ts";     // register addCmd at module-load time
+import type { IPlugin } from "jsr:@ursamu/mush";
+
+export const plugin: IPlugin = {
+  name: "my-plugin",
+  version: "1.0.0",
+  init: async () =&gt; {
+    // seed data, connect external services, etc.
+    return true;
+  },
+  remove: async () =&gt; {
+    // cleanup
+  },
+};
+</code></pre>
+<h2>Plugin is auto-discovered when placed in <code>src/plugins/&lt;name&gt;/index.ts</code>.</h2>
+<h2>Exported Functions</h2>
+<h3><code>addCmd(...cmds: ICmd[])</code></h3>
+<p>Registers commands. Call at module level in <code>commands.ts</code>, not inside <code>init()</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "jsr:@ursamu/mush";
+addCmd({ name: "+foo", pattern: /^\+foo/i, exec: (u) =&gt; u.send("foo") });
+</code></pre>
+<h3><code>registerPluginRoute(prefix, handler)</code></h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerPluginRoute } from "jsr:@ursamu/mush";
+registerPluginRoute("/api/v1/myplugin", async (req, userId) =&gt; {
+  return Response.json({ ok: true });
+});
+// handler: (req: Request, userId: string | null) =&gt; Promise&lt;Response&gt;
+</code></pre>
+<h3><code>DBO&lt;T&gt;</code> — Plugin database collections</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { DBO } from "jsr:@ursamu/mush";
+
+interface INote { id: string; playerId: string; text: string; date: number; }
+const notes = new DBO&lt;INote&gt;("myplugin.notes");
+
+await notes.create({ id: crypto.randomUUID(), playerId: u.me.id, text: "hello", date: Date.now() });
+const all = await notes.find({ playerId: u.me.id });
+const one = await notes.findOne({ id: noteId });
+await notes.update({ id: noteId }, { text: "updated" });
+await notes.delete({ id: noteId });
+const all = await notes.all();
+</code></pre>
+<h3><code>dbojs</code> — Game objects</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { dbojs } from "jsr:@ursamu/mush";
+
+const players = await dbojs.queryAll((o) =&gt; o.flags.has("player"));
+const room    = await dbojs.queryOne((o) =&gt; o.id === "1");
+</code></pre>
+<h3><code>createObj(template)</code> — Outside command context</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { createObj } from "jsr:@ursamu/mush";
+const room = await createObj({
+  name: "The Void", flags: new Set(["room"]),
+  state: { desc: "Empty." }, contents: [],
+});
+</code></pre>
+<h3><code>mu()</code> — Start the server</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { mu } from "jsr:@ursamu/mush";
+await mu();
+</code></pre>
+<hr>
+<h2>GameHooks — Engine Event Bus</h2>
+<p><code>GameHookMap</code> is an <strong>interface</strong> — plugins can extend it via TypeScript<br>
+declaration merging to add their own typed events without modifying the engine:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In your plugin's augmentation file:
+import type { IJob } from "./types.ts";
+declare module "../../../services/Hooks/GameHooks.ts" {
+  interface GameHookMap {
+    "job:created": (job: IJob) =&gt; void | Promise&lt;void&gt;;
+  }
+}
+</code></pre>
+<p>Once imported, all <code>gameHooks.on/off/emit</code> calls become fully typed for the<br>
+new event across the entire codebase.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+
+gameHooks.on("player:login", ({ actorId, actorName }) =&gt; { /* ... */ });
+gameHooks.off("player:login", handler);
+await gameHooks.emit("player:login", payload);
+</code></pre>
+<h3>Built-in events</h3>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Payload fields</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>player:say</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>roomId</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>player:pose</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>roomId</code>, <code>content</code>, <code>isSemipose</code></td>
+</tr>
+<tr>
+<td><code>player:page</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>targetId</code>, <code>targetName</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>player:move</code></td>
+<td><code>actorId</code>, <code>actorName</code>, <code>fromRoomId</code>, <code>toRoomId</code>, <code>fromRoomName</code>, <code>toRoomName</code>, <code>exitName</code></td>
+</tr>
+<tr>
+<td><code>player:login</code></td>
+<td><code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>player:logout</code></td>
+<td><code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>channel:message</code></td>
+<td><code>channelName</code>, <code>senderId</code>, <code>senderName</code>, <code>message</code></td>
+</tr>
+<tr>
+<td><code>scene:created</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>sceneType</code></td>
+</tr>
+<tr>
+<td><code>scene:pose</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>msg</code>, <code>type</code></td>
+</tr>
+<tr>
+<td><code>scene:set</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>roomId</code>, <code>actorId</code>, <code>actorName</code>, <code>description</code></td>
+</tr>
+<tr>
+<td><code>scene:title</code></td>
+<td><code>sceneId</code>, <code>oldName</code>, <code>newName</code>, <code>actorId</code>, <code>actorName</code></td>
+</tr>
+<tr>
+<td><code>scene:clear</code></td>
+<td><code>sceneId</code>, <code>sceneName</code>, <code>actorId</code>, <code>actorName</code>, <code>status</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Script System</h2>
+<p>Scripts live in <code>system/scripts/</code>. File name = command name.</p>
+<h3>ESM style (recommended for complex scripts)</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// system/scripts/mycommand.ts
+export default async (u: IUrsamuSDK) =&gt; {
+  // full access to u.*
+};
+
+export const aliases = ["myalias", "mc"];  // optional extra trigger names
+</code></pre>
+<h3>Legacy block style (simple scripts, no export)</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// system/scripts/gold.ts  (no export = block mode)
+const gold = (u.me.state.gold as number) || 0;
+u.send(`You have ${gold} gold.`);
+</code></pre>
+<h3>ESM import restrictions in scripts</h3>
+<p>Workers support standard ESM imports BUT:</p>
+<ul>
+<li>JSR sub-path imports (<code>jsr:@std/fmt/printf</code>) do NOT work — use u.util.sprintf instead</li>
+<li>Cannot import from <code>jsr:@ursamu/mush</code> inside scripts — use the <code>u</code> global</li>
+</ul>
+<hr>
+<h2>MUSH Color Codes</h2>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Effect</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>%ch</code></td>
+<td>Bold / bright</td>
+</tr>
+<tr>
+<td><code>%cn</code></td>
+<td>Reset to normal</td>
+</tr>
+<tr>
+<td><code>%cr</code></td>
+<td>Red</td>
+</tr>
+<tr>
+<td><code>%cg</code></td>
+<td>Green</td>
+</tr>
+<tr>
+<td><code>%cb</code></td>
+<td>Blue</td>
+</tr>
+<tr>
+<td><code>%cy</code></td>
+<td>Yellow (actually cyan in some terminals)</td>
+</tr>
+<tr>
+<td><code>%cw</code></td>
+<td>White</td>
+</tr>
+<tr>
+<td><code>%cc</code></td>
+<td>Cyan</td>
+</tr>
+<tr>
+<td><code>%cm</code></td>
+<td>Magenta</td>
+</tr>
+<tr>
+<td><code>%cx</code></td>
+<td>Dark gray</td>
+</tr>
+<tr>
+<td><code>%n</code></td>
+<td>Actor’s name</td>
+</tr>
+<tr>
+<td><code>%r</code> / <code>%R</code></td>
+<td>Newline</td>
+</tr>
+<tr>
+<td><code>%t</code></td>
+<td>Tab</td>
+</tr>
+<tr>
+<td><code>%b</code></td>
+<td>Space</td>
+</tr>
+</tbody>
+</table>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">u.send("%ch%cyWelcome!%cn");
+u.send(`%ch%cr[ALERT]%cn Server restarting.`);
+u.send(u.util.center("%ch=== NEWS ===%cn", 78, "="));
+</code></pre>
+<h2>Strip all codes: <code>u.util.stripSubs(str)</code> — use before storing or measuring length.</h2>
+<h2>Project Layout</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">src/
+  @types/          Type definitions (IDBObj, ICmd, IPlugin, etc.)
+  commands/        Native addCmd registrations (admin, mail, help, etc.)
+  plugins/         Plugin directory — each sub-folder is a plugin
+  routes/          HTTP route handlers (scenes, mail, wiki, etc.)
+  services/        Core services (Database, Sandbox, GameClock, Hooks, etc.)
+  utils/           Shared utilities (flags, target, locks, etc.)
+system/
+  scripts/         Auto-loaded scripts (one per command: look.ts, say.ts, etc.)
+  help/            In-game help text files
+config/            Game configuration (config.json / config.toml)
+docs/              Documentation site (Lume static site generator)
+tests/             Test suite (Deno test)
+</code></pre>
+<hr>
+<h2>Common Patterns</h2>
+<h3>Permission guard (admin/wizard)</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const isAdmin = u.me.flags.has("admin") ||
+                u.me.flags.has("wizard") ||
+                u.me.flags.has("superuser");
+if (!isAdmin) { u.send("Permission denied."); return; }
+</code></pre>
+<h3>Edit permission check</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">if (!(await u.canEdit(u.me, target))) {
+  u.send("Permission denied.");
+  return;
+}
+</code></pre>
+<h3>Standard switch-based command</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">addCmd({
+  name: "+cmd",
+  pattern: /^\+cmd(?:\/(\S+))?\s*(.*)/i,
+  lock: "connected",
+  exec: async (u) =&gt; {
+    const sw  = (u.cmd.args[0] || "").toLowerCase().trim();
+    const arg = (u.cmd.args[1] || "").trim();
+    if (!sw || sw === "list") { /* default */ return; }
+    if (sw === "view")  { /* ... */ return; }
+    if (sw === "create") { /* ... */ return; }
+    u.send(`Unknown switch "/${sw}".`);
+  },
+});
+</code></pre>
+<h3>Read and write a state field</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// READ
+const gold = (u.me.state.gold as number) || 0;
+
+// WRITE (spread to preserve existing fields)
+await u.db.modify(u.me.id, "$set", { "data.gold": gold + 10 });
+
+// Or write the entire state object (safe for small objects):
+await u.db.modify(u.me.id, "$set", { data: { ...u.me.state, gold: gold + 10 } });
+</code></pre>
+<h3>Increment a counter</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await u.db.modify(u.me.id, "$inc", { "data.deaths": 1 });
+</code></pre>
+<h3>Multi-column output table</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">const lines: string[] = [];
+lines.push(u.util.center("%ch=== WHO ===%cn", 78, "="));
+for (const p of online) {
+  lines.push(
+    u.util.ljust(u.util.displayName(p, u.me), 25) +
+    u.util.rjust(`${idle}m`, 6)
+  );
+}
+lines.push("=".repeat(78));
+u.send(lines.join("\r\n"));
+</code></pre>
+<h3>Register a plugin REST route</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">registerPluginRoute("/api/v1/myplugin", async (req, userId) =&gt; {
+  if (!userId) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (req.method === "GET") {
+    return Response.json({ data: await notes.find({ playerId: userId }) });
+  }
+  return Response.json({ error: "Not found" }, { status: 404 });
+});
+</code></pre>
+<h3>Listen for a game hook in a plugin</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+import type { SessionEvent } from "jsr:@ursamu/mush";
+
+const onLogin = ({ actorId, actorName }: SessionEvent) =&gt; {
+  console.log(`[myplugin] ${actorName} connected`);
+};
+
+export const plugin: IPlugin = {
+  name: "myplugin", version: "1.0.0",
+  init: () =&gt; { gameHooks.on("player:login", onLogin); return true; },
+  remove: () =&gt; { gameHooks.off("player:login", onLogin); },
+};
+</code></pre>
+<hr>
+<h2>REST API — Core Endpoints</h2>
+<p>Authentication: pass <code>Authorization: Bearer &lt;jwt&gt;</code> header.</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Path</th>
+<th>Auth</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/login</code></td>
+<td>No</td>
+<td>Login — returns JWT</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/who</code></td>
+<td>Yes</td>
+<td>Online players list</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/players/:id</code></td>
+<td>Yes</td>
+<td>Player info</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Yes</td>
+<td>Scene list</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes</code></td>
+<td>Yes</td>
+<td>Open a new scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Yes</td>
+<td>Scene detail</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/scenes/:id</code></td>
+<td>Yes</td>
+<td>Update scene</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/scenes/:id/pose</code></td>
+<td>Yes</td>
+<td>Post to scene</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/scenes/:id/export</code></td>
+<td>Yes</td>
+<td>Export scene (<code>?format=markdown|json</code>)</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/mail</code></td>
+<td>Yes</td>
+<td>Inbox list</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/mail</code></td>
+<td>Yes</td>
+<td>Send mail</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/mail/:id</code></td>
+<td>Yes</td>
+<td>Read message</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/mail/:id</code></td>
+<td>Yes</td>
+<td>Delete message</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Yes</td>
+<td>List/search wiki</td>
+</tr>
+<tr>
+<td><code>GET</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Yes</td>
+<td>Read page</td>
+</tr>
+<tr>
+<td><code>POST</code></td>
+<td><code>/api/v1/wiki</code></td>
+<td>Staff</td>
+<td>Create page</td>
+</tr>
+<tr>
+<td><code>PATCH</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Staff</td>
+<td>Update page</td>
+</tr>
+<tr>
+<td><code>DELETE</code></td>
+<td><code>/api/v1/wiki/:path</code></td>
+<td>Staff</td>
+<td>Delete page</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<hr>
+<h2>Plugin Coupling Patterns</h2>
+<h3>Rule: never use <code>@ursamu/ursamu/*</code> sub-paths inside <code>src/plugins/</code></h3>
+<p>When running the engine directly, Deno resolves <code>@ursamu/ursamu</code> from the<br>
+local <code>deno.json</code> — not from JSR. A sub-path export that is absent from the<br>
+local <code>deno.json</code> will halt startup even if the published JSR version has it.</p>
+<table>
+<thead>
+<tr>
+<th>Context</th>
+<th>Correct import</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Plugin importing another <strong>bundled</strong> plugin</td>
+<td>Relative: <code>../../jobs/mod.ts</code></td>
+</tr>
+<tr>
+<td>External plugin (separate repo) importing engine types</td>
+<td>Sub-path: <code>@ursamu/ursamu/jobs</code></td>
+</tr>
+</tbody>
+</table>
+<h3>Two strategies for plugin-to-plugin communication</h3>
+<p><strong>Tight coupling — use <code>dependencies</code></strong></p>
+<p>When plugin B genuinely cannot function without plugin A’s API (types, DB<br>
+access, configuration):</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// discord/src/index.ts
+export const plugin: IPlugin = {
+  name: "discord",
+  version: "1.1.0",
+  dependencies: [{ name: "chargen", version: "&gt;=1.0.0" }],
+  // chargen is guaranteed to be init()'d before discord
+};
+</code></pre>
+<p>Startup behavior:</p>
+<ul>
+<li>Dep missing or version out of range → <strong>throws, server halts</strong></li>
+<li>Dep’s <code>init()</code> returned false → dependent is cascade-skipped, server continues</li>
+<li>Circular dependency → <strong>throws, server halts</strong> (fix: use <code>gameHooks</code> instead)</li>
+</ul>
+<p><strong>Loose coupling — use <code>gameHooks</code> declaration merging</strong></p>
+<p>When plugin B only needs to <em>react</em> to plugin A’s lifecycle events (no types,<br>
+no direct API calls):</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In plugin A (jobs) — game-hooks-augment.ts:
+declare module "../../../services/Hooks/GameHooks.ts" {
+  interface GameHookMap {
+    "job:created": (job: IJob) =&gt; void | Promise&lt;void&gt;;
+  }
+}
+
+// In plugin A's hooks.ts — bridge emit to gameHooks:
+await gameHooks.emit("job:created", job);   // fires AFTER jobHooks subscribers
+
+// In plugin B (discord) — no jobs import needed:
+import { gameHooks } from "@ursamu/ursamu";
+gameHooks.on("job:created", async (job) =&gt; { /* post to webhook */ });
+</code></pre>
+<p>Loose coupling means:</p>
+<ul>
+<li>Plugin B has no <code>dependencies</code> entry for plugin A</li>
+<li>Plugin B works whether or not plugin A is installed</li>
+<li>No import resolution errors regardless of JSR publish state</li>
+</ul>
+<h3>Case study: discord → jobs import error</h3>
+<p><strong>Symptom</strong> (<code>deno task start</code>):</p>
+<pre class="language-none" tabindex="0"><code class="language-none">Error loading plugin from .../discord/index.ts:
+  TypeError: Unknown export './jobs' for '@ursamu/ursamu'.
+</code></pre>
+<p><strong>Root cause</strong>: <code>discord/src/job-hooks.ts</code> imported <code>jobHooks</code> from<br>
+<code>@ursamu/ursamu/jobs</code>. When running the engine directly, <code>@ursamu/ursamu</code><br>
+resolves to the local <code>deno.json</code> whose exports did not include <code>./jobs</code>.</p>
+<p><strong>Wrong fix</strong>: Add <code>"./jobs": "..."</code> to <code>deno.json</code> exports and leave the<br>
+cross-plugin import as-is. This silences the error locally but doesn’t address<br>
+the architectural problem.</p>
+<p><strong>Right fix (applied)</strong>:</p>
+<ol>
+<li><code>GameHookMap</code> changed from <code>type</code> to <code>interface</code> — enables declaration merging.</li>
+<li>Jobs plugin added <code>game-hooks-augment.ts</code> extending <code>GameHookMap</code> with<br>
+<code>job:created</code>, <code>job:commented</code>, etc.</li>
+<li>Jobs <code>jobHooks.emit()</code> now also bridges to <code>gameHooks.emit()</code>.</li>
+<li>Discord <code>job-hooks.ts</code> uses <code>gameHooks.on("job:created", ...)</code> —<br>
+no import from the jobs plugin at all.</li>
+</ol>
+<h2>Result: discord no longer declares a <code>jobs</code> dependency. It reacts to job<br>
+events whether or not it knows jobs is installed.</h2>
+<p><em>Generated from <code>src/@types/UrsamuSDK.ts</code>, <code>src/services/Sandbox/worker.ts</code>, and source review. Last updated: 2026-05-15 (v2.6.0).</em></p>
+</body></html>

--- a/docs/_site/market-research-2026-04/index.html
+++ b/docs/_site/market-research-2026-04/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html><head><meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/market-research-2026-04/">
+<meta name="twitter:card" content="summary">
+</head><body><h1>UrsaMU Market Research — April 2026</h1>
+<h2>Market Size</h2>
+<ul>
+<li>~10,000 active players, ~722 games tracked on Mudstats</li>
+<li>Small, passionate, aging demographic — not a growth market</li>
+<li>Opportunity is consolidation: be the obvious modern choice so new games start on UrsaMU instead of a 30-year-old C codebase</li>
+</ul>
+<hr>
+<h2>Pain Points (What’s Driving People Away)</h2>
+<ol>
+<li><strong>Setup requires a coder</strong> — spinning up a MUSH still means compiling C, editing flat-file configs, or knowing Deno. Non-technical storytellers can’t self-serve.</li>
+<li><strong>MUSHcode is a development hell</strong> — no editor support, no linter, no version control, no tests. Bugs are found by players, not builders.</li>
+<li><strong>No web client</strong> — every modern player expects to open a URL. Requiring a MUD client (MUSHclient, Mudlet) is a hard filter that kills casual adoption.</li>
+<li><strong>No package ecosystem</strong> — every game reinvents jobs, bboards, chargen from scratch. No <code>npm install bbs</code>.</li>
+<li><strong>No Discord integration</strong> — ~70% of active MUSH communities already live in Discord. The game and the community are siloed.</li>
+</ol>
+<hr>
+<h2>What People Want</h2>
+<ul>
+<li>Zero-install web client (browser play, mobile-friendly)</li>
+<li>Discord bridge (relay game events ↔ Discord channels)</li>
+<li>OAuth login (Google/Discord — no more <code>connect name password</code>)</li>
+<li>Plugin marketplace / one-command installs</li>
+<li>REST API for web dashboards and bots</li>
+<li>Live dev feedback — the one thing classic engines do well that modern ones don’t: type softcode, see output immediately</li>
+</ul>
+<hr>
+<h2>The Gap UrsaMU Hasn’t Closed Yet</h2>
+<p>Classic MUSH’s irreplaceable advantage is the <strong>in-game REPL</strong> — <code>think add(1,2)</code> returns <code>3</code> instantly. Experienced builders live in that loop. UrsaMU has the softcode engine but no interactive eval surface exposed to builders in-game. That’s the one capability keeping veterans from fully migrating.</p>
+<hr>
+<h2>Competitive Landscape</h2>
+<ul>
+<li>JS/TS MUSH engine space is underpopulated</li>
+<li>Ranvier targets combat MUDs, not RP-focused MUSH</li>
+<li>No direct competitor for “modern TypeScript MUSH engine with plugin ecosystem”</li>
+</ul>
+<hr>
+<h2>Game Genres Active in the Community</h2>
+<ul>
+<li>World of Darkness (WoD)</li>
+<li>Sci-fi / Star Trek</li>
+<li>Urban RP</li>
+<li>Tabletop RPG adaptations</li>
+</ul>
+<hr>
+<h2>UrsaMU Status vs. Market Wants</h2>
+<table>
+<thead>
+<tr>
+<th>What they want</th>
+<th>UrsaMU has it?</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>REST API</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Plugin system</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td>Discord hooks</td>
+<td>Yes (gameHooks)</td>
+</tr>
+<tr>
+<td>Softcode engine</td>
+<td>Yes (TinyMUX 2.x)</td>
+</tr>
+<tr>
+<td>Zero-install web client</td>
+<td>No</td>
+</tr>
+<tr>
+<td>In-game eval REPL (<code>think</code>)</td>
+<td>No</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Highest-Leverage Next Steps</h2>
+<ol>
+<li><strong>In-game <code>think</code>/eval command</strong> — lets builders test softcode expressions live without writing files. Closes the biggest psychological barrier for veteran MUSHers.</li>
+<li><strong>Zero-install web client</strong> — removes the MUD client requirement entirely; opens the game to casual players.</li>
+</ol>
+</body></html>

--- a/docs/_site/mush_compatibility/index.html
+++ b/docs/_site/mush_compatibility/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -270,6 +270,9 @@
         <h1>MUSH Compatibility</h1>
 <p>UrsaMU is <strong>not a drop-in replacement</strong> for PennMUSH, TinyMUSH, or MUX2. It is a fresh platform with a different architecture — WebSocket-native, TypeScript, sandboxed scripts instead of MUSHcode.</p>
 <p>If you are migrating from a traditional MUSH or hosting your first server, this page tells you exactly what works today and what is planned.</p>
+<blockquote>
+<p>Updated for v2.6.0.</p>
+</blockquote>
 <hr>
 <h2>What Works Today</h2>
 <table>
@@ -506,8 +509,214 @@
 <td>✅ Working</td>
 <td><code>&amp;ACONNECT</code> / <code>&amp;ADISCONNECT</code> attributes fire on login/logout</td>
 </tr>
+<tr>
+<td>MUX softcode evaluator</td>
+<td>✅ Working</td>
+<td>TinyMUX 2.x compatible — see <a href="#mux-softcode-support">Softcode</a> below</td>
+</tr>
+<tr>
+<td><code>@tag</code> / <code>@ltag</code></td>
+<td>✅ Working</td>
+<td>Global and personal named-object registry (RhostMUSH-style)</td>
+</tr>
+<tr>
+<td><code>@switch</code></td>
+<td>✅ Working</td>
+<td>Eval value as softcode, compare cases, execute matching action</td>
+</tr>
+<tr>
+<td><code>@dolist</code></td>
+<td>✅ Working</td>
+<td>Iterate a softcode list, execute action per item with <code>##</code>/<code>#@</code></td>
+</tr>
+<tr>
+<td><code>@if &lt;expr&gt;=&lt;true&gt;[,&lt;false&gt;]</code></td>
+<td>✅ Working</td>
+<td>Conditional action command</td>
+</tr>
+<tr>
+<td><code>@while &lt;expr&gt;=&lt;action&gt;</code></td>
+<td>✅ Working</td>
+<td>Loop while expression is true (100ms timeout enforced)</td>
+</tr>
+<tr>
+<td><code>@break</code></td>
+<td>✅ Working</td>
+<td>Exit current <code>@dolist</code> or <code>@while</code></td>
+</tr>
+<tr>
+<td><code>@wait &lt;seconds&gt;=&lt;action&gt;</code></td>
+<td>✅ Working</td>
+<td>Delay an action</td>
+</tr>
+<tr>
+<td><code>@function &lt;name&gt;=&lt;obj&gt;/&lt;attr&gt;</code></td>
+<td>✅ Working</td>
+<td>Define a global softcode user function</td>
+</tr>
+<tr>
+<td><code>@cpattr</code> / <code>@mvattr</code></td>
+<td>✅ Working</td>
+<td>Copy / move attributes between objects</td>
+</tr>
+<tr>
+<td><code>@grep &lt;obj&gt;=&lt;pattern&gt;</code></td>
+<td>✅ Working</td>
+<td>Search object attributes by name pattern</td>
+</tr>
+<tr>
+<td><code>@decompile &lt;obj&gt;</code></td>
+<td>✅ Working</td>
+<td>Dump object as copyable <code>@name</code>/<code>&amp;ATTR</code> lines</td>
+</tr>
+<tr>
+<td><code>@ps</code></td>
+<td>✅ Working</td>
+<td>List pending <code>@wait</code> jobs</td>
+</tr>
+<tr>
+<td><code>@drain &lt;obj&gt;</code></td>
+<td>✅ Working</td>
+<td>Cancel all pending <code>@wait</code> jobs on an object</td>
+</tr>
+<tr>
+<td><code>@notify &lt;obj&gt;[/&lt;sem&gt;][=&lt;count&gt;]</code></td>
+<td>✅ Working</td>
+<td>Signal a semaphore</td>
+</tr>
+<tr>
+<td>Zone system (<code>@zone</code>)</td>
+<td>✅ Working</td>
+<td>Assign objects to a zone master for shared <code>$</code>-pattern routing</td>
+</tr>
+<tr>
+<td><code>$pattern</code> attrs</td>
+<td>✅ Working</td>
+<td>Objects respond to player input via <code>$&lt;glob&gt;:&lt;action&gt;</code> attributes; captures map to <code>%0</code>–<code>%9</code></td>
+</tr>
+<tr>
+<td><code>^pattern</code> attrs (MONITOR)</td>
+<td>✅ Working</td>
+<td>MONITOR-flagged objects listen to room speech/poses via <code>^&lt;glob&gt;</code> attributes; captures map to <code>%0</code>–<code>%9</code></td>
+</tr>
 </tbody>
 </table>
+<hr>
+<h2>MUX Softcode Support</h2>
+<p>UrsaMU Phase 1 ships a full TinyMUX 2.x compatible softcode evaluator alongside the TypeScript sandbox. In-game object attributes can be written in MUX softcode; all system scripts remain in TypeScript.</p>
+<h3>How it works</h3>
+<ul>
+<li><strong>TypeScript/JS attributes</strong> (default) — executed in the existing Deno Web Worker sandbox.</li>
+<li><strong>Softcode attributes</strong> — executed in a dedicated softcode Deno Worker with a 100ms wall-clock timeout.</li>
+</ul>
+<p>To mark an attribute as softcode when setting it with <code>&amp;</code>:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&amp;GREET/softcode me=[name(%#)] greets you!
+</code></pre>
+<p>The <code>/softcode</code> flag persists on the attribute and routes all future evaluations through the softcode engine. Omitting the flag uses the TypeScript sandbox as before. Attributes that contain MUX substitution syntax (<code>%N</code>, <code>[func()]</code>) and no TypeScript keywords are also auto-detected as softcode.</p>
+<h3>Supported functions (~250 total)</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Functions</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Math</td>
+<td><code>add</code>, <code>sub</code>, <code>mul</code>, <code>div</code>, <code>mod</code>, <code>abs</code>, <code>floor</code>, <code>ceil</code>, <code>round</code>, <code>power</code>, <code>sqrt</code>, <code>exp</code>, <code>sin</code>, <code>cos</code>, <code>tan</code>, <code>rand</code>, <code>max</code>, <code>min</code>, <code>isnum</code>, <code>isint</code>, <code>eq</code>, <code>gt</code>, <code>lt</code>, <code>gte</code>, <code>lte</code>, <code>band</code>, <code>bor</code>, <code>bxor</code>, <code>shl</code>, <code>shr</code>, <code>dist2d</code>, <code>dist3d</code>, <code>vadd</code>, <code>vsub</code>, <code>vmul</code>, <code>vmag</code>, <code>vunit</code>, <code>vcross</code>, <code>vdot</code>, …</td>
+</tr>
+<tr>
+<td>String</td>
+<td><code>strlen</code>, <code>upcase</code>, <code>lowcase</code>, <code>capstr</code>, <code>trim</code>, <code>squish</code>, <code>left</code>, <code>right</code>, <code>mid</code>, <code>ljust</code>, <code>rjust</code>, <code>center</code>, <code>before</code>, <code>after</code>, <code>index</code>, <code>pos</code>, <code>lpos</code>, <code>edit</code>, <code>reverse</code>, <code>space</code>, <code>repeat</code>, <code>chr</code>, <code>ord</code>, <code>cat</code>, <code>strcat</code>, <code>strmatch</code>, <code>comp</code>, <code>alpha</code>, <code>regex</code>, <code>regmatch</code>, <code>regrab</code>, <code>regraball</code>, <code>wrap</code>, <code>columns</code>, <code>ansi</code>, <code>stripansi</code>, <code>sha1</code>, <code>spellnumber</code>, <code>itemize</code>, …</td>
+</tr>
+<tr>
+<td>List</td>
+<td><code>words</code>, <code>word</code>, <code>first</code>, <code>rest</code>, <code>last</code>, <code>extract</code>, <code>elements</code>, <code>member</code>, <code>lnum</code>, <code>ldelete</code>, <code>insert</code>, <code>replace</code>, <code>remove</code>, <code>revwords</code>, <code>shuffle</code>, <code>splice</code>, <code>grab</code>, <code>graball</code>, <code>match</code>, <code>matchall</code>, <code>pickrand</code>, <code>setunion</code>, <code>setinter</code>, <code>setdiff</code>, <code>sort</code>, <code>sortby</code>, <code>ladd</code>, <code>lmin</code>, <code>lmax</code>, <code>iter</code>, <code>parse</code>, <code>map</code>, <code>filter</code>, <code>filterbool</code>, <code>fold</code>, <code>foreach</code>, <code>munge</code>, <code>step</code>, <code>mix</code>, <code>distribute</code>, <code>merge</code>, <code>table</code>, …</td>
+</tr>
+<tr>
+<td>Logic</td>
+<td><code>t</code>, <code>not</code>, <code>and</code>, <code>or</code>, <code>xor</code>, <code>cand</code>, <code>cor</code>, <code>andflags</code>, <code>orflags</code>, <code>if</code>, <code>ifelse</code>, <code>switch</code>, <code>case</code>, <code>null</code>, <code>lit</code>, <code>@@</code>, …</td>
+</tr>
+<tr>
+<td>Object</td>
+<td><code>name</code>, <code>fullname</code>, <code>dbref</code>, <code>num</code>, <code>type</code>, <code>hastype</code>, <code>hasflag</code>, <code>flags</code>, <code>lflags</code>, <code>setflag</code>, <code>unflag</code>, <code>loc</code>, <code>where</code>, <code>room</code>, <code>home</code>, <code>contents</code>, <code>lcon</code>, <code>lexits</code>, <code>lwho</code>, <code>lplayers</code>, <code>match</code>, <code>pmatch</code>, <code>nearby</code>, <code>u</code>, <code>ulocal</code>, <code>get</code>, <code>default</code>, <code>xget</code>, <code>attr</code>, <code>lattr</code>, <code>hasattr</code>, <code>v</code>, <code>conn</code>, <code>connlast</code>, <code>connnum</code>, <code>idle</code>, <code>doing</code>, <code>host</code>, <code>ip</code>, <code>money</code>, <code>mudname</code>, <code>version</code>, <code>conntotal</code>, …</td>
+</tr>
+<tr>
+<td>Register</td>
+<td><code>setq</code>, <code>setr</code>, <code>r</code>, <code>localize</code></td>
+</tr>
+<tr>
+<td>Output</td>
+<td><code>pemit</code>, <code>remit</code>, <code>oemit</code>, <code>cemit</code>, <code>emit</code>, <code>npemit</code>, <code>trigger</code></td>
+</tr>
+<tr>
+<td>Tags</td>
+<td><code>tag</code>, <code>istag</code>, <code>listtags</code>, <code>tagmatch</code>, <code>ltag</code>, <code>isltag</code>, <code>listltags</code>, <code>ltagmatch</code></td>
+</tr>
+</tbody>
+</table>
+<h3>Substitutions</h3>
+<p>All standard TinyMUX substitutions are supported: <code>%#</code> (enactor dbref), <code>%!</code> (executor dbref), <code>%@</code> (caller), <code>%N</code>/<code>%n</code> (name), <code>%L</code> (location), <code>%s</code>/<code>%S</code>/<code>%o</code>/<code>%O</code>/<code>%p</code>/<code>%P</code>/<code>%a</code> (pronouns), <code>%0</code>–<code>%9</code> (args), <code>%q0</code>–<code>%qz</code> (registers), <code>##</code> / <code>#@</code> (iter variables), <code>%VA</code>–<code>%VZ</code> (object attributes), <code>%r</code> (newline), <code>%t</code> (tab), <code>%b</code> (space), <code>%%</code> (literal <code>%</code>), full ANSI color codes (<code>%ch</code>, <code>%cr</code>, <code>%cg</code>, <code>%cb</code>, <code>%cy</code>, <code>%cw</code>, <code>%cc</code>, <code>%cn</code>, <code>%xN</code> truecolor).</p>
+<h3>TinyMUX compatibility stubs</h3>
+<table>
+<thead>
+<tr>
+<th>Function</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>sql()</code></td>
+<td>Returns <code>#-1 FUNCTION DISABLED</code></td>
+</tr>
+<tr>
+<td><code>rxlevel()</code> / <code>txlevel()</code></td>
+<td>Returns <code>0</code></td>
+</tr>
+<tr>
+<td><code>beep()</code></td>
+<td>Returns <code>""</code></td>
+</tr>
+<tr>
+<td><code>height()</code> / <code>width()</code></td>
+<td>Returns <code>24</code> / <code>78</code></td>
+</tr>
+<tr>
+<td><code>colordepth()</code></td>
+<td>Returns <code>256</code></td>
+</tr>
+<tr>
+<td><code>textfile()</code> / <code>text()</code></td>
+<td>Returns <code>""</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>@tag / @ltag — Named Object Registry</h2>
+<p>UrsaMU ships a RhostMUSH-style named object registry. Instead of remembering dbrefs, you can assign human-readable names to objects.</p>
+<h3>@tag (global, wizard-only)</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@tag citygate=here          Register current room as "citygate"
+@tag vault=#142             Register #142 as "vault"
+@tag                        (no args) list all tags
+@tag/remove citygate        Remove the "citygate" global tag
+</code></pre>
+<p>Global tags are visible to everyone. Only wizards and admins may create or remove them. When a tagged object is destroyed, its tags are automatically removed.</p>
+<h3>@ltag (personal, any player)</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">@ltag home=here             Register current room as your "home"
+@ltag/list                  List all your personal tags
+@ltag/remove home           Remove your personal "home" tag
+</code></pre>
+<p>Personal tags are scoped to your character (max 50). They are visible only in your own softcode evaluations.</p>
+<h3>Softcode usage</h3>
+<pre class="language-none" tabindex="0"><code class="language-none">[tag(citygate)]             → dbref of the citygate room
+[istag(vault)]              → 1 if "vault" global tag exists
+[tagmatch(here,citygate)]   → 1 if here is tagged "citygate"
+[ltag(home)]                → dbref of your personal "home" tag
+[name(#citygate)]           → name of the citygate object (shorthand)
+</code></pre>
+<p>The <code>#tagname</code> shorthand works anywhere an object reference is accepted in softcode (personal tags shadow global ones).</p>
 <hr>
 <h2>What’s Different from Traditional MUSH</h2>
 <table>
@@ -519,16 +728,16 @@
 </thead>
 <tbody>
 <tr>
-<td>MUSHcode (softcode) scripting</td>
-<td>TypeScript/JS in sandboxed Web Workers</td>
+<td>MUSHcode scripting only</td>
+<td>TypeScript/JS sandbox <strong>and</strong> MUX softcode — both supported</td>
 </tr>
 <tr>
 <td>Telnet primary</td>
 <td>WebSocket primary (Telnet sidecar available)</td>
 </tr>
 <tr>
-<td>Attributes on objects run softcode</td>
-<td>Scripts registered as commands or object triggers</td>
+<td>All attributes run softcode</td>
+<td><code>&amp;ATTR/softcode</code> opts in; default is TypeScript sandbox</td>
 </tr>
 <tr>
 <td><code>@tr</code> / <code>@trigger</code></td>
@@ -539,12 +748,40 @@
 <td><code>@pemit</code> and <code>@remit</code> — both implemented</td>
 </tr>
 <tr>
-<td><code>@switch</code> / <code>@if</code> / MUSHcode functions</td>
-<td>Full JavaScript/TypeScript in scripts</td>
+<td>No named-object registry</td>
+<td><code>@tag</code> / <code>@ltag</code> provide global and personal registries</td>
+</tr>
+<tr>
+<td>Lock ops <code>&amp;</code> / <code>|</code> only</td>
+<td><code>&amp;&amp;</code> / <code>||</code> / <code>!</code> with parens, plus legacy <code>&amp;</code>/<code>|</code> (v2.2.0)</td>
+</tr>
+<tr>
+<td>Hard-coded format attrs</td>
+<td>8-slot format pipeline: register TS handlers or raw softcode templates (v2.3.0+)</td>
 </tr>
 </tbody>
 </table>
-<p>MUSHcode attributes (<code>@va</code>–<code>@vz</code>, inline softcode, <code>&amp;ATTRIBUTE</code>) are <strong>not supported</strong>. UrsaMU scripting uses the <a href="../guides/scripting/">Sandbox SDK</a> instead.</p>
+<h2>Format-Attribute Pipeline</h2>
+<p>Eight engine-known format slots route through both softcode attributes on the<br>
+object and plugin-registered handlers (priority: softcode attr → plugin handler<br>
+→ fallback):</p>
+<p><code>NAMEFORMAT</code>, <code>DESCFORMAT</code>, <code>CONFORMAT</code>, <code>EXITFORMAT</code>, <code>WHOFORMAT</code>,<br>
+<code>WHOROWFORMAT</code>, <code>PSFORMAT</code>, <code>PSROWFORMAT</code>.</p>
+<p>Plugins may also register arbitrary uppercase slot names (e.g. <code>MAILFORMAT</code>,<br>
+<code>BBROWFORMAT</code>) — <code>FormatSlot</code> is an open union as of v2.3.4.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// TS handler
+registerFormatHandler("WHOROWFORMAT", (ctx) =&gt; `${ctx.name} - idle ${ctx.idle}`);
+
+// Softcode template (v2.4.0)
+registerFormatTemplate("WHOFORMAT", "[center(===,78,=)]%r[u(#1/HEADER)]");
+</code></pre>
+<h2>Lock Expressions (v2.2.0+)</h2>
+<p>Locks support <code>&amp;&amp;</code>, <code>||</code>, <code>!</code> with <code>()</code> grouping plus the legacy <code>&amp;</code>/<code>|</code><br>
+operators. Built-in lockfuncs: <code>flag(name)</code>, <code>attr(name[, val])</code>, <code>type(name)</code>,<br>
+<code>is(#id)</code>, <code>holds(#id)</code>, <code>perm(level)</code>. Custom lockfuncs register via<br>
+<code>registerLockFunc(name, fn)</code>.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">lock: "connected &amp;&amp; (flag(wizard) || attr(tribe, glasswalker))"
+</code></pre>
 <hr>
 <h2>Planned Enhancements</h2>
 <table>
@@ -558,10 +795,6 @@
 <tr>
 <td>Terminal/screen settings</td>
 <td>Width detection via Telnet NAWS, persistent pager settings</td>
-</tr>
-<tr>
-<td>MUSHcode inline softcode</td>
-<td>Not planned — use TypeScript scripts instead</td>
 </tr>
 </tbody>
 </table>
@@ -685,11 +918,73 @@
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
         
       
         
@@ -710,9 +1005,9 @@
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/guides/user-guide/" class="page-nav-btn prev">
+          <a href="/ursamu/guides/wiki/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title">User Guide</span>
+            <span class="page-nav-title">Wiki</span>
           </a>
         
 

--- a/docs/_site/plugins/basics/index.html
+++ b/docs/_site/plugins/basics/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -273,7 +273,6 @@
 <code>index.ts</code> exporting a default <code>IPlugin</code> object. No registration, no config<br>
 entry required — just drop the folder in and restart the server.</p>
 <pre class="language-none" tabindex="0"><code class="language-none">src/plugins/
-├── bboards/        ← auto-loaded
 ├── events/         ← auto-loaded
 ├── jobs/           ← auto-loaded
 └── my-plugin/      ← auto-loaded the next time you start
@@ -291,10 +290,9 @@ export interface IPlugin {
   remove?: () =&gt; void   | Promise&lt;void&gt;;    // called when the plugin is unloaded
 }
 </code></pre>
-<p>That is the complete interface. There is no <code>author</code> field, no <code>dependencies</code><br>
+<h2>That is the complete interface. There is no <code>author</code> field, no <code>dependencies</code><br>
 array, no <code>App</code> parameter, and no <code>onInit</code>/<code>onLoad</code>/<code>onUnload</code> lifecycle<br>
-methods. The interface is intentionally minimal.</p>
-<hr>
+methods. The interface is intentionally minimal.</h2>
 <h2>Lifecycle</h2>
 <table>
 <thead>
@@ -327,6 +325,23 @@ methods. The interface is intentionally minimal.</p>
 <code>init()</code>. Import <code>"./commands.ts"</code> from <code>index.ts</code> and the registrations<br>
 happen automatically.</p>
 </blockquote>
+<blockquote>
+<p><strong>Named handler refs.</strong> Any <code>gameHooks.on(event, handler)</code> registered in<br>
+<code>init()</code> must be paired with <code>gameHooks.off(event, handler)</code> in <code>remove()</code><br>
+using the <strong>same named function reference</strong>. Inline arrow functions cannot<br>
+be unsubscribed. See <a href="/ursamu/plugins/hooks/#full-example">hooks.md</a>.</p>
+</blockquote>
+<blockquote>
+<p><strong>DBO namespacing.</strong> Collection names must be prefixed with your plugin<br>
+name to avoid colliding with the core engine or other plugins:<br>
+<code>new DBO&lt;T&gt;("my-plugin.records")</code>. See <a href="/ursamu/plugins/database/">database.md</a>.</p>
+</blockquote>
+<blockquote>
+<p><strong>Stdlib primitives.</strong> Plugins written in TypeScript can import<br>
+<code>Noise</code>, <code>Rng</code>, vector/spatial helpers, interpolation, and physics<br>
+primitives directly from <code>jsr:@ursamu/mush</code> (v2.5.1+). No need to vendor<br>
+<code>simplex-noise</code> or <code>alea</code>.</p>
+</blockquote>
 <hr>
 <h2>A Minimal Plugin</h2>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/hello/index.ts
@@ -349,9 +364,8 @@ const helloPlugin: IPlugin = {
 
 export default helloPlugin;
 </code></pre>
-<p>That is a complete, loadable plugin. Start the server and you will see<br>
-<code>[hello] initialized</code> in the log.</p>
-<hr>
+<h2>That is a complete, loadable plugin. Start the server and you will see<br>
+<code>[hello] initialized</code> in the log.</h2>
 <h2>Standard File Layout</h2>
 <p>Full-featured plugins split their code across four files, plus a manifest:</p>
 <pre class="language-none" tabindex="0"><code class="language-none">src/plugins/my-plugin/
@@ -395,13 +409,20 @@ manifest at the plugin root:</p>
   "ursamu": "&gt;=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "main": "index.ts"
+  "main": "index.ts",
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 </code></pre>
-<p>This is the file <code>ursamu plugin install</code> reads to confirm what it is installing,<br>
-display details, and populate the local registry. See the<br>
-<a href="/ursamu/plugins/#installing-community-plugins">Plugin Manager</a> docs for the full<br>
-install/update/remove workflow.</p>
+<p>Each <code>deps[]</code> entry may include an optional <code>version</code> semver range<br>
+(<code>"^1.2.0"</code>, <code>"&gt;=1.0.0 &lt;2.0.0"</code>). When present, the installer reads the<br>
+dep’s own manifest <code>version</code> and aborts the whole install if it does not<br>
+satisfy the range. Omit <code>version</code> to install the dep without a check<br>
+(backwards compatible). See the<br>
+<a href="/ursamu/plugins/#installing-community-plugins">Plugin Manager</a> and the<br>
+<a href="/ursamu/plugins/#deps-entries"><code>deps[]</code> reference</a> for the full install,<br>
+update, remove, and atomic-rollback semantics.</p>
 
       </article>
 
@@ -490,11 +511,73 @@ install/update/remove workflow.</p>
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
         
       
         
@@ -518,9 +601,9 @@ install/update/remove workflow.</p>
         
 
         
-          <a href="/ursamu/plugins/commands/" class="page-nav-btn next">
+          <a href="/ursamu/plugins/chargen/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Character Generation Plugin</span>
           </a>
         
       </nav>

--- a/docs/_site/plugins/chargen/index.html
+++ b/docs/_site/plugins/chargen/index.html
@@ -1,0 +1,899 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Character Generation Plugin | UrsaMU Documentation</title>
+  <meta name="description" content="How to use and configure the chargen plugin for new player character applications.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/plugins/chargen/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link active">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Character Generation Plugin</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Character Generation Plugin</h1>
+<h2>The <code>chargen</code> plugin provides a simple application workflow for new players to<br>
+submit character backgrounds for staff review before being granted full access.</h2>
+<h2>Overview</h2>
+<p>Players fill in application fields at their own pace, then submit for review.<br>
+Staff review pending applications, approve or reject them, and can leave notes.<br>
+When a character is approved, the player receives a mail notification and their<br>
+account is fully activated.</p>
+<h2>The plugin auto-loads when <code>src/plugins/chargen/</code> exists. No configuration<br>
+is required — just the plugin folder.</h2>
+<h2>Player Workflow</h2>
+<ol>
+<li>Connect to the game as a new, unapproved character</li>
+<li>Run <code>+chargen</code> to see your current application status</li>
+<li>Fill in fields with <code>+chargen/set &lt;field&gt;=&lt;value&gt;</code></li>
+<li>Review your application with <code>+chargen</code></li>
+<li>Submit with <code>+chargen/submit</code></li>
+<li>Wait for staff review — you’ll receive in-game mail when processed</li>
+</ol>
+<h2>While your application is <strong>pending</strong>, you cannot edit fields. If you need<br>
+changes, contact staff and ask them to reopen it.</h2>
+<h2>Player Commands</h2>
+<h3><code>+chargen</code></h3>
+<p>View your current application.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen
+========================================= Character Generation =========================================
+Status: DRAFT
+Player: 42
+-------------------------------------------------------------------------------------------------------
+name: Alice
+concept: A wandering healer from the northern reaches
+background: She grew up in...
+========================================================================================================
+</code></pre>
+<h3><code>+chargen/set &lt;field&gt;=&lt;value&gt;</code></h3>
+<p>Set a field on your application. Field names are case-insensitive and stored<br>
+lowercase. You can set any field name your game requires — there is no enforced<br>
+schema.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/set name=Alice Lightwood
+Set name on your chargen application.
+
+&gt; +chargen/set concept=A wandering healer from the northern reaches
+Set concept on your chargen application.
+
+&gt; +chargen/set background=She grew up in the village of Frostmere...
+Set background on your chargen application.
+</code></pre>
+<p>Limits:</p>
+<ul>
+<li>Field name: max 64 characters</li>
+<li>Field value: max 4,096 characters</li>
+<li>Cannot set fields while application is <strong>pending</strong> or <strong>approved</strong></li>
+</ul>
+<h3><code>+chargen/submit</code></h3>
+<p>Submit your application for staff review.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/submit
+Your character application has been submitted for staff review. You will be notified when it is processed.
+</code></pre>
+<h2>Once submitted, online staff are automatically notified. Your application<br>
+status changes to <strong>pending</strong> and you cannot modify it until staff acts.</h2>
+<h2>Staff Workflow</h2>
+<ol>
+<li>Online staff see a notification when a player submits</li>
+<li>Use <code>+chargen/staff</code> to see all pending applications</li>
+<li>Use <code>+chargen/view &lt;player&gt;</code> to read the application</li>
+<li>Use <code>+chargen/approve</code> or <code>+chargen/reject</code></li>
+<li>Player receives in-game mail with the result</li>
+</ol>
+<hr>
+<h2>Staff Commands</h2>
+<p>All staff commands require the <code>admin</code>, <code>wizard</code>, or <code>superuser</code> flag.</p>
+<h3><code>+chargen/staff</code></h3>
+<p>List all applications with non-draft status (pending, approved, rejected).</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/staff
+============================================================
+  Player         Status     Submitted
+  alice          pending    2026-03-21T14:30:00.000Z
+  bob            rejected   2026-03-20T09:15:00.000Z
+============================================================
+</code></pre>
+<h3><code>+chargen/view &lt;player&gt;</code></h3>
+<p>View a player’s full application including all fields, timestamps, and any<br>
+staff notes.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/view alice
+============================================ Chargen: Alice ============================================
+Status:    PENDING
+Player:    42
+Submitted: 2026-03-21T14:30:00.000Z
+-------------------------------------------------------------------------------------------------------
+name: Alice Lightwood
+concept: A wandering healer from the northern reaches
+background: She grew up in the village of Frostmere...
+========================================================================================================
+</code></pre>
+<h3><code>+chargen/approve &lt;player&gt;[=&lt;note&gt;]</code></h3>
+<p>Approve a player’s application. An optional note is sent to the player in the<br>
+approval mail.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/approve alice
+Approved alice's application.
+
+&gt; +chargen/approve alice=Welcome! Your character has been approved — enjoy the game!
+Approved alice's application.
+</code></pre>
+<p>On approval:</p>
+<ul>
+<li>Application status → <code>approved</code></li>
+<li><code>chargen:approved</code> hook fires</li>
+<li>Player receives in-game mail with approval message</li>
+</ul>
+<h3><code>+chargen/reject &lt;player&gt;=&lt;reason&gt;</code></h3>
+<p>Reject a player’s application with a reason. The reason is sent to the player.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/reject bob=Please expand your background section — it's too brief.
+Rejected bob's application.
+</code></pre>
+<p>On rejection:</p>
+<ul>
+<li>Application status → <code>rejected</code></li>
+<li><code>chargen:rejected</code> hook fires</li>
+<li>Player receives in-game mail with the reason</li>
+<li>Player can update fields and resubmit after staff reopens the application</li>
+</ul>
+<h3><code>+chargen/reopen &lt;player&gt;</code></h3>
+<p>Reopen a rejected (or approved) application so the player can edit and<br>
+resubmit.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/reopen bob
+Reopened bob's chargen application.
+</code></pre>
+<h3><code>+chargen/delete &lt;player&gt;</code></h3>
+<p>Permanently delete a player’s application.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +chargen/delete bob
+Deleted bob's chargen application.
+</code></pre>
+<hr>
+<h2>Application Statuses</h2>
+<pre class="language-none" tabindex="0"><code class="language-none">draft     → pending (player submits)
+pending   → approved (staff approves)
+pending   → rejected (staff rejects)
+rejected  → draft (staff reopens)
+approved  → draft (staff reopens)
+</code></pre>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Player can edit</th>
+<th>Staff action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>draft</code></td>
+<td>Yes</td>
+<td>View, delete</td>
+</tr>
+<tr>
+<td><code>pending</code></td>
+<td>No</td>
+<td>View, approve, reject, delete</td>
+</tr>
+<tr>
+<td><code>approved</code></td>
+<td>No</td>
+<td>Reopen, delete</td>
+</tr>
+<tr>
+<td><code>rejected</code></td>
+<td>No (until reopened)</td>
+<td>Reopen, delete</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>chargenHooks</h2>
+<p>Subscribe to chargen lifecycle events in your plugin.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { chargenHooks } from "../../plugins/chargen/mod.ts";
+
+// Notify staff in a Discord channel when a player submits
+chargenHooks.on("chargen:submitted", (app) =&gt; {
+  const playerId = app.data.playerId;
+  console.log(`[chargen] New application from player ${playerId}`);
+  // send Discord webhook, etc.
+});
+
+// Grant starting room or items on approval
+chargenHooks.on("chargen:approved", async (app) =&gt; {
+  const playerId = app.data.playerId;
+  // e.g. teleport to starting room, give starting items
+});
+
+// Log rejections for audit
+chargenHooks.on("chargen:rejected", (app) =&gt; {
+  console.log(`[chargen] Application rejected: ${app.data.notes}`);
+});
+</code></pre>
+<h3>Event payloads</h3>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Payload fields</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>chargen:submitted</code></td>
+<td>Full application object (<code>data.playerId</code>, <code>data.status</code>, <code>data.fields</code>, <code>data.submittedAt</code>)</td>
+</tr>
+<tr>
+<td><code>chargen:approved</code></td>
+<td>Full application object with <code>data.reviewedBy</code>, <code>data.reviewedAt</code>, <code>data.notes</code></td>
+</tr>
+<tr>
+<td><code>chargen:rejected</code></td>
+<td>Full application object with <code>data.notes</code> (rejection reason)</td>
+</tr>
+<tr>
+<td><code>chargen:deleted</code></td>
+<td>Full application object</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>REST API</h2>
+<p>The chargen plugin mounts a REST API at <code>/api/v1/chargen</code>. Authentication<br>
+required on all endpoints (<code>Authorization: Bearer &lt;jwt&gt;</code>).</p>
+<h3>GET /api/v1/chargen</h3>
+<p>Staff only. Lists all applications.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -H "Authorization: Bearer $TOKEN" http://localhost:4202/api/v1/chargen
+</code></pre>
+<p>Response:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  {
+    "id": "cg-abc123",
+    "data": {
+      "playerId": "42",
+      "status": "pending",
+      "fields": { "name": "Alice", "concept": "A healer" },
+      "submittedAt": 1742567400000
+    }
+  }
+]
+</code></pre>
+<h3>GET /api/v1/chargen/:id</h3>
+<p>Staff only. Get a single application.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -H "Authorization: Bearer $TOKEN" http://localhost:4202/api/v1/chargen/cg-abc123
+</code></pre>
+<h3>PATCH /api/v1/chargen/:id</h3>
+<p>Staff only. Update an application (approve, reject, reopen).</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "approved", "notes": "Welcome!"}' \
+  http://localhost:4202/api/v1/chargen/cg-abc123
+</code></pre>
+<h3>GET /api/v1/chargen/me</h3>
+<p>Player endpoint. Returns the calling player’s own application.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -H "Authorization: Bearer $TOKEN" http://localhost:4202/api/v1/chargen/me
+</code></pre>
+<hr>
+<h2>Extending Chargen</h2>
+<h3>Add required fields validation</h3>
+<p>Listen to <code>chargen:submitted</code> and auto-reject if required fields are missing:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { chargenHooks } from "../../plugins/chargen/mod.ts";
+import { chargenApps } from "../../plugins/chargen/db.ts";
+
+const REQUIRED = ["name", "concept", "background"];
+
+chargenHooks.on("chargen:submitted", async (app) =&gt; {
+  const missing = REQUIRED.filter(f =&gt; !app.data.fields[f]);
+  if (missing.length === 0) return;
+
+  // Auto-reject with a message listing missing fields
+  await chargenApps.update({ id: app.id }, {
+    ...app,
+    data: {
+      ...app.data,
+      status: "rejected",
+      notes: `Missing required fields: ${missing.join(", ")}. Please fill these in and resubmit.`,
+      reviewedAt: Date.now(),
+      reviewedBy: "system",
+    },
+  });
+});
+</code></pre>
+<h3>Grant starting gear on approval</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">chargenHooks.on("chargen:approved", async (app) =&gt; {
+  const { createObj } = await import("jsr:@ursamu/mush");
+
+  await createObj({
+    name: "Starting Pack",
+    flags: new Set(["thing"]),
+    location: app.data.playerId,
+    state: { desc: "A small pack with basic supplies.", owner: app.data.playerId },
+    contents: [],
+  });
+});
+</code></pre>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/plugins/basics/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+
+        
+          <a href="/ursamu/plugins/commands/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/plugins/commands/index.html
+++ b/docs/_site/plugins/commands/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -276,12 +276,16 @@
 <li>Add <code>import "./commands.ts"</code> in <code>index.ts</code> so registrations happen when the<br>
 plugin is loaded.</li>
 </ol>
-<p>When a player types input, the command parser checks it against every<br>
-registered pattern in turn and calls the first matching <code>exec</code> function.</p>
-<hr>
+<h2>When a player types input, the command parser checks it against every<br>
+registered pattern in turn and calls the first matching <code>exec</code> function.</h2>
 <h2>addCmd Reference</h2>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "../../services/commands/cmdParser.ts";
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In a plugin inside src/plugins/:
+import { addCmd } from "../../services/commands/cmdParser.ts";
 import type { IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
+
+// From a child game (outside src/):
+import { addCmd } from "jsr:@ursamu/mush";
+import type { IUrsamuSDK } from "jsr:@ursamu/mush";
 
 addCmd({
   name: "+myplugin",          // unique identifier — shown in logs
@@ -338,10 +342,21 @@ addCmd({
 </tr>
 </tbody>
 </table>
+<p>Lock expressions also support callable <strong>lockfuncs</strong> combined with <code>&amp;&amp;</code>,<br>
+<code>||</code>, <code>!</code>, and <code>()</code> (v2.2.0+). Built-ins include <code>flag(name)</code>, <code>attr(name, val)</code>, <code>type(name)</code>, <code>is(#id)</code>, <code>holds(#id)</code>, and <code>perm(level)</code>. Plugins<br>
+can register custom lockfuncs:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { registerLockFunc } from "jsr:@ursamu/mush";
+
+registerLockFunc("tribe", (enactor, _target, args) =&gt;
+  String(enactor.state.tribe ?? "").toLowerCase() === args[0]?.toLowerCase()
+);
+
+// lock: "connected &amp;&amp; tribe(glasswaler)"
+</code></pre>
+<p>See <a href="/ursamu/guides/lock-expressions/">Lock Expressions</a> for the full grammar.</p>
 <h3><code>exec</code></h3>
-<p>The function called on match. Receives <code>u: IUrsamuSDK</code> — the same SDK object<br>
-available to sandbox scripts.</p>
-<hr>
+<h2>The function called on match. Receives <code>u: IUrsamuSDK</code> — the same SDK object<br>
+available to sandbox scripts.</h2>
 <h2>The IUrsamuSDK Object</h2>
 <h3>Identity</h3>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">u.me.id           // actor's DB ID
@@ -391,7 +406,51 @@ if (!isAdmin) { u.send("Permission denied."); return; }
 u.util.ljust(str, width)  // left-pad to width
 u.util.rjust(str, width)  // right-pad to width
 u.util.center(str, width) // center in width
+u.util.header(label)      // bordered 78-col block header (===… / centered %ch/cn / ===…)
+u.util.divider(label)     // labelled section rule (\n%chlabel%cn\n---…)
+u.util.footer(label)      // bordered 78-col block footer (empty label → rule only)
 </code></pre>
+<h3>u.mail, u.attr, u.eval, u.forceAs</h3>
+<p>These are also available in the <code>u</code> object. See the<br>
+<a href="/ursamu/guides/sdk-cookbook/">SDK Cookbook</a> for full examples:</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>u.attr.get(id, name)</code></td>
+<td>Read a soft-coded &amp;ATTR value (returns <code>string | null</code>)</td>
+</tr>
+<tr>
+<td><code>u.eval(targetId, attr, args?)</code></td>
+<td>Evaluate &amp;ATTR and return output as string</td>
+</tr>
+<tr>
+<td><code>u.forceAs(targetId, cmd)</code></td>
+<td>Execute command as another object (wizard/admin only)</td>
+</tr>
+<tr>
+<td><code>u.sys.gameTime()</code></td>
+<td>Read in-game calendar (<code>IGameTime</code>)</td>
+</tr>
+<tr>
+<td><code>u.sys.setGameTime(t)</code></td>
+<td>Set in-game calendar</td>
+</tr>
+<tr>
+<td><code>u.chan.history(name, limit?)</code></td>
+<td>Recent channel messages</td>
+</tr>
+<tr>
+<td><code>u.mail.send/read/delete/modify</code></td>
+<td>Mail system (sandbox scripts only)</td>
+</tr>
+</tbody>
+</table>
 <hr>
 <h2>Pattern Reference</h2>
 <h3>Simple command, no arguments</h3>
@@ -479,7 +538,8 @@ u.util.center(str, width) // center in width
 });
 </code></pre>
 <h3>Command that reads and writes a custom DBO</h3>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { addCmd } from "../../services/commands/cmdParser.ts";
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// Plugin in src/plugins/ — use relative imports
+import { addCmd } from "../../services/commands/cmdParser.ts";
 import type { IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
 import { myRecords } from "./db.ts";
 
@@ -510,6 +570,56 @@ addCmd({
   },
 });
 </code></pre>
+<hr>
+<h2>Related Registrations</h2>
+<p>Beyond <code>addCmd</code>, plugins can register several other engine extensions from<br>
+<code>init()</code>:</p>
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>registerPluginRoute(method, path, handler)</code></td>
+<td>Mount a REST handler on the main Express app</td>
+</tr>
+<tr>
+<td><code>registerUIComponent(component)</code></td>
+<td>Surface a UI panel via <code>GET /api/v1/ui-manifest</code></td>
+</tr>
+<tr>
+<td><code>unregisterUIComponent(name)</code></td>
+<td>Remove a UI panel (call from <code>remove()</code>)</td>
+</tr>
+<tr>
+<td><code>registerFormatHandler(slot, handler)</code></td>
+<td>TS-function format handler (NAMEFORMAT, DESCFORMAT, WHOFORMAT, etc.)</td>
+</tr>
+<tr>
+<td><code>registerFormatTemplate(slot, mushSource)</code></td>
+<td>MUSH-softcode shortcut for format handlers (v2.4.0+)</td>
+</tr>
+<tr>
+<td><code>registerLockFunc(name, fn)</code></td>
+<td>Custom lockfunc usable in <code>lock:</code> strings</td>
+</tr>
+<tr>
+<td><code>registerSoftcodeFunc(name, fn)</code></td>
+<td>Custom stdlib function callable from softcode</td>
+</tr>
+<tr>
+<td><code>registerScript(name, content)</code></td>
+<td>Override or add a sandbox script by name</td>
+</tr>
+</tbody>
+</table>
+<p>Each of these has a corresponding teardown — <code>gameHooks.off</code>,<br>
+<code>unregisterUIComponent</code>, <code>unregisterFormatHandler</code> — that should run in<br>
+<code>remove()</code> so reload is clean. See <a href="/ursamu/api/core/">API: Core</a> for full<br>
+signatures.</p>
 
       </article>
 
@@ -602,11 +712,75 @@ addCmd({
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
         
       
         
@@ -621,9 +795,9 @@ addCmd({
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/plugins/basics/" class="page-nav-btn prev">
+          <a href="/ursamu/plugins/chargen/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Character Generation Plugin</span>
           </a>
         
 

--- a/docs/_site/plugins/configuration/index.html
+++ b/docs/_site/plugins/configuration/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -269,11 +269,10 @@
       <article class="prose">
         <h1>Plugin Configuration</h1>
 <h2>Overview</h2>
-<p>Plugins can declare default configuration values via the <code>config</code> property on<br>
+<h2>Plugins can declare default configuration values via the <code>config</code> property on<br>
 <code>IPlugin</code>. These defaults are deep-merged into the global config at startup, so<br>
 game operators can override any value in <code>config/config.json</code> without touching<br>
-plugin code.</p>
-<hr>
+plugin code.</h2>
 <h2>Declaring Defaults</h2>
 <p>Add a <code>config</code> property to your <code>IPlugin</code> object. Nest your values under<br>
 <code>plugins.&lt;plugin-name&gt;</code> to avoid collisions with core config keys:</p>
@@ -310,9 +309,8 @@ const max     = getConfig&lt;number&gt;("plugins.my-plugin.maxItems")  ?? 50;
 const enabled = getConfig&lt;boolean&gt;("plugins.my-plugin.enabled")  ?? true;
 const msg     = getConfig&lt;string&gt;("plugins.my-plugin.welcomeMessage") ?? "";
 </code></pre>
-<p><code>getConfig&lt;T&gt;(key)</code> traverses the merged config using dot-notation and returns<br>
-<code>undefined</code> if the key does not exist. Always supply a fallback.</p>
-<hr>
+<h2><code>getConfig&lt;T&gt;(key)</code> traverses the merged config using dot-notation and returns<br>
+<code>undefined</code> if the key does not exist. Always supply a fallback.</h2>
 <h2>User Overrides</h2>
 <p>Operators drop their overrides into <code>config/config.json</code>. The plugin’s declared<br>
 defaults are the baseline; anything in the file wins:</p>
@@ -477,11 +475,75 @@ export default rateLimitPlugin;
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
         
       
         

--- a/docs/_site/plugins/database/index.html
+++ b/docs/_site/plugins/database/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -269,10 +269,9 @@
       <article class="prose">
         <h1>Plugin Database</h1>
 <h2>Overview</h2>
-<p>UrsaMU’s database layer is built on Deno KV. The generic class <code>DBO&lt;T&gt;</code><br>
+<h2>UrsaMU’s database layer is built on Deno KV. The generic class <code>DBO&lt;T&gt;</code><br>
 provides a typed CRUD interface for any collection. Each plugin creates its own<br>
-named collections that live in the shared KV store, isolated by key prefix.</p>
-<hr>
+named collections that live in the shared KV store, isolated by key prefix.</h2>
 <h2>Defining a Collection</h2>
 <p>Create a <code>db.ts</code> file in your plugin directory:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/my-plugin/db.ts
@@ -285,8 +284,11 @@ export interface IMyRecord {
   createdAt: number;   // ms timestamp
 }
 
-// The string key must be globally unique — prefix with "server." by convention
-export const myRecords = new DBO&lt;IMyRecord&gt;("server.my-plugin-records");
+// The collection key must be globally unique — prefix with your plugin name
+// (e.g. "my-plugin.records") so it cannot collide with engine collections or
+// other plugins. The legacy "server." prefix is reserved for core engine
+// collections like dbojs, counters, chans, mail, etc.
+export const myRecords = new DBO&lt;IMyRecord&gt;("my-plugin.records");
 </code></pre>
 <p>Import the collection wherever you need it:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { myRecords } from "./db.ts";
@@ -595,11 +597,75 @@ addCmd({
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
         
       
         

--- a/docs/_site/plugins/dependencies/index.html
+++ b/docs/_site/plugins/dependencies/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -269,12 +269,14 @@
       <article class="prose">
         <h1>Sharing Code Between Plugins</h1>
 <h2>Overview</h2>
-<p>UrsaMU does not have a formal runtime dependency resolver — there is no<br>
-<code>dependencies</code> array on <code>IPlugin</code> and no <code>app.plugins.get()</code> API. Instead,<br>
-plugins share code the same way any TypeScript modules do: <strong>direct imports</strong>.</p>
-<p>This keeps things simple and type-safe. If plugin B needs something from<br>
-plugin A, it imports it.</p>
-<hr>
+<p>UrsaMU resolves plugin <strong>install order</strong> through the <code>deps[]</code> array in<br>
+<code>ursamu.plugin.json</code> (see <a href="#ursamuplug-injson-dependencies">ursamu.plugin.json Dependencies</a><br>
+below), but there is no <code>app.plugins.get()</code> API for cross-plugin code<br>
+access at runtime. Plugins share code the same way any TypeScript modules<br>
+do: <strong>direct imports</strong>.</p>
+<h2>This keeps things simple and type-safe. If plugin B needs something from<br>
+plugin A, it declares plugin A in <code>deps[]</code> so the installer fetches it,<br>
+then imports from it directly.</h2>
 <h2>Sharing Utilities</h2>
 <p>The cleanest pattern is a <strong>shared utility module</strong> that both plugins import.<br>
 Put it in a neutral location like <code>src/plugins/shared/</code> or a dedicated<br>
@@ -330,10 +332,9 @@ export interface IJob {
 
 export const jobs = new DBO&lt;IJob&gt;("server.jobs");
 </code></pre>
-<p>Both the <code>jobs</code> plugin and a hypothetical <code>jobs-reporter</code> plugin import from<br>
+<h2>Both the <code>jobs</code> plugin and a hypothetical <code>jobs-reporter</code> plugin import from<br>
 <code>shared/jobsDb.ts</code>. The KV store is shared automatically since both collections<br>
-use the same key (<code>"server.jobs"</code>).</p>
-<hr>
+use the same key (<code>"server.jobs"</code>).</h2>
 <h2>Coordination via Events</h2>
 <p>When plugins need <strong>loose coupling</strong> — where plugin B reacts to what plugin A<br>
 does without importing from it directly — use <code>EventsService</code>:</p>
@@ -355,12 +356,12 @@ await svc.subscribe(
   "world",
 );
 </code></pre>
-<p>This pattern is preferred when the dependency is optional or when you want<br>
-Plugin B to work even if Plugin A is not installed.</p>
-<hr>
+<h2>This pattern is preferred when the dependency is optional or when you want<br>
+Plugin B to work even if Plugin A is not installed.</h2>
 <h2>ursamu.plugin.json Dependencies</h2>
-<p>While there is no runtime dependency resolver, you can document required<br>
-plugins in <code>ursamu.plugin.json</code> for human readers and future tooling:</p>
+<p>Declare transitive plugin dependencies in the <code>deps[]</code> array of your<br>
+<code>ursamu.plugin.json</code>. <code>ensurePlugins</code> resolves and installs the graph on<br>
+startup:</p>
 <pre class="language-json" tabindex="0"><code class="language-json">{
   "name": "jobs-reporter",
   "version": "1.0.0",
@@ -368,11 +369,19 @@ plugins in <code>ursamu.plugin.json</code> for human readers and future tooling:
   "ursamu": "&gt;=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "requires": ["jobs"]
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 </code></pre>
-<p>The <code>requires</code> field is informational only — <code>ursamu plugin install</code> displays<br>
-it so operators know what to install first. It does not affect load order.</p>
+<p>Each entry needs <code>name</code> and <code>url</code>. The <code>ref</code> (git ref) and <code>version</code><br>
+(semver range checked against the dep’s manifest) fields are optional.<br>
+Omit <code>version</code> to install the dep without a check — backwards compatible<br>
+with manifests written before the range feature shipped.</p>
+<p>If any dep fails to clone, fails its <code>version</code> range, or has incompatible<br>
+ranges across requesters, the entire install run aborts and rolls back —<br>
+disk and <code>.registry.json</code> are left exactly as they were before the run.<br>
+See the <a href="/ursamu/plugins/#deps-entries"><code>deps[]</code> reference</a> for full semantics.</p>
 
       </article>
 
@@ -477,11 +486,75 @@ it so operators know what to install first. It does not affect load order.</p>
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
         
       
         
@@ -497,9 +570,9 @@ it so operators know what to install first. It does not affect load order.</p>
         
 
         
-          <a href="/ursamu/plugins/first-plugin/" class="page-nav-btn next">
+          <a href="/ursamu/plugins/events/" class="page-nav-btn next">
             <span class="page-nav-label">Next →</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Events Plugin</span>
           </a>
         
       </nav>

--- a/docs/_site/plugins/events/index.html
+++ b/docs/_site/plugins/events/index.html
@@ -1,0 +1,921 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Events Plugin | UrsaMU Documentation</title>
+  <meta name="description" content="In-game event calendar with RSVP tracking, staff management, and REST API.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/plugins/events/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link active">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Events Plugin</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Events Plugin</h1>
+<p>The <code>events</code> plugin provides an in-game event calendar with RSVP tracking.<br>
+Players can browse upcoming events and reserve spots. Staff create and manage<br>
+events.</p>
+<blockquote>
+<p><strong>Note:</strong> This is the <em>event calendar</em> plugin (<code>+event</code> commands). It is<br>
+separate from <code>u.events</code>, the server-wide pub/sub system.</p>
+</blockquote>
+<hr>
+<h2>Overview</h2>
+<p>Events have a title, description, date/time, optional location and capacity,<br>
+and a status. Players can RSVP as attending, maybe, or declined.</p>
+<h2>The plugin auto-loads when <code>src/plugins/events/</code> exists. No configuration needed.</h2>
+<h2>Player Commands</h2>
+<h3><code>+event</code> / <code>+event/list</code></h3>
+<p>List all upcoming (and active) events.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event
++events
+  #   Title                         Date                 RSVPs   Status
+--------------------------------------------------------------------
+  1   Midsummer Festival            2026-06-21 20:00       5/20  upcoming
+  2   Guild Hall Opening            2026-04-01 19:00          3  upcoming
+Use "+event/view &lt;#&gt;" to see details and RSVP.
+</code></pre>
+<p>Cancelled events are hidden unless you are staff.</p>
+<h3><code>+event/view &lt;#&gt;</code></h3>
+<p>View event details and the full RSVP list.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/view 1
++event #1: Midsummer Festival
+  Status  : upcoming
+  Date    : 2026-06-21 20:00
+  Where   : The Grand Courtyard
+  Tags    : festival, seasonal
+  Host    : Gwyneira
+  Desc    : Annual midsummer celebration with music and dancing.
+  RSVPs:  5/20 attending, 2 maybe
+    Attending: Alice, Bob, Carol, Diana, Eve
+    Maybe    : Frank, Grace
+  Use "+event/rsvp 1" to RSVP, "+event/rsvp 1=maybe" for maybe.
+</code></pre>
+<h3><code>+event/rsvp &lt;#&gt;[=attending|maybe|decline]</code></h3>
+<p>RSVP to an event. Default status is <code>attending</code>.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/rsvp 1
+RSVP'd attending for "Midsummer Festival".
+
+&gt; +event/rsvp 1=maybe
+RSVP updated to maybe for "Midsummer Festival".
+
+&gt; +event/rsvp 1=decline
+RSVP updated to declined for "Midsummer Festival".
+</code></pre>
+<p>If the event has a <code>maxAttendees</code> cap and it’s full, attending RSVPs are blocked.</p>
+<h3><code>+event/unrsvp &lt;#&gt;</code></h3>
+<p>Cancel your RSVP.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/unrsvp 1
+RSVP cancelled for "Midsummer Festival".
+</code></pre>
+<hr>
+<h2>Staff Commands</h2>
+<p>All staff commands require <code>admin</code>, <code>wizard</code>, or <code>superuser</code> flag.</p>
+<h3><code>+event/create &lt;title&gt;=&lt;date&gt;/&lt;description&gt;</code></h3>
+<p>Create a new event. Date format: <code>YYYY-MM-DD</code> or <code>YYYY-MM-DD HH:MM</code>.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/create Midsummer Festival=2026-06-21 20:00/Annual midsummer celebration with music and dancing.
++event: Event #1 "Midsummer Festival" created for 2026-06-21 20:00.
+</code></pre>
+<h3><code>+event/edit &lt;#&gt;/&lt;field&gt;=&lt;value&gt;</code></h3>
+<p>Edit any event field.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/edit 1/location=The Grand Courtyard
++event: Event #1 field "location" updated.
+
+&gt; +event/edit 1/maxAttendees=20
++event: Event #1 field "maxAttendees" updated.
+
+&gt; +event/edit 1/tags=festival,seasonal
++event: Event #1 field "tags" updated.
+
+&gt; +event/edit 1/endTime=2026-06-21 23:00
++event: Event #1 field "endTime" updated.
+</code></pre>
+<p>Editable fields:</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>title</code></td>
+<td>string</td>
+<td>Event name</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td>string</td>
+<td>Full description</td>
+</tr>
+<tr>
+<td><code>location</code></td>
+<td>string</td>
+<td>Where it’s happening</td>
+</tr>
+<tr>
+<td><code>startTime</code></td>
+<td>date string</td>
+<td><code>YYYY-MM-DD</code> or <code>YYYY-MM-DD HH:MM</code></td>
+</tr>
+<tr>
+<td><code>endTime</code></td>
+<td>date string</td>
+<td>Optional end time</td>
+</tr>
+<tr>
+<td><code>tags</code></td>
+<td>comma-separated</td>
+<td>Comma-separated tag list</td>
+</tr>
+<tr>
+<td><code>maxAttendees</code></td>
+<td>number</td>
+<td>0 = unlimited</td>
+</tr>
+<tr>
+<td><code>status</code></td>
+<td>status string</td>
+<td>See status table</td>
+</tr>
+</tbody>
+</table>
+<h3><code>+event/cancel &lt;#&gt;</code></h3>
+<p>Mark an event as cancelled. Cancelled events are hidden from players.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/cancel 1
++event: Event #1 "Midsummer Festival" cancelled.
+</code></pre>
+<h3><code>+event/delete &lt;#&gt;</code></h3>
+<p>Permanently delete an event and all its RSVPs.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/delete 1
++event: Event #1 "Midsummer Festival" deleted.
+</code></pre>
+<h3><code>+event/status &lt;#&gt;=&lt;status&gt;</code></h3>
+<p>Set a status explicitly. Useful for marking events as active or completed.</p>
+<pre class="language-none" tabindex="0"><code class="language-none">&gt; +event/status 1=active
++event: Event #1 status set to active.
+
+&gt; +event/status 1=completed
++event: Event #1 status set to completed.
+</code></pre>
+<hr>
+<h2>Event Statuses</h2>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Visible to players</th>
+<th>RSVP allowed</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>upcoming</code></td>
+<td>Yes</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><code>active</code></td>
+<td>Yes</td>
+<td>Yes</td>
+</tr>
+<tr>
+<td><code>completed</code></td>
+<td>Yes</td>
+<td>No</td>
+</tr>
+<tr>
+<td><code>cancelled</code></td>
+<td>No (staff only)</td>
+<td>No</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>eventHooks</h2>
+<p>Subscribe to event lifecycle changes in your plugin.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { eventHooks } from "../../plugins/events/hooks.ts";
+
+// Notify Discord when an event is created
+eventHooks.on("event:created", ({ eventId, name, startTime, createdBy }) =&gt; {
+  console.log(`[events] New event "${name}" created by ${createdBy}`);
+});
+
+// Track RSVPs for reporting
+eventHooks.on("event:rsvp", ({ eventId, playerId, status }) =&gt; {
+  console.log(`[events] ${playerId} RSVPd ${status} to event ${eventId}`);
+});
+
+// Announce cancellations to all players
+eventHooks.on("event:cancelled", async ({ eventId, name }) =&gt; {
+  // Broadcast or send mail to all RSVPd players
+});
+</code></pre>
+<h3>Event payloads</h3>
+<table>
+<thead>
+<tr>
+<th>Event</th>
+<th>Key payload fields</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>event:created</code></td>
+<td><code>eventId</code>, <code>name</code>, <code>startTime</code>, <code>createdBy</code></td>
+</tr>
+<tr>
+<td><code>event:updated</code></td>
+<td><code>eventId</code>, <code>changes</code></td>
+</tr>
+<tr>
+<td><code>event:deleted</code></td>
+<td><code>eventId</code></td>
+</tr>
+<tr>
+<td><code>event:started</code></td>
+<td><code>eventId</code>, <code>name</code></td>
+</tr>
+<tr>
+<td><code>event:ended</code></td>
+<td><code>eventId</code>, <code>name</code></td>
+</tr>
+<tr>
+<td><code>event:rsvp</code></td>
+<td><code>eventId</code>, <code>playerId</code>, <code>status</code></td>
+</tr>
+<tr>
+<td><code>event:cancelled</code></td>
+<td><code>eventId</code>, <code>name</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>REST API</h2>
+<p>The events plugin mounts a REST API at <code>/api/v1/events</code>. Authentication<br>
+required on all endpoints (<code>Authorization: Bearer &lt;jwt&gt;</code>).</p>
+<h3>GET /api/v1/events</h3>
+<p>List all events. Staff see cancelled events; players do not.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -H "Authorization: Bearer $TOKEN" http://localhost:4202/api/v1/events
+</code></pre>
+<p>Response:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">[
+  {
+    "id": "ev-1",
+    "number": 1,
+    "title": "Midsummer Festival",
+    "description": "Annual midsummer celebration.",
+    "startTime": 1750536000000,
+    "location": "The Grand Courtyard",
+    "tags": ["festival", "seasonal"],
+    "maxAttendees": 20,
+    "status": "upcoming",
+    "createdByName": "Gwyneira"
+  }
+]
+</code></pre>
+<h3>GET /api/v1/events/:id</h3>
+<p>Get a single event with its RSVP list.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -H "Authorization: Bearer $TOKEN" http://localhost:4202/api/v1/events/ev-1
+</code></pre>
+<h3>POST /api/v1/events</h3>
+<p>Staff only. Create a new event.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Guild Meeting",
+    "description": "Monthly guild meeting.",
+    "startTime": 1750536000000
+  }' \
+  http://localhost:4202/api/v1/events
+</code></pre>
+<h3>PATCH /api/v1/events/:id</h3>
+<p>Staff only. Update an event.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "cancelled"}' \
+  http://localhost:4202/api/v1/events/ev-1
+</code></pre>
+<h3>DELETE /api/v1/events/:id</h3>
+<p>Staff only. Delete an event.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4202/api/v1/events/ev-1
+</code></pre>
+<h3>POST /api/v1/events/:id/rsvp</h3>
+<p>RSVP to an event (as the authenticated player).</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "attending"}' \
+  http://localhost:4202/api/v1/events/ev-1/rsvp
+</code></pre>
+<h3>DELETE /api/v1/events/:id/rsvp</h3>
+<p>Cancel RSVP.</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">curl -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4202/api/v1/events/ev-1/rsvp
+</code></pre>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/plugins/dependencies/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+
+        
+          <a href="/ursamu/plugins/first-plugin/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/plugins/first-plugin/index.html
+++ b/docs/_site/plugins/first-plugin/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -282,8 +282,7 @@ them, both in-game and through the REST API.</p>
 ├── router.ts     — REST handler for /api/v1/notes
 └── db.ts         — custom DBO database
 </code></pre>
-<p>The plugin is already auto-discovered. Restart the server and it loads.</p>
-<hr>
+<h2>The plugin is already auto-discovered. Restart the server and it loads.</h2>
 <h2>File Walkthrough</h2>
 <h3>db.ts — Define your data shape</h3>
 <p>Replace the generated stub with a <code>INote</code> type:</p>
@@ -438,7 +437,7 @@ export default notesPlugin;
 </code></pre>
 <p><strong>Via REST:</strong></p>
 <pre class="language-bash" tabindex="0"><code class="language-bash"># Get a token first
-TOKEN=$(curl -s -X POST http://localhost:4203/api/v1/auth/login \
+TOKEN=$(curl -s -X POST http://localhost:4203/api/v1/auth \
   -H "Content-Type: application/json" \
   -d '{"name":"Admin","password":"yourpassword"}' | jq -r .token)
 
@@ -481,7 +480,6 @@ curl -s -X DELETE http://localhost:4203/api/v1/notes/&lt;id&gt; \
 <h2>Next Steps</h2>
 <ul>
 <li><code>src/plugins/jobs/</code> — a real-world example with staff permission checks and complex REST routes</li>
-<li><code>src/plugins/bboards/</code> — per-user unread state across multiple resources</li>
 <li><code>src/plugins/events/</code> — sequential IDs, RSVP capacity enforcement, event status visibility</li>
 <li><a href="/ursamu/plugins/">Plugin Reference</a> — full <code>IUrsamuSDK</code> and <code>DBO&lt;T&gt;</code> API tables</li>
 <li><a href="/ursamu/plugins/hooks/">Plugin Events</a> — subscribing and emitting game events</li>
@@ -594,20 +592,86 @@ curl -s -X DELETE http://localhost:4203/api/v1/notes/&lt;id&gt; \
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
         
       
 
       
       <nav class="page-nav" aria-label="Page navigation">
         
-          <a href="/ursamu/plugins/dependencies/" class="page-nav-btn prev">
+          <a href="/ursamu/plugins/events/" class="page-nav-btn prev">
             <span class="page-nav-label">← Previous</span>
-            <span class="page-nav-title"></span>
+            <span class="page-nav-title">Events Plugin</span>
           </a>
         
 

--- a/docs/_site/plugins/hooks/index.html
+++ b/docs/_site/plugins/hooks/index.html
@@ -3,7 +3,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> | UrsaMU Documentation</title>
-  <meta name="description" content="Reacting to and emitting game events with EventsService">
+  <meta name="description" content="Typed event hooks for reacting to game, scene, wiki, and custom events">
   <link rel="stylesheet" href="/ursamu/styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
 <meta property="og:type" content="website">
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -267,172 +267,267 @@
 
       <!-- Page content -->
       <article class="prose">
-        <h1>Plugin Events</h1>
-<h2>Overview</h2>
-<p>UrsaMU uses an internal pub/sub system via <code>EventsService</code>. Plugins can<br>
-subscribe to named event channels, emit custom events, and trigger sandbox<br>
-scripts when events fire. This is the correct way to react to things that<br>
-happen in the game world — there is no <code>app.hooks</code> API.</p>
+        <h1>Plugin Hooks &amp; Events</h1>
+<p>UrsaMU ships two complementary event systems. Choose the one that fits your use case:</p>
+<table>
+<thead>
+<tr>
+<th>System</th>
+<th>Best for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>GameHooks</strong></td>
+<td>Reacting to engine-level events (player login, movement, say, scene changes) from TypeScript plugin code</td>
+</tr>
+<tr>
+<td><strong>EventsService</strong></td>
+<td>Running sandbox scripts when custom events fire; in-game <code>u.events.on/emit</code> scripting</td>
+</tr>
+</tbody>
+</table>
+<h2>Both are safe to use together in the same plugin.</h2>
+<h2>GameHooks</h2>
+<p><code>gameHooks</code> is a typed, singleton event bus exported from <code>mod.ts</code>. It fires<br>
+for 12 built-in engine events and is the correct way to react to player and<br>
+scene activity without modifying core command files.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { gameHooks } from "jsr:@ursamu/mush";
+
+// Subscribe
+gameHooks.on("player:login", ({ actorId, actorName }) =&gt; {
+  console.log(`[GM] ${actorName} connected.`);
+});
+
+// Unsubscribe (pass the same function reference)
+gameHooks.off("player:login", myHandler);
+</code></pre>
+<h3>API</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on(event, handler)   // subscribe — idempotent (no double-register)
+gameHooks.off(event, handler)  // unsubscribe
+await gameHooks.emit(event, payload)  // fire all handlers; errors are caught per-handler
+</code></pre>
+<p><strong>Error isolation</strong> — a throwing handler is logged and skipped; subsequent<br>
+handlers still run.</p>
+<p><strong>Fire-and-forget pattern</strong> (used throughout the engine):</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.emit("player:login", payload)
+  .catch((e) =&gt; console.error("[hooks] player:login error:", e));
+</code></pre>
 <hr>
-<h2>Subscribing to Events</h2>
+<h3>Player Events</h3>
+<h4><code>player:say</code></h4>
+<p>Fires when a player speaks in a room via <code>say</code> / <code>"</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:say", ({ actorId, actorName, roomId, message }) =&gt; {
+  // actorId   — DB id of the speaker
+  // actorName — display name
+  // roomId    — room where the message was spoken
+  // message   — the spoken text (raw, may contain MUSH codes)
+});
+</code></pre>
+<h4><code>player:pose</code></h4>
+<p>Fires when a player poses/emotes via <code>pose</code> / <code>:</code> / <code>;</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:pose", ({ actorId, actorName, roomId, content, isSemipose }) =&gt; {
+  // content    — full formatted content, e.g. "Alice grins."
+  // isSemipose — true when ; shorthand was used (no space between name and text)
+});
+</code></pre>
+<h4><code>player:page</code></h4>
+<p>Fires when a player pages another player.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:page", ({ actorId, actorName, targetId, targetName, message }) =&gt; {});
+</code></pre>
+<h4><code>player:move</code></h4>
+<p>Fires when a player traverses an exit.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:move", ({
+  actorId, actorName,
+  fromRoomId, toRoomId,
+  fromRoomName, toRoomName,
+  exitName,         // e.g. "North"
+}) =&gt; {});
+</code></pre>
+<h4><code>player:login</code></h4>
+<p>Fires when a player connects and logs in.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:login", ({ actorId, actorName }) =&gt; {});
+</code></pre>
+<h4><code>player:logout</code></h4>
+<p>Fires when a player disconnects.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("player:logout", ({ actorId, actorName }) =&gt; {});
+</code></pre>
+<h4><code>channel:message</code></h4>
+<p>Fires when a player speaks on a channel.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("channel:message", ({ channelName, senderId, senderName, message }) =&gt; {});
+</code></pre>
+<h3>Object Events</h3>
+<p>Fire when DBOs in the main <code>dbojs</code> collection are created, modified, or<br>
+destroyed. Useful for cache invalidation, audit logs, or reacting to<br>
+builder-plugin operations.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("object:created",   ({ id, obj }) =&gt; {});
+gameHooks.on("object:modified",  ({ id, before, after }) =&gt; {});
+gameHooks.on("object:destroyed", ({ id }) =&gt; {});
+</code></pre>
+<h4><code>object:moved</code></h4>
+<p>Fires whenever an object changes location through the engine: <code>get</code>, <code>drop</code>,<br>
+<code>give</code>, <code>u.db.create</code> (with a location), and <code>u.db.destroy</code>. <code>from</code> is <code>null</code><br>
+for fresh creation; <code>to</code> is <code>null</code> for destruction. <code>cause</code> is the verb<br>
+(“get”, “drop”, “give”, “create”, “destroy”, or a plugin-defined string).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("object:moved", ({ objectId, from, to, cause, actorId }) =&gt; {
+  // e.g. merge ammo stacks when a magazine lands in a new carrier
+});
+</code></pre>
+<h4><code>mail:received</code></h4>
+<p>Fires when in-game mail is delivered to a recipient.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("mail:received", ({ recipientId, senderId, subject }) =&gt; {});
+</code></pre>
+<hr>
+<h3>Scene Events</h3>
+<p>Scene hooks fire from the REST API (<code>/api/v1/scenes</code>) when scenes are created,<br>
+modified, or closed. They are the integration point for AI GM assistants and<br>
+other scene-aware plugins.</p>
+<h4><code>scene:created</code></h4>
+<p>Fires after a new scene is opened (<code>POST /api/v1/scenes</code>).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("scene:created", ({ sceneId, sceneName, roomId, actorId, actorName, sceneType }) =&gt; {
+  // sceneType — "social" | "action" | "event" | "vignette" | etc.
+});
+</code></pre>
+<h4><code>scene:pose</code></h4>
+<p>Fires when any pose is posted to a scene — type <code>"pose"</code>, <code>"ooc"</code>, or <code>"set"</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("scene:pose", ({ sceneId, sceneName, roomId, actorId, actorName, msg, type }) =&gt; {
+  // type — "pose" | "ooc" | "set"
+});
+</code></pre>
+<h4><code>scene:set</code></h4>
+<p>Fires <strong>additionally</strong> when a pose with <code>type: "set"</code> is posted (the scene<br>
+description hook). This is the primary integration point for an AI narrator —<br>
+it receives the raw description text and can respond with narration, open a new<br>
+round, or page participants.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("scene:set", ({ sceneId, sceneName, roomId, actorId, actorName, description }) =&gt; {
+  // description — the full scene-set text
+});
+</code></pre>
+<h4><code>scene:title</code></h4>
+<p>Fires when a scene is renamed via <code>PATCH /api/v1/scenes/:id</code>.</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("scene:title", ({ sceneId, oldName, newName, actorId, actorName }) =&gt; {});
+</code></pre>
+<h4><code>scene:clear</code></h4>
+<p>Fires when a scene is closed or finished (status transitions to <code>"closed"</code>,<br>
+<code>"finished"</code>, or <code>"archived"</code>).</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">gameHooks.on("scene:clear", ({ sceneId, sceneName, actorId, actorName, status }) =&gt; {
+  // status — "closed" | "finished" | "archived"
+});
+</code></pre>
+<hr>
+<h2>WikiHooks</h2>
+<p>The wiki plugin exposes its own typed hook bus for reacting to wiki page<br>
+mutations. Import it from the wiki plugin’s public module:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { wikiHooks } from "../../plugins/wiki/mod.ts";
+</code></pre>
+<h3>Events</h3>
+<h4><code>wiki:created</code></h4>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">wikiHooks.on("wiki:created", ({ path, meta, body }) =&gt; {
+  // path — URL path of the new page, e.g. "news/announcement"
+  // meta — frontmatter key/value map
+  // body — page body markdown
+});
+</code></pre>
+<h4><code>wiki:edited</code></h4>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">wikiHooks.on("wiki:edited", ({ path, meta, body }) =&gt; {});
+</code></pre>
+<h4><code>wiki:deleted</code></h4>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">wikiHooks.on("wiki:deleted", ({ path, meta }) =&gt; {});
+</code></pre>
+<h2>Same <code>on/off/emit</code> API and error-isolation semantics as GameHooks.</h2>
+<h2>EventHooks</h2>
+<p>The events plugin (calendar/RSVP system) exposes its own typed bus:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { eventHooks } from "../../plugins/events/hooks.ts";
+
+eventHooks.on("event:created",   ({ eventId, name, startTime, createdBy }) =&gt; {});
+eventHooks.on("event:updated",   ({ eventId, changes }) =&gt; {});
+eventHooks.on("event:deleted",   ({ eventId }) =&gt; {});
+eventHooks.on("event:started",   ({ eventId, name }) =&gt; {});
+eventHooks.on("event:ended",     ({ eventId, name }) =&gt; {});
+eventHooks.on("event:rsvp",      ({ eventId, playerId, status }) =&gt; {});
+eventHooks.on("event:cancelled", ({ eventId, name }) =&gt; {});
+</code></pre>
+<hr>
+<h2>EventsService (pub/sub)</h2>
+<p>For running <strong>sandbox scripts</strong> in response to events, use <code>EventsService</code>.<br>
+This is different from GameHooks — subscribers are script strings that run<br>
+inside Web Workers with full <code>u.*</code> SDK access.</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { EventsService } from "../../services/Events/index.ts";
 
 const svc = EventsService.getInstance();
 
 // Subscribe a handler script to run when "player.connect" fires.
-// Returns a subscription UUID — store it so you can unsubscribe later.
 const subId = await svc.subscribe(
-  "player.connect",         // event name
-  `u.send("Welcome back, " + u.me.name + "!");`,  // sandbox script
-  actorId,                  // the DB object that "owns" this subscription
+  "player.connect",
+  `u.send("Welcome back, " + u.me.name + "!");`,
+  actorId,   // DB object that "owns" this subscription
 );
+
+// Unsubscribe
+await svc.unsubscribe(subId);
 </code></pre>
-<p>The script string is run in the sandbox with full <code>u.*</code> SDK access. The<br>
-<code>actorId</code> is the DB object the script runs as (typically the player or a<br>
-world object).</p>
-<h3>Unsubscribing</h3>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">await svc.unsubscribe(subId);
+<p>Always unsubscribe in your plugin’s <code>remove()</code> — orphaned subscribers<br>
+accumulate across reloads.</p>
+<h3>Emitting custom events</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">await svc.emit("weather.change", { newWeather: "stormy" });
+
+// With actor context (becomes u.me in subscriber scripts)
+await svc.emit("weather.change", { newWeather: "stormy" }, { id: actorId, state: {} });
 </code></pre>
-<p>Always unsubscribe in your plugin’s <code>remove()</code> if you subscribed during<br>
-<code>init()</code> — otherwise orphaned subscribers accumulate across reloads.</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">let connectSubId: string;
-
-const myPlugin: IPlugin = {
-  name: "welcome",
-  version: "1.0.0",
-
-  init: async () =&gt; {
-    const svc = EventsService.getInstance();
-    connectSubId = await svc.subscribe(
-      "player.connect",
-      `u.send("%ch%cgWelcome back, " + u.me.name + "!%cn");`,
-      "world",   // run as the world object
-    );
-    return true;
-  },
-
-  remove: async () =&gt; {
-    const svc = EventsService.getInstance();
-    await svc.unsubscribe(connectSubId);
-  },
-};
-</code></pre>
-<hr>
-<h2>Emitting Events</h2>
-<p>Emit any named event from plugin code. All active subscribers for that event<br>
-will receive it:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">import { EventsService } from "../../services/Events/index.ts";
-
-const svc = EventsService.getInstance();
-
-// Emit with optional payload data and actor context
-await svc.emit("weather.change", { newWeather: "stormy" });
-
-// With an actor context (the actor becomes u.me in subscriber scripts)
-await svc.emit(
-  "weather.change",
-  { newWeather: "stormy" },
-  { id: actorId, state: {} },
-);
-</code></pre>
-<hr>
-<h2>In-Game Event Subscriptions</h2>
-<p>Players and world objects can subscribe to events from inside the game using<br>
-<code>u.events.on()</code> and fire them with <code>u.events.emit()</code> in sandbox scripts:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In a sandbox script or system script:
+<h3>In-game event scripting</h3>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In a sandbox or system script:
 const subId = await u.events.on("weather.change", `
   u.send("The weather changed to: " + event.newWeather);
 `);
 
 await u.events.emit("weather.change", { newWeather: "rainy" });
 </code></pre>
-<p>This makes the events system available to in-game scripting without exposing<br>
-server internals.</p>
 <hr>
 <h2>Naming Conventions</h2>
-<p>Use dot-separated namespaces to avoid collisions:</p>
-<pre class="language-none" tabindex="0"><code class="language-none">player.connect          ← core engine event
-player.disconnect       ← core engine event
-weather.change          ← weather plugin event
-my-plugin.item.pickup   ← custom plugin event
+<p>Use dot-separated namespaces for custom events; built-in events use <code>:</code>-separated namespaces:</p>
+<pre class="language-none" tabindex="0"><code class="language-none">player:login          ← built-in GameHook
+scene:set             ← built-in GameHook
+wiki:created          ← built-in WikiHook
+weather.change        ← custom plugin event (EventsService)
+my-plugin.item.pickup ← custom plugin event (EventsService)
 </code></pre>
-<p>Prefix your plugin’s events with its name. Core events use bare namespaces<br>
-(<code>player.*</code>, <code>room.*</code>, etc.).</p>
 <hr>
 <h2>Full Example</h2>
-<p>A weather plugin that broadcasts weather changes to all subscribers:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/weather/index.ts
+<p>A plugin that reacts to scene:set to broadcast a GM narration and also logs<br>
+player logins:</p>
+<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/gm-assist/index.ts
 import type { IPlugin } from "../../@types/IPlugin.ts";
-import { EventsService } from "../../services/Events/index.ts";
-import "./commands.ts";
+import { gameHooks } from "jsr:@ursamu/mush";
+import { send } from "../../services/broadcast/index.ts";
+import type { SceneSetEvent, SessionEvent } from "jsr:@ursamu/mush";
 
-const WEATHER_TYPES = ["sunny", "cloudy", "rainy", "stormy", "snowy"] as const;
-let weatherInterval: number | undefined;
+const onSceneSet = async ({ sceneId, sceneName, roomId, description }: SceneSetEvent) =&gt; {
+  // Narrate the scene to the room in GM voice
+  send([roomId], `%ch%cm[GM]%cn ${description}`, {});
+  console.log(`[GM] Scene "${sceneName}" set in room ${roomId}`);
+};
 
-const weatherPlugin: IPlugin = {
-  name: "weather",
+const onLogin = ({ actorName }: SessionEvent) =&gt; {
+  console.log(`[GM] ${actorName} logged in.`);
+};
+
+const gmPlugin: IPlugin = {
+  name: "gm-assist",
   version: "1.0.0",
-  description: "Rotating weather system with event hooks",
 
-  init: async () =&gt; {
-    let current: string = "sunny";
-
-    weatherInterval = setInterval(async () =&gt; {
-      const options = WEATHER_TYPES.filter(w =&gt; w !== current);
-      current = options[Math.floor(Math.random() * options.length)];
-
-      const svc = EventsService.getInstance();
-      await svc.emit("weather.change", { weather: current });
-    }, 30 * 60 * 1000) as unknown as number;   // every 30 min
-
-    console.log("[weather] initialized — weather cycle started");
+  init: () =&gt; {
+    gameHooks.on("scene:set",     onSceneSet);
+    gameHooks.on("player:login",  onLogin);
     return true;
   },
 
-  remove: async () =&gt; {
-    if (weatherInterval !== undefined) clearInterval(weatherInterval);
-    console.log("[weather] removed");
+  remove: () =&gt; {
+    gameHooks.off("scene:set",    onSceneSet);
+    gameHooks.off("player:login", onLogin);
   },
 };
 
-export default weatherPlugin;
-</code></pre>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// src/plugins/weather/commands.ts
-import { addCmd } from "../../services/commands/cmdParser.ts";
-import type { IUrsamuSDK } from "../../@types/UrsamuSDK.ts";
-import { EventsService } from "../../services/Events/index.ts";
-
-addCmd({
-  name: "+weather",
-  pattern: /^\+weather(?:\/(\S+))?\s*(.*)/i,
-  lock: "connected",
-  exec: async (u: IUrsamuSDK) =&gt; {
-    const sw = (u.cmd.args[0] || "").toLowerCase();
-
-    if (sw === "watch") {
-      // Subscribe this player to weather changes
-      const svc = EventsService.getInstance();
-      const subId = await svc.subscribe(
-        "weather.change",
-        `u.send("%ch%cyWeather report:%cn The weather is now " + event.weather + ".");`,
-        u.me.id,
-      );
-      u.send(`%ch+weather:%cn You will now receive weather updates. (sub: ${subId.slice(-6)})`);
-      return;
-    }
-
-    u.send("Usage: +weather/watch  — subscribe to weather updates");
-  },
-});
-</code></pre>
-<p>Any other plugin can now react to weather changes:</p>
-<pre class="language-typescript" tabindex="0"><code class="language-typescript">// In another plugin's init():
-const svc = EventsService.getInstance();
-await svc.subscribe(
-  "weather.change",
-  `if (event.weather === "stormy") u.broadcast("Thunder rumbles in the distance!");`,
-  "world",
-);
+export default gmPlugin;
 </code></pre>
 
       </article>
@@ -546,6 +641,74 @@ await svc.subscribe(
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
           
         
       
@@ -559,6 +722,11 @@ await svc.subscribe(
           </a>
         
 
+        
+          <a href="/ursamu/plugins/official-plugins/" class="page-nav-btn next">
+            <span class="page-nav-label">Next →</span>
+            <span class="page-nav-title">Official Plugins</span>
+          </a>
         
       </nav>
       

--- a/docs/_site/plugins/index.html
+++ b/docs/_site/plugins/index.html
@@ -62,7 +62,7 @@
 
   <!-- Actions -->
   <div class="header-actions">
-    <span class="header-version">v1.2.0</span>
+    <span class="header-version">mush 1.0.30</span>
 
     <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
       <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
@@ -277,10 +277,9 @@ combination of:</p>
 <li><strong>A private database</strong> — a <code>DBO&lt;T&gt;</code> collection namespaced to the plugin</li>
 <li><strong>Config defaults</strong> — merged into the global config on startup</li>
 </ul>
-<p>Plugins are <strong>auto-discovered</strong>. Drop a folder into <code>src/plugins/</code> with an<br>
+<h2>Plugins are <strong>auto-discovered</strong>. Drop a folder into <code>src/plugins/</code> with an<br>
 <code>index.ts</code> that exports a default <code>IPlugin</code> object and the engine loads it on<br>
-next start — no registration required.</p>
-<hr>
+next start — no registration required.</h2>
 <h2>Plugin Structure</h2>
 <p>A full plugin lives in its own subdirectory:</p>
 <pre class="language-none" tabindex="0"><code class="language-none">src/plugins/my-plugin/
@@ -290,17 +289,15 @@ next start — no registration required.</p>
 ├── db.ts                — custom DBO database
 └── ursamu.plugin.json   — manifest (required for ursamu plugin install)
 </code></pre>
-<p>Only <code>index.ts</code> is required. The other files are imported from it.</p>
-<hr>
+<h2>Only <code>index.ts</code> is required. The other files are imported from it.</h2>
 <h2>Quick Scaffold</h2>
 <p>The fastest way to start is the built-in CLI scaffolder. Run from your game<br>
 project root:</p>
 <pre class="language-bash" tabindex="0"><code class="language-bash">ursamu create plugin my-plugin
 </code></pre>
-<p>This generates all four files pre-named and pre-wired. Restart the server and<br>
+<h2>This generates all four files pre-named and pre-wired. Restart the server and<br>
 the plugin loads automatically. You can also copy <code>src/plugins/example/</code><br>
-directly — it is a fully working reference implementation.</p>
-<hr>
+directly — it is a fully working reference implementation.</h2>
 <h2>Plugin Interface</h2>
 <p>Every plugin implements <code>IPlugin</code>:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import type { IPlugin } from "../../@types/IPlugin.ts";
@@ -396,10 +393,6 @@ import "./commands.ts";
 <td>Query the main object database</td>
 </tr>
 <tr>
-<td><code>u.bb.*</code></td>
-<td>Bulletin board SDK</td>
-</tr>
-<tr>
 <td><code>u.chan.*</code></td>
 <td>Channel SDK</td>
 </tr>
@@ -458,8 +451,7 @@ export async function myRouteHandler(
   return json({ error: "Not Found" }, 404);
 }
 </code></pre>
-<p>All CORS headers are added automatically by the engine.</p>
-<hr>
+<h2>All CORS headers are added automatically by the engine.</h2>
 <h2>Custom Database</h2>
 <p>Create a typed <code>DBO&lt;T&gt;</code> collection in <code>db.ts</code>:</p>
 <pre class="language-typescript" tabindex="0"><code class="language-typescript">import { DBO } from "../../services/Database/database.ts";
@@ -520,8 +512,7 @@ export const myRecords = new DBO&lt;IMyRecord&gt;("server.my-plugin-records");
 
 const maxItems = getConfig&lt;number&gt;("plugins.my-plugin.maxItems") ?? 50;
 </code></pre>
-<p>Operators override values in <code>config/config.json</code> under the same key path.</p>
-<hr>
+<h2>Operators override values in <code>config/config.json</code> under the same key path.</h2>
 <h2>The Manifest File</h2>
 <p>Every plugin that will be shared or installed from GitHub <strong>must</strong> include an<br>
 <code>ursamu.plugin.json</code> at the plugin root. The install command reads this file to<br>
@@ -533,7 +524,10 @@ display details and populate the local registry.</p>
   "ursamu": "&gt;=1.0.0",
   "author": "Your Name",
   "license": "MIT",
-  "main": "index.ts"
+  "main": "index.ts",
+  "deps": [
+    { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+  ]
 }
 </code></pre>
 <table>
@@ -580,11 +574,69 @@ display details and populate the local registry.</p>
 <td>no</td>
 <td>Entry-point file, defaults to <code>"index.ts"</code></td>
 </tr>
+<tr>
+<td><code>deps</code></td>
+<td>no</td>
+<td>Array of transitive plugin dependencies — see below</td>
+</tr>
 </tbody>
 </table>
-<p>The <code>ursamu create plugin &lt;name&gt; --standalone</code> command generates this file<br>
-automatically when scaffolding a new publishable plugin project.</p>
-<hr>
+<h3><code>deps[]</code> entries</h3>
+<p>Each entry declares a plugin this one needs at runtime. The installer<br>
+resolves the full graph before writing anything.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>name</code></td>
+<td>yes</td>
+<td>Plugin slug — install folder name</td>
+</tr>
+<tr>
+<td><code>url</code></td>
+<td>yes</td>
+<td>Git URL the installer will clone</td>
+</tr>
+<tr>
+<td><code>ref</code></td>
+<td>no</td>
+<td>Git ref (tag, branch, commit)</td>
+</tr>
+<tr>
+<td><code>version</code></td>
+<td>no</td>
+<td>Semver range (e.g. <code>"^1.2.0"</code>, <code>"&gt;=1.0.0 &lt;2.0.0"</code>) checked against the dep’s own manifest <code>version</code></td>
+</tr>
+</tbody>
+</table>
+<p>The <code>version</code> field is optional and opt-in. When omitted, the dep installs<br>
+as before with no version check. When present, the installer reads the<br>
+dep’s <code>ursamu.plugin.json</code> after clone and aborts if its <code>version</code> does<br>
+not satisfy the range — or if two requesters ask for incompatible ranges.</p>
+<h3>Atomic installs</h3>
+<p><code>ensurePlugins</code> (and the bulk install path used on first startup) is<br>
+fail-fast across the entire manifest. If any plugin or transitive dep<br>
+fails for any of these reasons, the whole run aborts and rolls back:</p>
+<ul>
+<li>Clone failure or rename failure</li>
+<li>Unsafe plugin name (path traversal, reserved characters)</li>
+<li>Unsafe or unsupported clone URL</li>
+<li>Manifest version does not satisfy a requested <code>version:</code> range</li>
+<li>Two requesters declare incompatible <code>version:</code> ranges for the same dep</li>
+<li>Malformed semver in any range or manifest version</li>
+</ul>
+<p>On abort, nothing from the failed run is left on disk or in<br>
+<code>.registry.json</code>. Plugins installed in previous successful runs are not<br>
+touched. The installer throws a <code>PluginInstallError</code> (or one of its<br>
+subclasses) describing which entry failed and why.</p>
+<h2>The <code>ursamu create plugin &lt;name&gt; --standalone</code> command generates this file<br>
+automatically when scaffolding a new publishable plugin project.</h2>
 <h2>Installing Community Plugins</h2>
 <p>The plugin manager handles install, update, remove, and inspect operations:</p>
 <pre class="language-bash" tabindex="0"><code class="language-bash"># Install from a GitHub URL
@@ -633,12 +685,60 @@ ursamu plugin remove my-plugin
 <td>Full CRUD REST API, staff permission checks, in-game commands with switches</td>
 </tr>
 <tr>
-<td><code>src/plugins/bboards/</code></td>
-<td>Multi-resource REST API, per-user state (unread counts), admin-restricted mutations</td>
-</tr>
-<tr>
 <td><code>src/plugins/events/</code></td>
 <td>Sequential IDs, RSVP capacity enforcement, cancelled-event visibility rules, REST + in-game commands</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Plugin Docs Index</h2>
+<table>
+<thead>
+<tr>
+<th>Page</th>
+<th>Topic</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/ursamu/plugins/basics/">basics.md</a></td>
+<td><code>IPlugin</code> interface, lifecycle, auto-discovery, file layout</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/first-plugin/">first-plugin.md</a></td>
+<td>Step-by-step walkthrough of a complete plugin</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/commands/">commands.md</a></td>
+<td><code>addCmd</code> reference, patterns, switches, lockfuncs</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/database/">database.md</a></td>
+<td><code>DBO&lt;T&gt;</code> collections, queries, namespacing rules</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/configuration/">configuration.md</a></td>
+<td>Default config values, <code>getConfig</code>, env vars for secrets</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/hooks/">hooks.md</a></td>
+<td><code>gameHooks</code> event bus, scene/wiki/event/chargen hooks, <code>EventsService</code></td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/dependencies/">dependencies.md</a></td>
+<td>Sharing code between plugins, <code>deps[]</code> manifest entries</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/official-plugins/">official-plugins.md</a></td>
+<td>Plugin registry — channel, discord, jobs, events, bbs, wiki, mail, builder, chargen, help</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/chargen/">chargen.md</a></td>
+<td>Bundled chargen plugin — commands, hooks, REST API</td>
+</tr>
+<tr>
+<td><a href="/ursamu/plugins/events/">events.md</a></td>
+<td>Bundled events plugin — calendar, RSVPs, REST API</td>
 </tr>
 </tbody>
 </table>
@@ -726,11 +826,73 @@ ursamu plugin remove my-plugin
       
         
           
+        
+      
+        
           
         
       
         
           
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+        
+          
+        
+      
+        
+      
+        
+      
         
       
         

--- a/docs/_site/plugins/official-plugins/index.html
+++ b/docs/_site/plugins/official-plugins/index.html
@@ -1,0 +1,714 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Official Plugins | UrsaMU Documentation</title>
+  <meta name="description" content="The official UrsaMU plugin ecosystem — what each plugin provides, install requirements, and links to their documentation.">
+  <link rel="stylesheet" href="/ursamu/styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ursamu.github.io/ursamu/plugins/official-plugins/">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+
+<!-- Mobile overlay -->
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ═══ HEADER ══════════════════════════════════════════════════════ -->
+<header class="site-header">
+
+  <!-- Wordmark -->
+  <a href="/ursamu/" class="site-logo">
+    <span class="site-logo-name">UrsaMU</span>
+    <span class="site-logo-tag">docs</span>
+  </a>
+
+  <!-- Divider -->
+  <div class="header-divider"></div>
+
+  <!-- Top nav links -->
+  <nav class="header-nav" aria-label="Primary navigation">
+    
+    
+    
+    
+    <a href="/ursamu/guides/" class="header-nav-link">
+      Guides
+    </a>
+    
+    
+    
+    <a href="/ursamu/api/" class="header-nav-link">
+      API
+    </a>
+    
+    
+    
+    <a href="/ursamu/plugins/" class="header-nav-link active">
+      Plugins
+    </a>
+    
+    
+    
+    <a href="/ursamu/development/" class="header-nav-link">
+      Development
+    </a>
+    
+    
+  </nav>
+
+  <div class="header-spacer"></div>
+
+  <!-- Actions -->
+  <div class="header-actions">
+    <span class="header-version">mush 1.0.30</span>
+
+    <a href="https://github.com/ursamu/ursamu" class="header-icon-btn" title="GitHub" target="_blank" rel="noopener">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="currentColor">
+        <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
+      </svg>
+    </a>
+
+    <!-- Mobile menu button — CSS hides this above 1024px -->
+    <button class="menu-btn" id="menuBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+        <line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line>
+      </svg>
+    </button>
+  </div>
+
+</header>
+
+<!-- ═══ BODY ═════════════════════════════════════════════════════════ -->
+
+<!-- ── DOCS PAGE (3-column) ─────────────────────────────────────────── -->
+<div class="docs-layout">
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="docs-sidebar" id="docsSidebar" aria-label="Documentation navigation">
+
+    <!-- Search -->
+    <div class="sidebar-search">
+      <input class="sidebar-search-input" type="search" placeholder="Search docs…" id="sidebarSearch" aria-label="Search documentation">
+      <div class="search-results" id="searchResults" style="display:none;position:relative;margin-top:0.25rem;"></div>
+    </div>
+
+    <!-- Section: Overview -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Overview</div>
+
+      <a href="/ursamu/about/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+        About UrsaMU
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Getting Started -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Getting Started</div>
+
+      <a href="/ursamu/guides/installation/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"></path><path d="M2 17l10 5 10-5M2 12l10 5 10-5"></path></svg>
+        Installation
+      </a>
+      <a href="/ursamu/guides/user-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+        Player Guide
+      </a>
+      <a href="/ursamu/guides/admin-guide/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+        Admin Guide
+      </a>
+      <a href="/ursamu/guides/customization/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"></circle><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M4.93 19.07l1.41-1.41M19.07 19.07l-1.41-1.41M21 12h-2M5 12H3M12 21v-2M12 5V3"></path></svg>
+        Customization
+      </a>
+      <a href="/ursamu/guides/scripting/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Scripting Guide
+      </a>
+      <a href="/ursamu/guides/first-script/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path></svg>
+        Your First Script
+      </a>
+      <a href="/ursamu/guides/sdk-cookbook/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path></svg>
+        SDK Cookbook
+      </a>
+      <a href="/ursamu/guides/recipes/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+        Recipes
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Configuration -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Configuration</div>
+
+      <a href="/ursamu/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z"></path><path d="M12 8v4l3 3"></path></svg>
+        Overview
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: API Reference -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">API Reference</div>
+
+      <a href="/ursamu/api/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
+        Overview
+      </a>
+      <a href="/ursamu/api/core/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 9h6M9 12h6M9 15h4"></path></svg>
+        Core API
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Plugins -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Plugins</div>
+
+      <a href="/ursamu/plugins/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
+        Overview
+      </a>
+      <a href="/ursamu/plugins/basics/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"></circle><circle cx="19" cy="12" r="1"></circle><circle cx="5" cy="12" r="1"></circle></svg>
+        Basics
+      </a>
+      <a href="/ursamu/plugins/first-plugin/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+        First Plugin
+      </a>
+      <a href="/ursamu/plugins/commands/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+        Commands
+      </a>
+      <a href="/ursamu/plugins/hooks/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8.56 2.9A7 7 0 1 1 2.9 8.56"></path><polyline points="2 2 2 8 8 8"></polyline></svg>
+        Hooks
+      </a>
+      <a href="/ursamu/plugins/database/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+        Database
+      </a>
+      <a href="/ursamu/plugins/configuration/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path></svg>
+        Configuration
+      </a>
+      <a href="/ursamu/plugins/dependencies/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"></circle><circle cx="6" cy="6" r="3"></circle><path d="M6 21V9a9 9 0 0 0 9 9"></path></svg>
+        Dependencies
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Development -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Development</div>
+
+      <a href="/ursamu/development/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+        Overview
+      </a>
+      <a href="/ursamu/development/contributing/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
+        Contributing
+      </a>
+      <a href="/ursamu/extending/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
+        Extending
+      </a>
+      <a href="/ursamu/child-games/" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg>
+        Child Games
+      </a>
+    </div>
+
+    <div class="sidebar-divider"></div>
+
+    <!-- Section: Community -->
+    <div class="sidebar-section">
+      <div class="sidebar-section-title">Community</div>
+      <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+        GitHub
+      </a>
+      <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="sidebar-link">
+        <svg class="sidebar-link-icon" viewbox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"></path></svg>
+        Discord
+      </a>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT AREA -->
+  <div class="docs-content-wrap">
+    <main class="docs-content animate-in">
+
+      <!-- Breadcrumbs -->
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="/ursamu/">Home</a>
+        <span class="breadcrumbs-sep">›</span>
+        <span class="breadcrumbs-current">Official Plugins</span>
+      </nav>
+      
+
+      <!-- Page content -->
+      <article class="prose">
+        <h1>Official Plugins</h1>
+<h2>UrsaMU’s official plugins live in the <a href="https://github.com/UrsaMU">UrsaMU GitHub organization</a>.<br>
+They are listed in <code>src/plugins/plugins.manifest.json</code> and installed automatically on first run via <code>ensurePlugins</code>.</h2>
+<h2>Auto-installation</h2>
+<p>On startup, the engine reads <code>plugins.manifest.json</code> and fetches any plugin whose <code>ref</code> differs from the installed copy. No manual install step is required.</p>
+<p>The install run is <strong>atomic across the whole manifest</strong>: if any plugin or transitive dep fails to clone, has an unsafe name/URL, or violates a <code>version</code> semver range from its requester, the entire run aborts and rolls back. Disk and <code>src/plugins/.registry.json</code> are left exactly as they were — previously installed plugins are not touched.</p>
+<h2>To disable auto-install for a specific plugin, remove its entry from the manifest.</h2>
+<h2>Plugin Registry</h2>
+<table>
+<thead>
+<tr>
+<th>Plugin</th>
+<th>Repo</th>
+<th>Min Engine</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>channel</strong></td>
+<td><a href="https://github.com/UrsaMU/channel-plugin">UrsaMU/channel-plugin</a></td>
+<td><code>&gt;=1.9.27</code></td>
+<td>Channel system — alias dispatch, auto-join, <code>@chancreate</code>/<code>@chandestroy</code>/<code>@chanset</code>, message history</td>
+</tr>
+<tr>
+<td><strong>discord</strong></td>
+<td><a href="https://github.com/UrsaMU/discord-plugin">UrsaMU/discord-plugin</a></td>
+<td><code>&gt;=1.9.0</code></td>
+<td>Webhook-based Discord integration — channel bridging, presence, chargen events</td>
+</tr>
+<tr>
+<td><strong>jobs</strong></td>
+<td><a href="https://github.com/UrsaMU/jobs-plugin">UrsaMU/jobs-plugin</a></td>
+<td><code>&gt;=1.9.0</code></td>
+<td>Jobs and request system — player requests, staff commands, REST API</td>
+</tr>
+<tr>
+<td><strong>events</strong></td>
+<td><a href="https://github.com/UrsaMU/events-plugin">UrsaMU/events-plugin</a></td>
+<td><code>&gt;=1.9.2</code></td>
+<td>In-game event calendar with RSVP tracking and REST API</td>
+</tr>
+<tr>
+<td><strong>bbs</strong></td>
+<td><a href="https://github.com/UrsaMU/bbs-plugin">UrsaMU/bbs-plugin</a></td>
+<td><code>&gt;=1.9.0</code></td>
+<td>Myrddin-style bulletin boards — threading, categories, sticky posts, Discord webhooks</td>
+</tr>
+<tr>
+<td><strong>wiki</strong></td>
+<td><a href="https://github.com/UrsaMU/wiki-plugin">UrsaMU/wiki-plugin</a></td>
+<td><code>&gt;=1.9.0</code></td>
+<td>File-based markdown wiki — pages, search, history, backlinks</td>
+</tr>
+<tr>
+<td><strong>mail</strong></td>
+<td><a href="https://github.com/UrsaMU/mail-plugin">UrsaMU/mail-plugin</a></td>
+<td><code>&gt;=1.9.3</code></td>
+<td>In-game mail — drafts, reply/forward, folders, attachments, quota, REST API</td>
+</tr>
+<tr>
+<td><strong>builder</strong></td>
+<td><a href="https://github.com/UrsaMU/builder-plugin">UrsaMU/builder-plugin</a></td>
+<td><code>&gt;=1.9.5</code></td>
+<td>World-building commands — <code>@dig</code>, <code>@open</code>, <code>@link</code>, <code>@describe</code>, <code>@examine</code>, REST API</td>
+</tr>
+<tr>
+<td><strong>chargen</strong></td>
+<td>Bundled — <code>src/plugins/chargen/</code></td>
+<td><code>&gt;=1.8.0</code></td>
+<td>Character generation scaffolding — hooks into the connection flow to guide new players through stat selection</td>
+</tr>
+<tr>
+<td><strong>help</strong></td>
+<td><a href="https://github.com/UrsaMU/help-plugin">UrsaMU/help-plugin</a></td>
+<td><code>&gt;=1.9.0</code></td>
+<td>API-first help system — file + DB + command providers, <code>+help/set</code>/<code>+help/del</code>, REST API, per-plugin help dirs</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h2>Adding a Plugin</h2>
+<p>Any GitHub repo can be added to the manifest:</p>
+<pre class="language-json" tabindex="0"><code class="language-json">{
+  "plugins": [
+    {
+      "name": "my-plugin",
+      "url": "https://github.com/example/my-plugin",
+      "ref": "v1.0.0",
+      "description": "What this plugin does.",
+      "ursamu": "&gt;=1.9.27",
+      "deps": [
+        { "name": "jobs", "url": "https://github.com/UrsaMU/jobs-plugin", "version": "^1.9.0" }
+      ]
+    }
+  ]
+}
+</code></pre>
+<p>Each <code>deps[]</code> entry may include an optional <code>version</code> semver range (e.g. <code>"^1.2.0"</code>, <code>"&gt;=1.0.0 &lt;2.0.0"</code>) — the installer cross-checks it against the dep’s own manifest <code>version</code> and aborts the run on mismatch. Omit <code>version</code> for backwards-compatible behavior.</p>
+<p>Or use the CLI:</p>
+<pre class="language-bash" tabindex="0"><code class="language-bash">deno run -A jsr:@ursamu/cli@0.1.2/plugin install https://github.com/example/my-plugin
+</code></pre>
+<p>See <a href="/ursamu/plugins/first-plugin/">Building a Plugin</a> to publish your own.</p>
+
+      </article>
+
+      <!-- Prev / Next navigation -->
+      
+      
+      
+      
+      
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+        
+      
+        
+          
+          
+        
+      
+
+      
+      <nav class="page-nav" aria-label="Page navigation">
+        
+          <a href="/ursamu/plugins/hooks/" class="page-nav-btn prev">
+            <span class="page-nav-label">← Previous</span>
+            <span class="page-nav-title"></span>
+          </a>
+        
+
+        
+      </nav>
+      
+
+    </main>
+
+    <!-- FOOTER -->
+    <footer class="site-footer">
+      <div>
+        <strong style="color:var(--text-muted)">UrsaMU</strong>
+        &nbsp;—&nbsp;MIT License • © 2025
+      </div>
+      <div class="footer-links">
+        <a href="/ursamu/guides/installation/">Installation</a>
+        <a href="/ursamu/api/">API</a>
+        <a href="/ursamu/plugins/">Plugins</a>
+        <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener">GitHub</a>
+      </div>
+    </footer>
+  </div>
+
+  <!-- RIGHT: TABLE OF CONTENTS (auto-built by JS) -->
+  <aside class="docs-toc" id="docsToc" aria-label="On this page">
+    <div class="toc-title">On this page</div>
+    <ul class="toc-list" id="tocList"></ul>
+  </aside>
+
+</div><!-- /docs-layout -->
+
+
+<!-- ═══ SCRIPTS ══════════════════════════════════════════════════════ -->
+<script>
+(function() {
+  // ── Mobile sidebar toggle ──────────────────────────────────────────
+  const menuBtn = document.getElementById('menuBtn');
+  const sidebar = document.getElementById('docsSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+
+  function openSidebar() {
+    sidebar && sidebar.classList.add('open');
+    overlay && overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeSidebar() {
+    sidebar && sidebar.classList.remove('open');
+    overlay && overlay.classList.remove('open');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', function() {
+    if (sidebar && sidebar.classList.contains('open')) closeSidebar();
+    else openSidebar();
+  });
+
+  overlay && overlay.addEventListener('click', closeSidebar);
+
+  // Close on resize past mobile breakpoint
+  window.addEventListener('resize', function() {
+    if (window.innerWidth >= 1024) closeSidebar();
+  });
+
+  // ── Auto table of contents ─────────────────────────────────────────
+  const tocList = document.getElementById('tocList');
+  const article = document.querySelector('article.prose');
+
+  if (tocList && article) {
+    const headings = article.querySelectorAll('h2, h3');
+
+    if (headings.length === 0) {
+      const tocEl = document.getElementById('docsToc');
+      if (tocEl) tocEl.style.display = 'none';
+    } else {
+      headings.forEach(function(h, i) {
+        // Ensure heading has an ID
+        if (!h.id) {
+          h.id = 'section-' + i + '-' + h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+
+        const li = document.createElement('li');
+        li.className = 'toc-item' + (h.tagName === 'H3' ? ' toc-h3' : '');
+
+        const a = document.createElement('a');
+        a.href = '#' + h.id;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocList.appendChild(li);
+      });
+
+      // Highlight active section on scroll
+      const tocLinks = tocList.querySelectorAll('a');
+
+      function updateToc() {
+        let activeIndex = 0;
+        const scrollTop = window.scrollY + 80;
+
+        headings.forEach(function(h, i) {
+          if (h.offsetTop <= scrollTop) activeIndex = i;
+        });
+
+        tocList.querySelectorAll('.toc-item').forEach(function(item, i) {
+          item.classList.toggle('active', i === activeIndex);
+        });
+      }
+
+      window.addEventListener('scroll', updateToc, { passive: true });
+      updateToc();
+    }
+  }
+
+  // ── Sidebar search (client-side filter) ───────────────────────────
+  const searchInput = document.getElementById('sidebarSearch');
+  const sidebarLinks = sidebar ? sidebar.querySelectorAll('.sidebar-link') : [];
+
+  if (searchInput && sidebarLinks.length) {
+    searchInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase().trim();
+
+      sidebarLinks.forEach(function(link) {
+        const text = link.textContent.toLowerCase();
+        const section = link.closest('.sidebar-section');
+        if (!query) {
+          link.style.display = '';
+        } else {
+          link.style.display = text.includes(query) ? '' : 'none';
+        }
+      });
+
+      // Hide empty section titles
+      if (sidebar) {
+        sidebar.querySelectorAll('.sidebar-section').forEach(function(sec) {
+          const visibleLinks = sec.querySelectorAll('.sidebar-link:not([style*="none"])');
+          sec.style.display = (!query || visibleLinks.length > 0) ? '' : 'none';
+        });
+      }
+    });
+  }
+
+  // ── Scroll active sidebar link into view ───────────────────────────
+  const activeLink = sidebar && sidebar.querySelector('.sidebar-link.active');
+  if (activeLink) {
+    activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }
+})();
+</script>
+
+
+
+</body></html>

--- a/docs/_site/sitemap.xml
+++ b/docs/_site/sitemap.xml
@@ -2,110 +2,194 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ursamu.github.io/ursamu/</loc>
-    <lastmod>2026-03-16T19:48:28.137Z</lastmod>
+    <lastmod>2026-08-05T21:18:45.301Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/about/</loc>
-    <lastmod>2026-03-16T22:29:05.863Z</lastmod>
+    <lastmod>2026-08-05T21:18:45.300Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/api/</loc>
-    <lastmod>2026-03-16T22:28:10.218Z</lastmod>
+    <lastmod>2026-06-17T17:09:09.004Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/api/core/</loc>
-    <lastmod>2026-03-16T22:28:35.200Z</lastmod>
+    <lastmod>2026-07-25T17:52:39.348Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/api/rest/</loc>
+    <lastmod>2026-07-29T04:18:02.176Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/audit-holes/</loc>
+    <lastmod>2026-06-03T20:26:45.800Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/child-games/</loc>
-    <lastmod>2026-03-16T22:28:52.858Z</lastmod>
+    <lastmod>2026-08-05T21:18:45.300Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/configuration/</loc>
-    <lastmod>2026-01-01T15:56:35.687Z</lastmod>
+    <lastmod>2026-07-29T04:18:02.177Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/development/</loc>
-    <lastmod>2026-01-01T15:56:35.687Z</lastmod>
+    <lastmod>2026-06-17T17:09:09.005Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/development/contributing/</loc>
-    <lastmod>2026-01-01T15:56:35.688Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.811Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/development/testing/</loc>
+    <lastmod>2026-06-03T20:26:45.808Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/discord-webhook/</loc>
+    <lastmod>2026-06-03T20:26:45.789Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/extending/</loc>
-    <lastmod>2026-03-16T22:27:51.419Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.872Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/</loc>
-    <lastmod>2026-03-16T17:42:05.321Z</lastmod>
+    <lastmod>2026-07-29T04:18:02.177Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/admin-guide/</loc>
-    <lastmod>2026-03-17T00:58:34.057Z</lastmod>
+    <lastmod>2026-08-05T21:18:40.772Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/cli/</loc>
+    <lastmod>2026-08-05T21:18:45.300Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/commands/</loc>
+    <lastmod>2026-06-03T20:26:45.843Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/customization/</loc>
-    <lastmod>2026-01-01T15:56:35.692Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.842Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/debugging/</loc>
+    <lastmod>2026-06-03T20:26:45.865Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/deployment/</loc>
+    <lastmod>2026-08-05T21:18:45.301Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/docker/</loc>
+    <lastmod>2026-07-25T17:52:39.348Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/first-script/</loc>
-    <lastmod>2026-03-16T18:53:42.209Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.862Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/gameclock/</loc>
+    <lastmod>2026-06-03T20:26:45.850Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/help-authoring/</loc>
+    <lastmod>2026-06-03T20:26:45.860Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/installation/</loc>
-    <lastmod>2026-03-16T17:46:08.467Z</lastmod>
+    <lastmod>2026-08-05T21:18:45.301Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/lock-expressions/</loc>
+    <lastmod>2026-06-03T20:26:45.840Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/password-reset/</loc>
+    <lastmod>2026-06-03T20:26:45.851Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/recipes/</loc>
-    <lastmod>2026-03-16T18:55:49.988Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.836Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/scenes/</loc>
+    <lastmod>2026-06-03T20:26:45.834Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/scripting/</loc>
-    <lastmod>2026-03-16T18:53:10.400Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.871Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/sdk-cookbook/</loc>
-    <lastmod>2026-03-16T18:54:58.935Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.853Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/softcoding/</loc>
+    <lastmod>2026-07-29T04:18:02.177Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/guides/user-guide/</loc>
-    <lastmod>2026-03-17T00:58:28.524Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.855Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/guides/wiki/</loc>
+    <lastmod>2026-06-03T20:26:45.848Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/llms/</loc>
+    <lastmod>2026-06-03T20:26:45.791Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/market-research-2026-04/</loc>
+    <lastmod>2026-06-03T20:26:45.804Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/mush_compatibility/</loc>
-    <lastmod>2026-03-16T18:56:35.581Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.796Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/</loc>
-    <lastmod>2026-03-17T01:48:22.264Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.821Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/basics/</loc>
-    <lastmod>2026-03-17T01:45:47.086Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.816Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/plugins/chargen/</loc>
+    <lastmod>2026-06-03T20:26:45.829Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/commands/</loc>
-    <lastmod>2026-03-17T01:49:34.832Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.817Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/configuration/</loc>
-    <lastmod>2026-03-17T01:46:35.726Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.823Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/database/</loc>
-    <lastmod>2026-03-17T01:46:15.529Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.832Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/dependencies/</loc>
-    <lastmod>2026-03-17T01:47:29.939Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.819Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/plugins/events/</loc>
+    <lastmod>2026-06-03T20:26:45.831Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/first-plugin/</loc>
-    <lastmod>2026-03-17T01:48:56.020Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.825Z</lastmod>
   </url>
   <url>
     <loc>https://ursamu.github.io/ursamu/plugins/hooks/</loc>
-    <lastmod>2026-03-17T01:47:05.382Z</lastmod>
+    <lastmod>2026-06-03T20:26:45.827Z</lastmod>
+  </url>
+  <url>
+    <loc>https://ursamu.github.io/ursamu/plugins/official-plugins/</loc>
+    <lastmod>2026-08-05T21:18:45.302Z</lastmod>
   </url>
 </urlset>

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -397,26 +397,59 @@ video {
   display: none;
 }
 
+/*
+   * Docs site tokens — same violet-night family as
+   * packages/web/ui/src/assets/staff-theme.css and
+   * packages/site/public/css/tokens.css (design.md).
+   * Flat surfaces, hairline borders, no multi-stop glow.
+   */
+
 :root {
-    /* UrsaMU Brand — matched to github banner */
-    --bg:              #0c0a1e;
-    --bg-sidebar:      #0f0d24;
-    --bg-surface:      #15122e;
-    --bg-card:         rgba(21, 18, 46, 0.7);
-    --bg-code:         #08071a;
-    --border:          rgba(139, 92, 246, 0.12);
-    --border-hover:    rgba(139, 92, 246, 0.3);
-    --border-active:   rgba(167, 139, 250, 0.5);
-    --text:            #ddd9f5;
-    --text-muted:      #8480aa;
-    --text-dim:        #4e4a6b;
-    --primary:         #8b5cf6;
+    /* packages/web/design.md §2 — violet night (source of truth) */
+    --bg:              #0b0a12;
+    --bg-elevated:     #12101c;
+    --bg-sidebar:      #12101c;
+    --bg-surface:      #161422;
+    --bg-surface-2:    #1c1929;
+    --bg-card:         #161422;
+    --bg-code:         #0e0c16;
+    --border:          #3a3554;
+    --border-subtle:   #2a2640;
+    --border-strong:   #5a5480;
+    --border-hover:    #5a5480;
+    --border-active:   rgba(167, 139, 250, 0.45);
+    --text:            #f0eef8;
+    --text-secondary:  #c4c0d4;
+    --text-muted:      #b0a9c4;
+    --text-dim:        #7a7494;
+    --text-on-primary: #ffffff;
+    --text-inverse:    #0b0a12;
+    --primary:         #a78bfa;
     --primary-light:   #a78bfa;
     --primary-bright:  #c4b5fd;
-    --primary-glow:    rgba(139, 92, 246, 0.2);
+    --primary-hover:   #c4b5fd;
+    --primary-muted:   rgba(167, 139, 250, 0.16);
+    --primary-border:  rgba(167, 139, 250, 0.45);
+    --btn-primary-bg:  #6d28d9;
+    --btn-primary-bg-hover: #7c3aed;
+    --btn-primary-fg:  var(--text-on-primary);
+    --success:         #3ecf8e;
+    --warning:         #e6b84d;
+    --error:           #f07178;
+    --info:            #7eb8ff;
+    --radius-xs:       2px;
+    --radius-sm:       4px;
+    --radius-md:       6px;
+    --radius-lg:       8px;
+    --radius:          var(--radius-md);
+    --gutter:          1.25rem;
     --sidebar-width:   280px;
     --toc-width:       220px;
-    --header-height:   72px;
+    --header-height:   56px;
+    --font-ui:         Inter, ui-sans-serif, system-ui, sans-serif;
+    --font-mono:       ui-monospace, "SFMono-Regular", "JetBrains Mono",
+                       Menlo, Consolas, monospace;
+    color-scheme: dark;
   }
 
 * {
@@ -431,24 +464,20 @@ html {
 body {
     background-color: var(--bg);
     color: var(--text);
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: var(--font-ui);
     font-size: 15px;
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-image:
-      radial-gradient(ellipse 80% 60% at 0% -10%, rgba(109, 40, 217, 0.18) 0%, transparent 60%),
-      radial-gradient(ellipse 60% 40% at 100% 110%, rgba(79, 29, 149, 0.15) 0%, transparent 50%);
-    background-attachment: fixed;
     min-height: 100vh;
   }
 
 ::-moz-selection {
-    background: rgba(139, 92, 246, 0.35);
+    background: var(--primary-muted);
   }
 
 ::selection {
-    background: rgba(139, 92, 246, 0.35);
+    background: var(--primary-muted);
   }
 
 *, ::before, ::after{
@@ -1099,10 +1128,6 @@ body {
   visibility: visible;
 }
 
-.invisible{
-  visibility: hidden;
-}
-
 .static{
   position: static;
 }
@@ -1111,8 +1136,20 @@ body {
   position: fixed;
 }
 
+.absolute{
+  position: absolute;
+}
+
+.relative{
+  position: relative;
+}
+
 .sticky{
   position: sticky;
+}
+
+.isolate{
+  isolation: isolate;
 }
 
 .block{
@@ -1127,6 +1164,10 @@ body {
   display: table;
 }
 
+.grid{
+  display: grid;
+}
+
 .contents{
   display: contents;
 }
@@ -1139,12 +1180,32 @@ body {
   resize: both;
 }
 
+.uppercase{
+  text-transform: uppercase;
+}
+
 .lowercase{
   text-transform: lowercase;
 }
 
+.italic{
+  font-style: italic;
+}
+
+.shadow{
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .filter{
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.transition{
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 /* ─── LAYOUT ─────────────────────────────────────────────────────── */
@@ -1162,19 +1223,22 @@ body {
   height: calc(100vh - var(--header-height));
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--bg-sidebar);
-  border-right: 1px solid var(--border);
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-subtle);
   padding: 1.25rem 0 3rem;
   display: flex;
   flex-direction: column;
   gap: 0;
   scrollbar-width: thin;
-  scrollbar-color: rgba(139,92,246,0.2) transparent;
+  scrollbar-color: var(--border) transparent;
 }
 
 .docs-sidebar::-webkit-scrollbar { width: 4px; }
 
-.docs-sidebar::-webkit-scrollbar-thumb { background: rgba(139,92,246,0.2); border-radius: 4px; }
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-sm);
+}
 
 .docs-content-wrap {
   flex: 1;
@@ -1216,10 +1280,8 @@ body {
   height: var(--header-height);
   display: flex;
   align-items: center;
-  background: rgba(12, 10, 30, 0.88);
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
   padding: 0 2rem;
   gap: 1.25rem;
 }
@@ -1248,11 +1310,11 @@ body {
   font-size: 0.68rem;
   font-weight: 600;
   letter-spacing: 0.05em;
-  color: var(--primary-light);
-  background: rgba(139, 92, 246, 0.12);
-  border: 1px solid rgba(139, 92, 246, 0.25);
+  color: var(--primary);
+  background: var(--primary-muted);
+  border: 1px solid var(--primary-border);
   padding: 0.15rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   align-self: center;
   margin-top: 1px;
 }
@@ -1281,18 +1343,18 @@ body {
   color: var(--text-muted);
   text-decoration: none;
   padding: 0.4rem 0.8rem;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   transition: color 0.15s, background 0.15s;
   white-space: nowrap;
 }
 
 .header-nav-link:hover {
   color: var(--text);
-  background: rgba(139, 92, 246, 0.1);
+  background: var(--primary-muted);
 }
 
 .header-nav-link.active {
-  color: var(--primary-light);
+  color: var(--primary);
 }
 
 .header-spacer { flex: 1; }
@@ -1309,7 +1371,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   transition: color 0.15s, background 0.15s;
   text-decoration: none;
@@ -1318,7 +1380,7 @@ body {
 
 .header-icon-btn:hover {
   color: var(--text);
-  background: rgba(255,255,255,0.06);
+  background: var(--bg-surface-2);
 }
 
 .header-version {
@@ -1342,14 +1404,14 @@ body {
   background: none;
   border: none;
   cursor: pointer;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   transition: color 0.15s, background 0.15s;
 }
 
 .menu-btn:hover {
   color: var(--text);
-  background: rgba(255,255,255,0.06);
+  background: var(--bg-surface-2);
 }
 
 @media (max-width: 1023px) {
@@ -1365,24 +1427,23 @@ body {
 
 .sidebar-search-input {
   width: 100%;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
   padding: 0.45rem 0.75rem 0.45rem 2.2rem;
   font-size: 0.8rem;
   color: var(--text);
   font-family: inherit;
   outline: none;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%236b68a8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E");
+  transition: border-color 0.15s, background 0.15s;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23b0a9c4' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 0.6rem center;
 }
 
 .sidebar-search-input:focus {
-  border-color: var(--border-hover);
-  background-color: rgba(255,255,255,0.06);
-  box-shadow: 0 0 0 3px rgba(139,92,246,0.1);
+  border-color: var(--primary-border);
+  background-color: var(--bg-surface-2);
 }
 
 .sidebar-search-input::-moz-placeholder {
@@ -1422,12 +1483,12 @@ body {
 
 .sidebar-link:hover {
   color: var(--text);
-  background: rgba(139, 92, 246, 0.07);
+  background: var(--primary-muted);
 }
 
 .sidebar-link.active {
-  color: var(--primary-bright);
-  background: rgba(139, 92, 246, 0.1);
+  color: var(--primary);
+  background: var(--primary-muted);
   border-left-color: var(--primary);
   font-weight: 550;
 }
@@ -1475,7 +1536,7 @@ body {
 }
 
 .breadcrumbs-current {
-  color: var(--primary-light);
+  color: var(--primary);
   font-weight: 500;
 }
 
@@ -1517,7 +1578,7 @@ body {
 }
 
 .toc-item.active a {
-  color: var(--primary-light);
+  color: var(--primary);
   border-left-color: var(--primary);
 }
 
@@ -1538,10 +1599,7 @@ body {
   line-height: 1.2;
   margin-bottom: 0.75rem;
   margin-top: 0;
-  background: linear-gradient(135deg, #fff 30%, var(--primary-light) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text);
 }
 
 .prose h2 {
@@ -1560,7 +1618,7 @@ body {
   font-weight: 600;
   margin-top: 2rem;
   margin-bottom: 0.5rem;
-  color: rgba(221, 217, 245, 0.9);
+  color: var(--text-secondary);
 }
 
 .prose h4 {
@@ -1568,49 +1626,49 @@ body {
   font-weight: 600;
   margin-top: 1.5rem;
   margin-bottom: 0.35rem;
-  color: rgba(221, 217, 245, 0.8);
+  color: var(--text-secondary);
 }
 
 .prose p {
   margin-bottom: 1.1rem;
-  color: rgba(221, 217, 245, 0.85);
+  color: var(--text-secondary);
 }
 
 .prose a {
-  color: var(--primary-light);
+  color: var(--primary);
   text-decoration: none;
-  border-bottom: 1px solid rgba(167, 139, 250, 0.25);
+  border-bottom: 1px solid var(--primary-border);
   transition: color 0.15s, border-color 0.15s;
 }
 
 .prose a:hover {
-  color: var(--primary-bright);
-  border-bottom-color: rgba(196, 181, 253, 0.5);
+  color: var(--primary-hover);
+  border-bottom-color: var(--primary-hover);
 }
 
 .prose code {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 0.82em;
-  background: rgba(139, 92, 246, 0.12);
-  border: 1px solid rgba(139, 92, 246, 0.2);
+  background: var(--primary-muted);
+  border: 1px solid var(--border-subtle);
   color: var(--primary-bright);
   padding: 0.15em 0.45em;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
 }
 
 .prose pre {
   background: var(--bg-code);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   padding: 1.25rem 1.5rem;
   overflow-x: auto;
   margin: 1.5rem 0;
   position: relative;
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 0.83rem;
   line-height: 1.7;
   scrollbar-width: thin;
-  scrollbar-color: rgba(139,92,246,0.2) transparent;
+  scrollbar-color: var(--border) transparent;
 }
 
 .prose pre code {
@@ -1623,12 +1681,15 @@ body {
 
 .prose pre::-webkit-scrollbar { height: 4px; }
 
-.prose pre::-webkit-scrollbar-thumb { background: rgba(139,92,246,0.25); border-radius: 4px; }
+.prose pre::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-sm);
+}
 
 .prose ul, .prose ol {
   padding-left: 1.5rem;
   margin-bottom: 1.1rem;
-  color: rgba(221, 217, 245, 0.85);
+  color: var(--text-secondary);
 }
 
 .prose li {
@@ -1641,16 +1702,16 @@ body {
 }
 
 .prose em {
-  color: rgba(221, 217, 245, 0.8);
+  color: var(--text-secondary);
 }
 
 .prose blockquote {
   border-left: 3px solid var(--primary);
   margin: 1.5rem 0;
   padding: 0.75rem 1.25rem;
-  background: rgba(139, 92, 246, 0.07);
-  border-radius: 0 8px 8px 0;
-  color: rgba(221, 217, 245, 0.75);
+  background: var(--primary-muted);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -1664,26 +1725,26 @@ body {
 }
 
 .prose th {
-  background: rgba(139, 92, 246, 0.1);
-  color: var(--primary-bright);
+  background: var(--bg-surface-2);
+  color: var(--primary);
   font-weight: 600;
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   padding: 0.6rem 1rem;
   text-align: left;
-  border-bottom: 1px solid var(--border-hover);
+  border-bottom: 1px solid var(--border);
 }
 
 .prose td {
   padding: 0.6rem 1rem;
-  border-bottom: 1px solid var(--border);
-  color: rgba(221, 217, 245, 0.85);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
 }
 
 .prose tr:last-child td { border-bottom: none; }
 
-.prose tr:hover td { background: rgba(139, 92, 246, 0.04); }
+.prose tr:hover td { background: var(--primary-muted); }
 
 .prose hr {
   border: none;
@@ -1705,20 +1766,20 @@ body {
 .page-nav-btn {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.875rem 1.25rem;
+  gap: 0.2rem;
+  padding: 0.75rem 1rem;
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   text-decoration: none;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.15s, background 0.15s;
   max-width: 48%;
   min-width: 0;
 }
 
 .page-nav-btn:hover {
-  border-color: var(--border-hover);
-  background: rgba(139, 92, 246, 0.07);
+  border-color: var(--border-strong);
+  background: var(--bg-surface-2);
 }
 
 .page-nav-btn.next { text-align: right; margin-left: auto; }
@@ -1734,7 +1795,7 @@ body {
 .page-nav-title {
   font-size: 0.88rem;
   font-weight: 600;
-  color: var(--primary-light);
+  color: var(--primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1742,283 +1803,344 @@ body {
 
 /* ─── HOMEPAGE ────────────────────────────────────────────────────── */
 
+/*
+ * One pattern only: .home-stack (raised list / code panel).
+ * design.md: flat surfaces, hairline borders, no card mosaics.
+ */
+
 .home-hero {
   text-align: center;
-  padding: 4rem 2rem 3rem;
-  max-width: 900px;
+  padding: 3rem var(--gutter) 2rem;
+  max-width: 40rem;
   margin: 0 auto;
-  position: relative;
+}
+
+.home-hero__chip {
+  display: inline-block;
+  margin: 0 0 1rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--primary-muted);
+  border: 1px solid var(--primary-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--primary);
+  letter-spacing: 0.02em;
 }
 
 .home-hero h1 {
-  font-size: clamp(2.5rem, 6vw, 4.5rem);
-  font-weight: 900;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-  margin-bottom: 1.25rem;
-  background: linear-gradient(135deg, #ffffff 0%, #c4b5fd 50%, #8b5cf6 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0 0 0.85rem;
+  color: var(--text);
 }
 
-.home-hero p {
-  font-size: 1.1rem;
-  color: var(--text-muted);
-  max-width: 600px;
-  margin: 0 auto 2.5rem;
-  line-height: 1.7;
+.home-hero__lede {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  max-width: 34rem;
+  margin: 0 auto 1.75rem;
+  line-height: 1.6;
+}
+
+.home-hero__lede strong {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .home-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   justify-content: center;
   flex-wrap: wrap;
 }
 
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.7rem 1.5rem;
-  background: linear-gradient(135deg, var(--primary) 0%, #5b21b6 100%);
-  color: white;
-  font-size: 0.88rem;
-  font-weight: 600;
-  border-radius: 8px;
-  text-decoration: none;
-  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.35);
-  cursor: pointer;
-}
-
-.btn-primary:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 28px rgba(139, 92, 246, 0.45);
-}
-
+.btn-primary,
 .btn-secondary {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.4rem;
-  padding: 0.7rem 1.5rem;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border);
-  color: var(--text);
-  font-size: 0.88rem;
-  font-weight: 600;
-  border-radius: 8px;
+  min-height: 2.25rem;
+  padding: 0.45rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
   text-decoration: none;
-  transition: background 0.15s, border-color 0.15s;
   cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-primary {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border: 1px solid transparent;
+}
+
+.btn-primary:hover {
+  background: var(--btn-primary-bg-hover);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border-strong);
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: var(--border-hover);
+  background: var(--bg-surface-2);
 }
 
-/* ─── FEATURE CARDS ───────────────────────────────────────────────── */
+/* Stack sections — sole homepage content chrome */
 
-.feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1rem;
-  max-width: 900px;
-  margin: 2.5rem auto;
-  padding: 0 1rem;
+.home-stack {
+  max-width: 40rem;
+  margin: 0 auto 2.75rem;
+  padding: 0 var(--gutter);
 }
 
-.feature-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  transition: border-color 0.2s, background 0.2s, transform 0.2s;
-  backdrop-filter: blur(8px);
-  text-decoration: none;
-  display: block;
+.home-stack--end {
+  margin-bottom: 4.5rem;
 }
 
-.feature-card:hover {
-  border-color: var(--border-hover);
-  background: rgba(139, 92, 246, 0.07);
-  transform: translateY(-2px);
+.home-stack__head {
+  margin-bottom: 0.85rem;
 }
 
-.feature-card-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  background: rgba(139, 92, 246, 0.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 1rem;
+.home-stack__kicker {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 0.3rem;
 }
 
-.feature-card-icon svg {
-  width: 20px;
-  height: 20px;
-  stroke: var(--primary-light);
-  fill: none;
-  stroke-width: 1.75;
-}
-
-.feature-card h3 {
-  font-size: 0.95rem;
-  font-weight: 700;
+.home-stack__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
   color: var(--text);
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.35rem;
 }
 
-.feature-card p {
-  font-size: 0.82rem;
-  color: var(--text-muted);
-  line-height: 1.6;
+.home-stack__lede {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
   margin: 0;
+  max-width: 34rem;
 }
 
-/* ─── QUICK START BLOCK ───────────────────────────────────────────── */
-
-.quickstart-block {
-  max-width: 680px;
-  margin: 0 auto 3rem;
-  padding: 0 1rem;
-}
-
-.quickstart-inner {
-  background: var(--bg-code);
+.home-stack__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
-.quickstart-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.6rem 1rem;
-  background: rgba(255,255,255,0.03);
-  border-bottom: 1px solid var(--border);
-}
-
-.quickstart-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.quickstart-code {
-  padding: 1rem 1.25rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.85rem;
-  line-height: 1.7;
-  color: var(--text-muted);
-  margin: 0;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-}
-
-.quickstart-code .cmd { color: var(--primary-light); }
-
-.quickstart-code .comment { color: var(--text-dim); }
-
-/* ─── SECTION CARDS (homepage) ────────────────────────────────────── */
-
-.home-section-grid {
+.home-stack__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1px;
-  background: var(--border);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden;
-  max-width: 900px;
-  margin: 0 auto 4rem;
+  grid-template-columns: 7.5rem 1fr;
+  gap: 0.75rem 1.25rem;
+  align-items: baseline;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 0;
 }
 
-.home-section-card {
-  background: var(--bg-sidebar);
-  padding: 1.25rem 1.5rem;
-  text-decoration: none;
-  transition: background 0.15s;
+.home-stack__row:last-child {
+  border-bottom: none;
 }
 
-.home-section-card:hover {
-  background: rgba(139,92,246,0.08);
-}
-
-.home-section-card h4 {
-  font-size: 0.88rem;
+.home-stack__row dt {
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 0.35rem;
+  margin: 0;
+  line-height: 1.4;
 }
 
-.home-section-card p {
-  font-size: 0.77rem;
-  color: var(--text-muted);
+.home-stack__row dd {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
 }
 
-/* ─── VERSION BADGE ───────────────────────────────────────────────── */
+.home-stack__row code,
+.home-stack__pre .cmd {
+  font-family: var(--font-mono);
+}
 
-.version-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.6rem;
-  background: rgba(139,92,246,0.12);
-  border: 1px solid rgba(139,92,246,0.25);
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--primary-light);
-  letter-spacing: 0.02em;
-  margin-bottom: 1.5rem;
+.home-stack__row code {
+  font-size: 0.75rem;
+  color: var(--primary);
+  background: var(--primary-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.05em 0.35em;
+}
+
+.home-stack__list--links > li {
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 0;
+}
+
+.home-stack__list--links > li:last-child {
+  border-bottom: none;
+}
+
+.home-stack__link {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 0.75rem 1rem;
   text-decoration: none;
-  cursor: default;
+  transition: background 0.12s;
+}
+
+.home-stack__link:hover {
+  background: var(--primary-muted);
+}
+
+.home-stack__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+  min-width: 0;
+}
+
+.home-stack__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.home-stack__link:hover .home-stack__label {
+  color: var(--primary);
+}
+
+.home-stack__desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.home-stack__path {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  letter-spacing: -0.01em;
+}
+
+.home-stack__link:hover .home-stack__path {
+  color: var(--primary);
+}
+
+/* Code panel (quick start) — same column, code elevation */
+
+.home-stack__code {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.home-stack__code-bar {
+  padding: 0.5rem 0.9rem;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.home-stack__pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  overflow-x: auto;
+}
+
+.home-stack__pre .cmd {
+  color: var(--primary);
+}
+
+.home-stack__pre .cmt {
+  color: var(--text-dim);
+}
+
+@media (max-width: 560px) {
+  .home-stack__row {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .home-stack__link {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
 }
 
 /* ─── CALLOUT BOXES ───────────────────────────────────────────────── */
 
 .callout {
-  border-radius: 10px;
-  padding: 1rem 1.25rem;
-  margin: 1.5rem 0;
-  border: 1px solid;
-  font-size: 0.88rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1rem;
+  margin: 1.25rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
 }
 
 .callout-note {
-  background: rgba(139,92,246,0.07);
-  border-color: rgba(139,92,246,0.25);
-  color: rgba(221,217,245,0.85);
+  border-left-color: var(--primary);
 }
 
 .callout-warning {
-  background: rgba(245,158,11,0.07);
-  border-color: rgba(245,158,11,0.25);
-  color: rgba(253,230,138,0.9);
+  border-left-color: var(--warning);
 }
 
 .callout-tip {
-  background: rgba(16,185,129,0.07);
-  border-color: rgba(16,185,129,0.25);
-  color: rgba(167,243,208,0.9);
+  border-left-color: var(--success);
+}
+
+.callout-error {
+  border-left-color: var(--error);
+}
+
+.callout-info {
+  border-left-color: var(--info);
 }
 
 .callout-title {
-  font-weight: 700;
-  margin-bottom: 0.35rem;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--text);
 }
 
 /* ─── FOOTER ──────────────────────────────────────────────────────── */
@@ -2103,11 +2225,10 @@ body {
   right: 0;
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   margin-top: 0.35rem;
   overflow: hidden;
   z-index: 999;
-  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
   max-height: 320px;
   overflow-y: auto;
 }
@@ -2123,7 +2244,7 @@ body {
 }
 
 .search-result-item:hover {
-  background: rgba(139,92,246,0.1);
+  background: var(--primary-muted);
   color: var(--text);
 }
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -31,22 +31,25 @@ UrsaMU takes a fresh approach:
 
 | Traditional MU* | UrsaMU |
 |----------------|--------|
-| Written in C | Written in TypeScript |
-| No standard package system | Deno native (JSR, npm imports) |
-| Telnet-only | WebSocket primary, Telnet sidecar |
-| Embedded scripting in MUSHcode | Scripts run in sandboxed Web Workers |
-| Modify core to extend | Plugin architecture |
-| Manual compile & deploy | `deno task start` |
+| Written in C | Written in TypeScript / Deno |
+| No standard package system | JSR packages (`@ursamu/mush`, plugins) |
+| Telnet-only | WS hub + HTTP portal + Telnet sidecar |
+| No first-class web UI | `@ursamu/site` (public) + `@ursamu/web` (staff) |
+| Embedded scripting in MUSHcode | Softcode + sandboxed TS Web Workers |
+| Modify core to extend | Plugin architecture (`addCmd`, hooks, routes) |
+| Manual compile & deploy | `jsr:@ursamu/cli` scaffold → `deno task start` |
 
 ## Core Features
 
-### WebSocket-Native Protocol
+### Portal + WebSocket-native protocol
 
-The primary interface to UrsaMU is **WebSocket**, not Telnet. This means:
+Scaffolded games ship a **public site** (`@ursamu/site`) and **staff
+console** (`@ursamu/web`) on the HTTP port, plus a WebSocket game hub:
 
-- Native browser connectivity — build web clients without proxies
-- Structured JSON messages for clean client/server contracts
-- A Telnet sidecar is still available for classic MU* clients
+- Browser play client at `/play` (sign-in required)
+- Staff tools at `/admin/` (wiki, DB, settings, plugin pages)
+- Structured JSON over WS for custom clients
+- Telnet sidecar for classic MU* clients
 
 ```javascript
 const socket = new WebSocket("ws://yourgame.example.com:4202");

--- a/docs/child-games/index.md
+++ b/docs/child-games/index.md
@@ -16,21 +16,20 @@ project, including daemon scripts, telnet sidecar, and a `.env` with a
 fresh JWT secret (v2.4.0):
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli create my-game
+deno run -A jsr:@ursamu/cli@0.1.2/create my-game
 cd my-game
 ```
 
 The scaffold writes:
 
-- `deno.json` with `start` / `dev` / `test` tasks
-- `config/config.json` (see "Configuration" below)
-- `plugins.manifest.json` — declared plugin dependencies
-- `system/scripts/` — empty, ready for local script overrides
-- `daemon.sh`, `stop.sh`, `restart.sh`, `status.sh` — supervised lifecycle
-- `.env` containing a generated `JWT_SECRET`
+- `deno.json` with `start` / `dev` / `test` tasks and import map
+- `config/config.json` — ports + default portal plugins (site + web)
+- `system/scripts/` — engine script copies / overrides
+- `scripts/daemon.sh`, `stop.sh`, `restart.sh`, `status.sh`
+- `.env` with a generated `JWT_SECRET`
 
-A `--local` variant points the import map at a checkout of the engine
-instead of JSR; the tasks, manifest, and scripts are otherwise identical.
+A `--local` variant points the import map at a monorepo checkout
+instead of JSR; tasks and config shape are otherwise the same.
 
 ## Running the game
 
@@ -92,9 +91,9 @@ remain legacy-compatible.
 Install or update from the CLI:
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli plugin install <url> [--ref <ref>]
-deno run -A jsr:@ursamu/mush/cli plugin update
-deno run -A jsr:@ursamu/mush/cli plugin list
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install <url> [--ref <ref>]
+deno run -A jsr:@ursamu/cli@0.1.2/plugin update
+deno run -A jsr:@ursamu/cli@0.1.2/plugin list
 ```
 
 ## Local script overrides
@@ -123,8 +122,8 @@ project-specific mechanics as their own.
 ## Updating the engine
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli update         # latest stable
-deno run -A jsr:@ursamu/mush/cli update main    # specific branch
+deno run -A jsr:@ursamu/cli@0.1.2/update         # latest stable
+deno run -A jsr:@ursamu/cli@0.1.2/update main    # specific branch
 ```
 
 The updater rewrites the import map and re-runs `ensurePlugins`. Restart

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,173 +1,144 @@
 ---
 layout: layout.vto
 title: CLI Reference
-description: Complete reference for the UrsaMU command-line interface — create projects, scaffold plugins, and manage the plugin registry.
+description: Complete reference for the UrsaMU command-line interface — create projects, scaffold plugins, and manage packages.
 ---
 
 # CLI Reference
 
-The UrsaMU CLI requires no install — run it directly from JSR with `deno run`.
+The CLI ships as **`jsr:@ursamu/cli`**. No global install required —
+run it with `deno run`.
 
-## Running the CLI
+Pin a known release in scripts and docs:
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli <command> [options]
+deno run -A jsr:@ursamu/cli@0.1.2/<export> …
 ```
 
-Or install it locally for convenience (see [install-cli](#install-cli)).
+| Export | Entry | Use |
+|--------|-------|-----|
+| `/create` | project + plugin scaffold | everyday |
+| `/ursamu` | interactive menu | package picker, helpers |
+| `/update` | bump engine import | existing games |
+| `/plugin` | manifest plugin ops | git plugins |
+| `/start` | supervised start helper | advanced |
+
 ---
 
 ## create
 
-Scaffold a new game project or plugin.
-
 ### New game project
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli create <project-name>
+deno run -A jsr:@ursamu/cli@0.1.2/create <project-name>
+deno run -A jsr:@ursamu/cli@0.1.2/create <project-name> --local
 ```
 
-Creates a new directory with a fully-configured UrsaMU game project:
-- `src/main.ts` — entry point
-- `src/plugins/` — plugin directory (auto-discovered)
-- `system/scripts/` — local script overrides
-- `config/config.json` — server configuration
-- `deno.json` — Deno project file
+Creates a directory with a supervised UrsaMU game:
 
-### In-tree plugin (inside an existing project)
+- `main.ts` / telnet entry — boot `@ursamu/mush`
+- `config/config.json` — ports + default portal plugins
+- `deno.json` — import map + tasks
+- `.env` — generated `JWT_SECRET`
+- `scripts/daemon.sh` (and stop/restart/status)
+- Default plugins: builder, channels, help, bbs, mail, wiki,
+  **web**, **site** (`serveRoot: true`)
+
+`--local` points imports at a monorepo checkout instead of JSR.
+
+### In-tree plugin
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli create plugin <name>
+deno run -A jsr:@ursamu/cli@0.1.2/create plugin <name>
 ```
 
-Run from your game project root. Generates `src/plugins/<name>/` with:
-- `index.ts` — plugin definition (`IPlugin`)
-- `commands.ts` — command registrations
-- `README.md` — plugin documentation stub
+Run from a game project root. Options:
 
-### Standalone publishable plugin
+| Flag | Effect |
+|------|--------|
+| `--standalone` | Separate publishable plugin repo |
+| `--admin-embed` / `-A` | Staff page under `/admin/<name>/` |
+| `--site-static` / `-S` | Public page at `/site/p/<name>/` |
+| `--non-interactive` | CI-friendly (no prompts) |
+
+---
+
+## Interactive menu
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli create plugin <name> --standalone
+deno run -A jsr:@ursamu/cli@0.1.2/ursamu
 ```
 
-Generates a self-contained plugin repo at `./<name>/` ready for publishing to JSR or GitHub.
+Create games/plugins, manage packages, update the engine, and edit
+shell scripts from a simple numbered menu.
+
 ---
 
 ## plugin
 
-Manage the plugin registry (`src/plugins/plugins.manifest.json`).
-
-### List installed plugins
+Manage git-based entries in `plugins.manifest.json` (when used):
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli plugin list
+deno run -A jsr:@ursamu/cli@0.1.2/plugin list
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install <github-url>
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install <github-url> --ref v1.2.0
+deno run -A jsr:@ursamu/cli@0.1.2/plugin update <name>
+deno run -A jsr:@ursamu/cli@0.1.2/plugin remove <name>
+deno run -A jsr:@ursamu/cli@0.1.2/plugin info <name>
+deno run -A jsr:@ursamu/cli@0.1.2/plugin search <query>
 ```
 
-### Install a plugin
+Most new games load official packages via **JSR** in
+`config.json` → `server.plugins` and the import map — prefer that for
+`@ursamu/help`, `@ursamu/bbs`, `@ursamu/site`, etc.
 
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin install <github-url>
-```
+### Install behavior
 
-Adds the plugin to the manifest and downloads it into `src/plugins/`.
+Fail-fast installs with whole-run rollback on unsafe names/URLs,
+clone failures, or semver conflicts. See
+[Admin Guide → Plugin Install Behavior](./admin-guide.md#plugin-install-behavior).
 
-Pin to a specific tag or commit:
-
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin install <github-url> --ref v1.2.0
-```
-
-### Update a plugin
-
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin update <name>
-```
-
-Fetches the latest ref for the plugin and updates the manifest.
-
-### Remove a plugin
-
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin remove <name>
-```
-
-Removes the plugin from the manifest and deletes its directory.
-
-### Show plugin info
-
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin info <name>
-```
-
-Displays metadata, installed version, and available update.
-
-### Search
-
-```bash
-deno run -A jsr:@ursamu/mush/cli plugin search <query>
-```
-
-Search the public plugin registry for plugins matching `<query>`.
-
-### Plugin install behavior (v2.6.0)
-
-The plugin installer is **fail-fast with whole-manifest atomic rollback**.
-If any plugin (or transitive `deps[]` entry) fails to clone, has an unsafe
-name or URL, violates a `version` semver range, or conflicts with another
-dep's range, the entire install run aborts. Disk and the plugin registry
-are left exactly as they were before the run — your previously installed
-plugins are not touched. See
-[Admin Guide → Plugin Install Behavior](./admin-guide.md#plugin-install-behavior)
-for the full list of error classes.
 ---
 
 ## update
 
-Update the UrsaMU engine in an existing game project.
+Bump the engine import in an existing game:
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli update
+deno run -A jsr:@ursamu/cli@0.1.2/update
+deno run -A jsr:@ursamu/cli@0.1.2/update --dry-run
 ```
 
-Preview changes without writing:
-
-```bash
-deno run -A jsr:@ursamu/mush/cli update --dry-run
-```
 ---
 
 ## scripts
 
-List the names and aliases of every script the engine and its plugins
-register at startup. Useful for discovering what's already registered before
-you write an override.
-
 ```bash
-deno run -A jsr:@ursamu/mush/cli scripts list
+deno run -A jsr:@ursamu/cli@0.1.2/scripts list
 ```
+
+Lists registered script names/aliases (engine + plugins).
+
 ---
 
-## config
+## config (game task)
 
-Print the current server configuration:
+Inside a scaffolded project:
 
 ```bash
 deno task config
+deno task config --get server.apiPort
+deno task config --set game.name "My Game"
 ```
+
 ---
 
-## install-cli
-
-Install the CLI as a local binary so you don't need the full `deno run` invocation:
+## Optional global install
 
 ```bash
-deno task install-cli
+deno install -Ag -n ursamu jsr:@ursamu/cli@0.1.2/ursamu
+# or create only:
+deno install -Ag -n ursamu-create jsr:@ursamu/cli@0.1.2/create
 ```
 
-After install:
-
-```bash
-ursamu create my-game
-ursamu plugin list
-```
+Then: `ursamu` / `ursamu-create my-game`.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -354,10 +354,10 @@ UrsaMU is a JSR package — your game project depends on a version pinned in
 
 ```bash
 # Preview what would change
-deno run -A jsr:@ursamu/mush/cli update --dry-run
+deno run -A jsr:@ursamu/cli@0.1.2/update --dry-run
 
 # Apply the update
-deno run -A jsr:@ursamu/mush/cli update
+deno run -A jsr:@ursamu/cli@0.1.2/update
 ```
 
 After updating, restart the servers:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -6,176 +6,145 @@ description: How to install and set up UrsaMU on your system
 
 # Installation Guide
 
-This guide will walk you through the process of installing and setting up UrsaMU
-on your system.
+Install Deno 2.x, scaffold a game with the CLI, start the server, then
+claim the first staff account on the web portal.
 
 ## Prerequisites
 
-Before installing UrsaMU, ensure you have the following:
-
 - [**Deno**](https://deno.land/) v2.x
-- Git (for cloning the repository and plugin installs)
+- Git (optional — for cloning the monorepo or git-based plugins)
 
-## Installation Methods
-
-UrsaMU can be installed in multiple ways. Choose the method that works best for
-your environment.
-
----
-
-### Method 1: Direct from GitHub
+## Method 1: Scaffold from JSR (recommended)
 
 ```bash
-# Clone the repository
-git clone https://github.com/ursamu/ursamu.git
-
-# Navigate to the project directory
-cd ursamu
-
-# Set up configuration
-deno task setup-config
-```
-
-### Method 2: Using the UrsaMU CLI
-
-UrsaMU provides a CLI tool for creating new projects:
-
-```bash
-# Install the UrsaMU CLI
-deno task install-cli
-
-# Create a new project
-ursamu create my-game
+deno run -A jsr:@ursamu/cli@0.1.2/create my-game
 cd my-game
-```
-
-> **Package names**: The primary import is now `jsr:@ursamu/mush`. The legacy
-> package `jsr:@ursamu/mush` still works as a shim that re-exports everything
-> from `@ursamu/mush`.
-
-## Configuration
-
-UrsaMU uses a flexible configuration system stored in JSON format:
-
-```bash
-# Show the entire configuration
-deno task config
-
-# Get a specific configuration value
-deno task config --get server.ws
-
-# Set a configuration value
-deno task config --set server.ws 4202
-```
-
-The configuration is stored in `config/config.json` and includes:
-
-- Server ports and database paths
-- Game name, description, and version
-- Text file locations
-- Plugin settings
-
-For detailed information on all available configuration options, see the
-[Configuration Guide](../configuration/).
-
-## Running the Server
-
-UrsaMU uses a dual-server architecture with the main server and telnet server
-running as separate processes:
-
-### Starting Both Servers
-
-```bash
-# Start both main and telnet servers with watch mode
 deno task start
 ```
 
-This will:
+The scaffold writes a supervised game project with:
 
-- Start both the main server and telnet server as separate processes
-- Enable watch mode for automatic reloading when files change
-- Allow each server to restart independently
+- `deno.json` — tasks (`start`, `dev`, `daemon`, …)
+- `config/config.json` — ports, plugins, optional site nav
+- `.env` — fresh `JWT_SECRET`
+- `scripts/` — `daemon.sh`, `stop.sh`, `restart.sh`, `status.sh`
+- Default **portal stack**: builder, channels, help, bbs, mail, wiki,
+  `@ursamu/web` (staff), `@ursamu/site` (public FE + `/play`)
 
-### Development Mode
+When `@ursamu/site` is selected, config sets
+`plugins.site.serveRoot: true` so the public site is served at `/`.
 
-For development with auto-restart on file changes:
+Optional: interactive menu and package picker:
 
 ```bash
-deno task dev
+deno run -A jsr:@ursamu/cli@0.1.2/ursamu
 ```
 
-### Production / Supervised Daemon
+Engine-dev mode (link imports to a local monorepo checkout):
 
-Game projects scaffolded with `ursamu create` include `scripts/daemon.sh`,
-`scripts/restart.sh`, `scripts/status.sh`, and `scripts/stop.sh`. These run
-the server as a supervised background process with signal-driven
-no-disconnect restarts. See [Production Deployment](./deployment.md#supervised-daemon-mode)
-for details.
+```bash
+deno run -A jsr:@ursamu/cli@0.1.2/create my-game --local
+```
+
+> **Imports:** game code uses `jsr:@ursamu/mush`. The legacy package
+> `jsr:@ursamu/ursamu` re-exports the same surface.
+
+## Method 2: From the monorepo
+
+```bash
+git clone https://github.com/ursamu/ursamu.git
+cd ursamu
+deno run -A packages/cli/src/create.ts my-game --local
+cd my-game
+deno task start
+```
+
+Use this when contributing to the engine or testing unreleased packages.
+
+## Default ports
+
+| Port | Role |
+|------|------|
+| `4201` | Telnet (sidecar) |
+| `4202` | WebSocket game hub |
+| `4203` | HTTP — REST API, `/admin`, public site, static assets |
+
+Override with `URSAMU_HTTP_PORT` / `URSAMU_TELNET_PORT` or edit
+`config/config.json` (`server.telnet`, `server.wsPort`, `server.apiPort`).
 
 ## Connecting
 
-### MU* Clients (Recommended for most players)
+### Web portal (default stack)
 
-The easiest way to connect is with a standard MU* client over Telnet (port `4201`):
+| URL | Purpose |
+|-----|---------|
+| `http://localhost:4203/` | Public site home |
+| `http://localhost:4203/play` | Browser play client (sign-in) |
+| `http://localhost:4203/admin/` | Staff console |
+| `http://localhost:4203/wiki/` | Wiki (when installed) |
 
-| Client | Platform | Download |
-|--------|----------|---------|
-| **Mudlet** | Windows / Mac / Linux | [mudlet.org](https://www.mudlet.org/) |
-| **MUSHclient** | Windows | [mushclient.com](https://mushclient.com/) |
-| **Potato** | Windows / Mac / Linux | [potatomushclient.com](https://www.potatomushclient.com/) |
-| Any terminal | Any | `telnet localhost 4201` |
+### MU* clients (Telnet)
 
-In your client, add a new connection profile with:
-- **Host**: `localhost` (or your server's hostname/IP)
-- **Port**: `4201`
+| Client | Platform |
+|--------|----------|
+| [Mudlet](https://www.mudlet.org/) | Win / Mac / Linux |
+| [MUSHclient](https://www.mushclient.com/) | Windows |
+| [Potato](https://www.potatomushclient.com/) | Win / Mac / Linux |
+| `telnet localhost 4201` | Any terminal |
 
-Once connected, type `create YourName YourPassword` to create a character, or
-`connect YourName YourPassword` to log in.
+### WebSocket (custom clients)
 
-### WebSocket (Developer / Custom Client)
+Connect to `ws://localhost:4202` (game hub) with a JWT from
+`POST /api/v1/auth/login`, or use the site play client which handles
+auth for you.
 
-For direct WebSocket access, connect to `ws://localhost:4203` and send JSON:
+## First admin / superuser
 
-```javascript
-const socket = new WebSocket("ws://localhost:4203");
+With an **empty database**:
 
-// Create a character
-socket.send(JSON.stringify({ msg: "create NewCharacter Password", data: {} }));
+1. Prefer the web path: open `/register` (or site login → register).
+2. The **first web registrant** is granted `superuser`.
+3. Telnet still works: `create <name> <password>` when no players
+   exist also promotes the first character.
 
-// Connect as a player
-socket.send(JSON.stringify({ msg: "connect PlayerName Password", data: {} }));
+After that, grant staff with in-game flags (`@set <player>=admin`) or
+the staff console. The `superuser` flag is only auto-granted on the
+empty-DB first-account flow.
 
-// Send any command
-socket.send(JSON.stringify({ msg: "look", data: {} }));
+## Configuration
+
+```bash
+# From a scaffolded game project
+deno task config
+deno task config --get server.apiPort
+deno task config --set game.name "My MUSH"
 ```
 
-## First Admin
+Config lives in `config/config.json`. Common keys:
 
-When the database is empty, UrsaMU prints:
+- `server.telnet` / `server.wsPort` / `server.apiPort`
+- `server.plugins` — JSR package list loaded at boot
+- `plugins.site` — public shell (`serveRoot`, `skin`, `nav`, …)
+- `game.name`, `game.playerStart`, layout templates
 
+See the [Configuration Guide](../configuration/).
+
+## Running the server
+
+```bash
+deno task start     # supervised foreground (game + telnet)
+deno task dev       # development / live logs
+deno task daemon    # background supervisor
+deno task status    # pid / health
+deno task stop      # graceful shutdown
+deno task restart   # SIGUSR2 no-disconnect restart
 ```
-Fresh database detected — no players exist yet.
 
-Connect via telnet and run:
-  create <name> <password>
+Production notes: [Deployment](./deployment.md).
 
-The first player created is automatically given superuser access.
-```
+## Next steps
 
-Connect with a Telnet client (`telnet localhost 4201`) and create your first
-account. That first player receives the **superuser** flag (level 10 — the
-highest permission level) automatically.
-
-After that, use `@set <player>=admin` in-game to grant admin rights to other
-trusted staff. The `superuser` flag itself can only be created via this
-first-run flow — it cannot be granted from inside the game.
-
-## Next Steps
-
-Now that you have UrsaMU installed and running, you might want to:
-
-- [**User Guide**](./user-guide.md) - Learn how to use UrsaMU as a player
-- [**Configuration**](../configuration/) - Explore detailed configuration
-  options
-- [**Plugin Development**](../plugins/index.md) - Learn how to create plugins to
-  extend UrsaMU
+- [Player Guide](./user-guide.md)
+- [Admin Guide](./admin-guide.md)
+- [CLI Reference](./cli.md)
+- [Plugin Development](../plugins/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,222 +7,237 @@ templateEngine: [vto, md]
 
 <!-- ── HERO ───────────────────────────────────────────────────────── -->
 <div class="home-hero animate-in">
-
-  <div class="version-badge" style="cursor:default">
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="var(--primary-light)"><circle cx="5" cy="5" r="5"/></svg>
-    v2.6.0 &nbsp;&bull;&nbsp; MIT License
-  </div>
-
+  <p class="home-hero__chip">mush 1.0.30 · cli 0.1.2 · MIT</p>
   <h1>A Modern MUSH Server</h1>
-
-  <p>
-    High-performance, modular MU* engine built with <strong style="color:var(--text)">TypeScript</strong>
-    and <strong style="color:var(--text)">Deno</strong>.<br>
-    WebSocket-native &bull; Sandbox scripting &bull; Plugin architecture &bull; Discord bridge.
+  <p class="home-hero__lede">
+    High-performance MU* engine in <strong>TypeScript</strong> and
+    <strong>Deno</strong>. WebSocket hub, public portal, staff console,
+    sandboxed scripts, JSR plugins.
   </p>
-
   <div class="home-actions">
-    <a href="/guides/installation/" class="btn-primary">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-      Get Started
-    </a>
-    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.834 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-      View on GitHub
-    </a>
-    <a href="/guides/user-guide/" class="btn-secondary">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
-      Read the Docs
-    </a>
+    <a href="/guides/installation/" class="btn-primary">Get Started</a>
+    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary">GitHub</a>
+    <a href="/guides/user-guide/" class="btn-secondary">Read the Docs</a>
   </div>
 </div>
 
 <!-- ── QUICK INSTALL ──────────────────────────────────────────────── -->
-<div class="quickstart-block" style="animation-delay:0.1s">
-  <div class="quickstart-inner">
-    <div class="quickstart-bar">
-      <span class="quickstart-dot" style="background:#ff5f57"></span>
-      <span class="quickstart-dot" style="background:#febc2e"></span>
-      <span class="quickstart-dot" style="background:#28c840"></span>
-      <span style="margin-left:auto;font-size:0.7rem;color:var(--text-dim);font-family:'JetBrains Mono',monospace">terminal</span>
-    </div>
-    <pre class="quickstart-code"><span class="comment"># Install the UrsaMU DX bootstrapper</span>
-<span class="cmd">deno install -A --global -n deno-x jsr:@dx/dx</span>
-<span class="cmd">deno x --install-alias</span>
-<span class="comment"># Initialize a new world</span>
-<span class="cmd">dx jsr:@ursamu/mush init</span></pre>
+<section class="home-stack">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Install</p>
+    <h2 class="home-stack__title">Quick start</h2>
+  </header>
+  <div class="home-stack__code">
+    <div class="home-stack__code-bar">Terminal</div>
+    <pre class="home-stack__pre"><span class="cmt"># Scaffold a game (engine + portal stack)</span>
+<span class="cmd">deno run -A jsr:@ursamu/cli@0.1.2/create my-game</span>
+<span class="cmd">cd my-game</span>
+<span class="cmd">deno task start</span>
+<span class="cmt"># http://localhost:4203/  ·  /play  ·  /admin/</span></pre>
   </div>
-</div>
+</section>
 
-<!-- ── FEATURE CARDS ─────────────────────────────────────────────── -->
-<div class="feature-grid" style="animation-delay:0.15s">
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+<!-- ── CAPABILITIES ──────────────────────────────────────────────── -->
+<section class="home-stack" aria-label="Capabilities">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Product</p>
+    <h2 class="home-stack__title">Capabilities</h2>
+  </header>
+  <dl class="home-stack__list">
+    <div class="home-stack__row">
+      <dt>Transport</dt>
+      <dd>WebSocket hub with rate limits — browser play, custom clients, or Telnet</dd>
     </div>
-    <h3>WebSocket Native</h3>
-    <p>First-class WebSocket interface with a 10 cmd/sec rate limiter. Connect from any browser or MU* client.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+    <div class="home-stack__row">
+      <dt>Runtime</dt>
+      <dd>Scripts in Web Workers with the full SDK — a bad attr cannot crash the host</dd>
     </div>
-    <h3>Sandboxed Scripting</h3>
-    <p>Scripts run in Web Workers with a rich SDK — database access, messaging, rooms, and channels — without touching the host.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"/><line x1="16" y1="8" x2="2" y2="22"/><line x1="17.5" y1="15" x2="9" y2="15"/></svg>
+    <div class="home-stack__row">
+      <dt>Plugins</dt>
+      <dd>Typed packages: commands, hooks, flags, routes, namespaced DBO</dd>
     </div>
-    <h3>Plugin Architecture</h3>
-    <p>Extend the engine with typed plugins. Add commands, hooks, flags, routes, and custom database services.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+    <div class="home-stack__row">
+      <dt>Front ends</dt>
+      <dd><code>@ursamu/site</code> (/play) and <code>@ursamu/web</code> (/admin) on one HTTP port</dd>
     </div>
-    <h3>Discord Bridge</h3>
-    <p>Built-in Discord integration with exponential-backoff reconnect — relay in-game chat to Discord channels and back.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+    <div class="home-stack__row">
+      <dt>Database</dt>
+      <dd>TypeGraph/PGlite by default, Deno KV fallback — query by flags, owner, data</dd>
     </div>
-    <h3>Flexible Database</h3>
-    <p>Pluggable database layer (dbojs) for game objects, channels, mail, and bulletin boards. Query by flags, owner, or custom data.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+    <div class="home-stack__row">
+      <dt>Softcode</dt>
+      <dd>TinyMUX 2.x evaluator — 250+ functions, ANSI, format handler pipeline</dd>
     </div>
-    <h3>Scene Archive</h3>
-    <p>Collaborative roleplay scene tracking with REST export endpoints — download logs as Markdown or JSON.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M18 20V10"/><path d="M12 20V4"/><path d="M6 20v-6"/></svg>
+    <div class="home-stack__row">
+      <dt>Events</dt>
+      <dd>Typed GameHooks bus for login, say, move, scenes, and plugin events</dd>
     </div>
-    <h3>Game Hooks</h3>
-    <p>Typed, fire-and-forget event bus — 12 built-in events covering players, scenes, and channels. Plugins subscribe without touching core command files.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+    <div class="home-stack__row">
+      <dt>Integrations</dt>
+      <dd>Optional Discord bridge with reconnect/backoff via JSR</dd>
     </div>
-    <h3>TinyMUX 2.x Softcode</h3>
-    <p>Full 250+ function softcode evaluator: math, string, list, logic, object, register, and output families with all TinyMUX substitutions and ANSI codes.</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+    <div class="home-stack__row">
+      <dt>Installs</dt>
+      <dd>Fail-fast manifests with semver checks and whole-run rollback</dd>
     </div>
-    <h3>Stdlib Primitives</h3>
-    <p>Noise (Perlin/Simplex/Worley/FBM), per-instance PRNG, physics, spatial, interpolation, and vector ops re-exported from mod.ts (v2.5.1+).</p>
-  </div>
+  </dl>
+</section>
 
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+<!-- ── DOCS DIRECTORY ─────────────────────────────────────────────── -->
+<nav class="home-stack" aria-label="Documentation sections">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Documentation</p>
+    <h2 class="home-stack__title">Where to go next</h2>
+  </header>
+  <ul class="home-stack__list home-stack__list--links">
+    <li>
+      <a href="/guides/installation/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Installation</span>
+          <span class="home-stack__desc">Scaffold, start, claim superuser</span>
+        </span>
+        <span class="home-stack__path">/guides/installation/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/guides/user-guide/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Player guide</span>
+          <span class="home-stack__desc">Commands, movement, building</span>
+        </span>
+        <span class="home-stack__path">/guides/user-guide/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/guides/admin-guide/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Admin guide</span>
+          <span class="home-stack__desc">Staff tools, security, channels</span>
+        </span>
+        <span class="home-stack__path">/guides/admin-guide/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/api/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">API reference</span>
+          <span class="home-stack__desc">SDK, REST, hooks, database</span>
+        </span>
+        <span class="home-stack__path">/api/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/plugins/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Plugin development</span>
+          <span class="home-stack__desc">addCmd, hooks, routes, DBO</span>
+        </span>
+        <span class="home-stack__path">/plugins/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/development/contributing/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Contributing</span>
+          <span class="home-stack__desc">Tests, PRs, conventions</span>
+        </span>
+        <span class="home-stack__path">/development/contributing/</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+
+<!-- ── ARCHITECTURE ──────────────────────────────────────────────── -->
+<section class="home-stack" aria-label="Architecture">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">System</p>
+    <h2 class="home-stack__title">Architecture</h2>
+    <p class="home-stack__lede">
+      One Deno process stack: game hub, HTTP portal, and Telnet sidecar.
+    </p>
+  </header>
+  <dl class="home-stack__list">
+    <div class="home-stack__row">
+      <dt>Runtime</dt>
+      <dd>Deno · TypeScript · ESM · sandboxed Web Workers</dd>
     </div>
-    <h3>Atomic Plugin Installs</h3>
-    <p>Fail-fast plugin manifests with semver constraints and InstallTxn rollback — every dir and registry mutation rolls back on any error (v2.6.0).</p>
-  </div>
-
-  <div class="feature-card">
-    <div class="feature-card-icon">
-      <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+    <div class="home-stack__row">
+      <dt>Transport</dt>
+      <dd>
+        <code>4201</code> telnet ·
+        <code>4202</code> ws hub ·
+        <code>4203</code> http api + site
+      </dd>
     </div>
-    <h3>Format Handler Pipeline</h3>
-    <p>Eight format slots (NAMEFORMAT, DESCFORMAT, CONFORMAT, EXITFORMAT, WHOFORMAT, WHOROWFORMAT, PSFORMAT, PSROWFORMAT) — register TS handlers or raw softcode templates.</p>
-  </div>
-
-</div>
-
-<!-- ── SECTION GRID ───────────────────────────────────────────────── -->
-<div style="max-width:900px;margin:0 auto 1rem;padding:0 1rem">
-  <p style="text-align:center;font-size:0.8rem;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-dim);margin-bottom:1.25rem">Jump to a section</p>
-</div>
-
-<div class="home-section-grid">
-  <a href="/guides/installation/" class="home-section-card">
-    <h4>Installation</h4>
-    <p>Get UrsaMU running in minutes with the DX wizard or from source.</p>
-  </a>
-  <a href="/guides/user-guide/" class="home-section-card">
-    <h4>Player Guide</h4>
-    <p>Commands, movement, communication, building, and object interaction.</p>
-  </a>
-  <a href="/guides/admin-guide/" class="home-section-card">
-    <h4>Admin Guide</h4>
-    <p>User management, channels, scene export, rate limiting, and security.</p>
-  </a>
-  <a href="/api/" class="home-section-card">
-    <h4>API Reference</h4>
-    <p>Core, database, command, flag, hook, and utility APIs documented in full.</p>
-  </a>
-  <a href="/plugins/" class="home-section-card">
-    <h4>Plugin Dev</h4>
-    <p>Build plugins that add commands, hooks, flags, and custom services.</p>
-  </a>
-  <a href="/development/contributing/" class="home-section-card">
-    <h4>Contributing</h4>
-    <p>Help shape UrsaMU — from bug reports to PRs and new features.</p>
-  </a>
-</div>
-
-<!-- ── ARCHITECTURE OVERVIEW ─────────────────────────────────────── -->
-<div style="max-width:900px;margin:0 auto 4rem;padding:0 1rem">
-  <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:14px;padding:2rem;backdrop-filter:blur(8px)">
-    <p style="font-size:0.68rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:var(--primary-light);margin-bottom:1rem">Architecture at a Glance</p>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;font-size:0.82rem;color:var(--text-muted)">
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Runtime</div>
-        Deno (TypeScript) &bull; ESM modules &bull; Web Workers for sandboxing
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Transport</div>
-        WebSocket hub (4202) &bull; HTTP REST (4203) &bull; Telnet sidecar (4201)
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Persistence</div>
-        dbojs (game objects) &bull; chans &bull; mail &bull; bboard &bull; counters
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Integrations</div>
-        Discord gateway &bull; Scene REST API &bull; Wiki REST API &bull; Plugin SDK
-      </div>
-      <div>
-        <div style="color:var(--text);font-weight:600;margin-bottom:0.35rem">Events</div>
-        GameHooks typed bus &bull; WikiHooks &bull; EventHooks &bull; Daemon restart loop (exit 75)
-      </div>
+    <div class="home-stack__row">
+      <dt>Engine</dt>
+      <dd><code>@ursamu/mush</code> on <code>@ursamu/core</code></dd>
     </div>
-  </div>
-</div>
+    <div class="home-stack__row">
+      <dt>Public FE</dt>
+      <dd><code>@ursamu/site</code> — portal, skins, <code>/play</code></dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Staff FE</dt>
+      <dd><code>@ursamu/web</code> — console at <code>/admin/</code></dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Persistence</dt>
+      <dd>TypeGraph / PGlite (default) or Deno KV · namespaced DBO</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Plugins</dt>
+      <dd>JSR packages · help, bbs, mail, wiki, jobs, discord, …</dd>
+    </div>
+    <div class="home-stack__row">
+      <dt>Events</dt>
+      <dd>GameHooks bus · supervised restart (<code>exit 75</code>)</dd>
+    </div>
+  </dl>
+</section>
 
 <!-- ── COMMUNITY ─────────────────────────────────────────────────── -->
-<div style="max-width:680px;margin:0 auto 5rem;text-align:center;padding:0 1rem">
-  <p style="font-size:0.68rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;color:var(--text-dim);margin-bottom:1.5rem">Community & Links</p>
-  <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap">
-    <a href="https://github.com/ursamu/ursamu" target="_blank" rel="noopener" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
-      GitHub
-    </a>
-    <a href="https://discord.gg/ursamu" target="_blank" rel="noopener" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg>
-      Discord
-    </a>
-    <a href="/guides/installation/" class="btn-secondary" style="font-size:0.8rem;padding:0.5rem 1rem">
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-      Quick Start
-    </a>
-  </div>
-</div>
+<section class="home-stack home-stack--end" aria-label="Community">
+  <header class="home-stack__head">
+    <p class="home-stack__kicker">Community</p>
+    <h2 class="home-stack__title">Get involved</h2>
+  </header>
+  <ul class="home-stack__list home-stack__list--links">
+    <li>
+      <a href="https://github.com/ursamu/ursamu" class="home-stack__link" target="_blank" rel="noopener">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">GitHub</span>
+          <span class="home-stack__desc">Source, issues, and releases</span>
+        </span>
+        <span class="home-stack__path">github.com/ursamu/ursamu</span>
+      </a>
+    </li>
+    <li>
+      <a href="https://discord.gg/ursamu" class="home-stack__link" target="_blank" rel="noopener">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Discord</span>
+          <span class="home-stack__desc">Chat with operators and builders</span>
+        </span>
+        <span class="home-stack__path">discord.gg/ursamu</span>
+      </a>
+    </li>
+    <li>
+      <a href="/guides/installation/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Install a game</span>
+          <span class="home-stack__desc">Scaffold with the CLI and go live</span>
+        </span>
+        <span class="home-stack__path">/guides/installation/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/development/contributing/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Contribute</span>
+          <span class="home-stack__desc">Tests, PRs, and coding conventions</span>
+        </span>
+        <span class="home-stack__path">/development/contributing/</span>
+      </a>
+    </li>
+  </ul>
+</section>

--- a/docs/plugins/official-plugins.md
+++ b/docs/plugins/official-plugins.md
@@ -25,7 +25,7 @@ To disable auto-install for a specific plugin, remove its entry from the manifes
 |--------|------|-----------|-------------|
 | **channel** | [UrsaMU/channel-plugin](https://github.com/UrsaMU/channel-plugin) | `>=1.9.27` | Channel system — alias dispatch, auto-join, `@chancreate`/`@chandestroy`/`@chanset`, message history |
 | **discord** | [UrsaMU/discord-plugin](https://github.com/UrsaMU/discord-plugin) | `>=1.9.0` | Webhook-based Discord integration — channel bridging, presence, chargen events |
-| **jobs** | [UrsaMU/jobs-plugin](https://github.com/UrsaMU/jobs-plugin) | `>=1.9.0` | Anomaly-style jobs/request system — player requests, staff commands, REST API |
+| **jobs** | [UrsaMU/jobs-plugin](https://github.com/UrsaMU/jobs-plugin) | `>=1.9.0` | Jobs and request system — player requests, staff commands, REST API |
 | **events** | [UrsaMU/events-plugin](https://github.com/UrsaMU/events-plugin) | `>=1.9.2` | In-game event calendar with RSVP tracking and REST API |
 | **bbs** | [UrsaMU/bbs-plugin](https://github.com/UrsaMU/bbs-plugin) | `>=1.9.0` | Myrddin-style bulletin boards — threading, categories, sticky posts, Discord webhooks |
 | **wiki** | [UrsaMU/wiki-plugin](https://github.com/UrsaMU/wiki-plugin) | `>=1.9.0` | File-based markdown wiki — pages, search, history, backlinks |
@@ -61,7 +61,7 @@ Each `deps[]` entry may include an optional `version` semver range (e.g. `"^1.2.
 Or use the CLI:
 
 ```bash
-deno run -A jsr:@ursamu/mush/cli plugin install https://github.com/example/my-plugin
+deno run -A jsr:@ursamu/cli@0.1.2/plugin install https://github.com/example/my-plugin
 ```
 
 See [Building a Plugin](./first-plugin.md) to publish your own.

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -5,26 +5,58 @@
 @tailwind utilities;
 
 @layer base {
+  /*
+   * Docs site tokens — same violet-night family as
+   * packages/web/ui/src/assets/staff-theme.css and
+   * packages/site/public/css/tokens.css (design.md).
+   * Flat surfaces, hairline borders, no multi-stop glow.
+   */
   :root {
-    /* UrsaMU Brand — matched to github banner */
-    --bg:              #0c0a1e;
-    --bg-sidebar:      #0f0d24;
-    --bg-surface:      #15122e;
-    --bg-card:         rgba(21, 18, 46, 0.7);
-    --bg-code:         #08071a;
-    --border:          rgba(139, 92, 246, 0.12);
-    --border-hover:    rgba(139, 92, 246, 0.3);
-    --border-active:   rgba(167, 139, 250, 0.5);
-    --text:            #ddd9f5;
-    --text-muted:      #8480aa;
-    --text-dim:        #4e4a6b;
-    --primary:         #8b5cf6;
+    /* packages/web/design.md §2 — violet night (source of truth) */
+    --bg:              #0b0a12;
+    --bg-elevated:     #12101c;
+    --bg-sidebar:      #12101c;
+    --bg-surface:      #161422;
+    --bg-surface-2:    #1c1929;
+    --bg-card:         #161422;
+    --bg-code:         #0e0c16;
+    --border:          #3a3554;
+    --border-subtle:   #2a2640;
+    --border-strong:   #5a5480;
+    --border-hover:    #5a5480;
+    --border-active:   rgba(167, 139, 250, 0.45);
+    --text:            #f0eef8;
+    --text-secondary:  #c4c0d4;
+    --text-muted:      #b0a9c4;
+    --text-dim:        #7a7494;
+    --text-on-primary: #ffffff;
+    --text-inverse:    #0b0a12;
+    --primary:         #a78bfa;
     --primary-light:   #a78bfa;
     --primary-bright:  #c4b5fd;
-    --primary-glow:    rgba(139, 92, 246, 0.2);
+    --primary-hover:   #c4b5fd;
+    --primary-muted:   rgba(167, 139, 250, 0.16);
+    --primary-border:  rgba(167, 139, 250, 0.45);
+    --btn-primary-bg:  #6d28d9;
+    --btn-primary-bg-hover: #7c3aed;
+    --btn-primary-fg:  var(--text-on-primary);
+    --success:         #3ecf8e;
+    --warning:         #e6b84d;
+    --error:           #f07178;
+    --info:            #7eb8ff;
+    --radius-xs:       2px;
+    --radius-sm:       4px;
+    --radius-md:       6px;
+    --radius-lg:       8px;
+    --radius:          var(--radius-md);
+    --gutter:          1.25rem;
     --sidebar-width:   280px;
     --toc-width:       220px;
-    --header-height:   72px;
+    --header-height:   56px;
+    --font-ui:         Inter, ui-sans-serif, system-ui, sans-serif;
+    --font-mono:       ui-monospace, "SFMono-Regular", "JetBrains Mono",
+                       Menlo, Consolas, monospace;
+    color-scheme: dark;
   }
 
   * {
@@ -39,20 +71,16 @@
   body {
     background-color: var(--bg);
     color: var(--text);
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: var(--font-ui);
     font-size: 15px;
     line-height: 1.7;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    background-image:
-      radial-gradient(ellipse 80% 60% at 0% -10%, rgba(109, 40, 217, 0.18) 0%, transparent 60%),
-      radial-gradient(ellipse 60% 40% at 100% 110%, rgba(79, 29, 149, 0.15) 0%, transparent 50%);
-    background-attachment: fixed;
     min-height: 100vh;
   }
 
   ::selection {
-    background: rgba(139, 92, 246, 0.35);
+    background: var(--primary-muted);
   }
 }
 
@@ -71,18 +99,21 @@
   height: calc(100vh - var(--header-height));
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--bg-sidebar);
-  border-right: 1px solid var(--border);
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-subtle);
   padding: 1.25rem 0 3rem;
   display: flex;
   flex-direction: column;
   gap: 0;
   scrollbar-width: thin;
-  scrollbar-color: rgba(139,92,246,0.2) transparent;
+  scrollbar-color: var(--border) transparent;
 }
 
 .docs-sidebar::-webkit-scrollbar { width: 4px; }
-.docs-sidebar::-webkit-scrollbar-thumb { background: rgba(139,92,246,0.2); border-radius: 4px; }
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-sm);
+}
 
 .docs-content-wrap {
   flex: 1;
@@ -124,10 +155,8 @@
   height: var(--header-height);
   display: flex;
   align-items: center;
-  background: rgba(12, 10, 30, 0.88);
-  border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
   padding: 0 2rem;
   gap: 1.25rem;
 }
@@ -156,11 +185,11 @@
   font-size: 0.68rem;
   font-weight: 600;
   letter-spacing: 0.05em;
-  color: var(--primary-light);
-  background: rgba(139, 92, 246, 0.12);
-  border: 1px solid rgba(139, 92, 246, 0.25);
+  color: var(--primary);
+  background: var(--primary-muted);
+  border: 1px solid var(--primary-border);
   padding: 0.15rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   align-self: center;
   margin-top: 1px;
 }
@@ -189,18 +218,18 @@
   color: var(--text-muted);
   text-decoration: none;
   padding: 0.4rem 0.8rem;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   transition: color 0.15s, background 0.15s;
   white-space: nowrap;
 }
 
 .header-nav-link:hover {
   color: var(--text);
-  background: rgba(139, 92, 246, 0.1);
+  background: var(--primary-muted);
 }
 
 .header-nav-link.active {
-  color: var(--primary-light);
+  color: var(--primary);
 }
 
 .header-spacer { flex: 1; }
@@ -217,7 +246,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   transition: color 0.15s, background 0.15s;
   text-decoration: none;
@@ -226,7 +255,7 @@
 
 .header-icon-btn:hover {
   color: var(--text);
-  background: rgba(255,255,255,0.06);
+  background: var(--bg-surface-2);
 }
 
 .header-version {
@@ -250,14 +279,14 @@
   background: none;
   border: none;
   cursor: pointer;
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   transition: color 0.15s, background 0.15s;
 }
 
 .menu-btn:hover {
   color: var(--text);
-  background: rgba(255,255,255,0.06);
+  background: var(--bg-surface-2);
 }
 
 @media (max-width: 1023px) {
@@ -273,24 +302,23 @@
 
 .sidebar-search-input {
   width: 100%;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
   padding: 0.45rem 0.75rem 0.45rem 2.2rem;
   font-size: 0.8rem;
   color: var(--text);
   font-family: inherit;
   outline: none;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%236b68a8' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E");
+  transition: border-color 0.15s, background 0.15s;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23b0a9c4' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 0.6rem center;
 }
 
 .sidebar-search-input:focus {
-  border-color: var(--border-hover);
-  background-color: rgba(255,255,255,0.06);
-  box-shadow: 0 0 0 3px rgba(139,92,246,0.1);
+  border-color: var(--primary-border);
+  background-color: var(--bg-surface-2);
 }
 
 .sidebar-search-input::placeholder {
@@ -326,12 +354,12 @@
 
 .sidebar-link:hover {
   color: var(--text);
-  background: rgba(139, 92, 246, 0.07);
+  background: var(--primary-muted);
 }
 
 .sidebar-link.active {
-  color: var(--primary-bright);
-  background: rgba(139, 92, 246, 0.1);
+  color: var(--primary);
+  background: var(--primary-muted);
   border-left-color: var(--primary);
   font-weight: 550;
 }
@@ -379,7 +407,7 @@
 }
 
 .breadcrumbs-current {
-  color: var(--primary-light);
+  color: var(--primary);
   font-weight: 500;
 }
 
@@ -421,7 +449,7 @@
 }
 
 .toc-item.active a {
-  color: var(--primary-light);
+  color: var(--primary);
   border-left-color: var(--primary);
 }
 
@@ -442,10 +470,7 @@
   line-height: 1.2;
   margin-bottom: 0.75rem;
   margin-top: 0;
-  background: linear-gradient(135deg, #fff 30%, var(--primary-light) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text);
 }
 
 .prose h2 {
@@ -464,7 +489,7 @@
   font-weight: 600;
   margin-top: 2rem;
   margin-bottom: 0.5rem;
-  color: rgba(221, 217, 245, 0.9);
+  color: var(--text-secondary);
 }
 
 .prose h4 {
@@ -472,49 +497,49 @@
   font-weight: 600;
   margin-top: 1.5rem;
   margin-bottom: 0.35rem;
-  color: rgba(221, 217, 245, 0.8);
+  color: var(--text-secondary);
 }
 
 .prose p {
   margin-bottom: 1.1rem;
-  color: rgba(221, 217, 245, 0.85);
+  color: var(--text-secondary);
 }
 
 .prose a {
-  color: var(--primary-light);
+  color: var(--primary);
   text-decoration: none;
-  border-bottom: 1px solid rgba(167, 139, 250, 0.25);
+  border-bottom: 1px solid var(--primary-border);
   transition: color 0.15s, border-color 0.15s;
 }
 
 .prose a:hover {
-  color: var(--primary-bright);
-  border-bottom-color: rgba(196, 181, 253, 0.5);
+  color: var(--primary-hover);
+  border-bottom-color: var(--primary-hover);
 }
 
 .prose code {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 0.82em;
-  background: rgba(139, 92, 246, 0.12);
-  border: 1px solid rgba(139, 92, 246, 0.2);
+  background: var(--primary-muted);
+  border: 1px solid var(--border-subtle);
   color: var(--primary-bright);
   padding: 0.15em 0.45em;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
 }
 
 .prose pre {
   background: var(--bg-code);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   padding: 1.25rem 1.5rem;
   overflow-x: auto;
   margin: 1.5rem 0;
   position: relative;
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 0.83rem;
   line-height: 1.7;
   scrollbar-width: thin;
-  scrollbar-color: rgba(139,92,246,0.2) transparent;
+  scrollbar-color: var(--border) transparent;
 }
 
 .prose pre code {
@@ -526,12 +551,15 @@
 }
 
 .prose pre::-webkit-scrollbar { height: 4px; }
-.prose pre::-webkit-scrollbar-thumb { background: rgba(139,92,246,0.25); border-radius: 4px; }
+.prose pre::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-sm);
+}
 
 .prose ul, .prose ol {
   padding-left: 1.5rem;
   margin-bottom: 1.1rem;
-  color: rgba(221, 217, 245, 0.85);
+  color: var(--text-secondary);
 }
 
 .prose li {
@@ -544,16 +572,16 @@
 }
 
 .prose em {
-  color: rgba(221, 217, 245, 0.8);
+  color: var(--text-secondary);
 }
 
 .prose blockquote {
   border-left: 3px solid var(--primary);
   margin: 1.5rem 0;
   padding: 0.75rem 1.25rem;
-  background: rgba(139, 92, 246, 0.07);
-  border-radius: 0 8px 8px 0;
-  color: rgba(221, 217, 245, 0.75);
+  background: var(--primary-muted);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -567,25 +595,25 @@
 }
 
 .prose th {
-  background: rgba(139, 92, 246, 0.1);
-  color: var(--primary-bright);
+  background: var(--bg-surface-2);
+  color: var(--primary);
   font-weight: 600;
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   padding: 0.6rem 1rem;
   text-align: left;
-  border-bottom: 1px solid var(--border-hover);
+  border-bottom: 1px solid var(--border);
 }
 
 .prose td {
   padding: 0.6rem 1rem;
-  border-bottom: 1px solid var(--border);
-  color: rgba(221, 217, 245, 0.85);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
 }
 
 .prose tr:last-child td { border-bottom: none; }
-.prose tr:hover td { background: rgba(139, 92, 246, 0.04); }
+.prose tr:hover td { background: var(--primary-muted); }
 
 .prose hr {
   border: none;
@@ -607,20 +635,20 @@
 .page-nav-btn {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.875rem 1.25rem;
+  gap: 0.2rem;
+  padding: 0.75rem 1rem;
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   text-decoration: none;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.15s, background 0.15s;
   max-width: 48%;
   min-width: 0;
 }
 
 .page-nav-btn:hover {
-  border-color: var(--border-hover);
-  background: rgba(139, 92, 246, 0.07);
+  border-color: var(--border-strong);
+  background: var(--bg-surface-2);
 }
 
 .page-nav-btn.next { text-align: right; margin-left: auto; }
@@ -636,291 +664,350 @@
 .page-nav-title {
   font-size: 0.88rem;
   font-weight: 600;
-  color: var(--primary-light);
+  color: var(--primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 /* ─── HOMEPAGE ────────────────────────────────────────────────────── */
+/*
+ * One pattern only: .home-stack (raised list / code panel).
+ * design.md: flat surfaces, hairline borders, no card mosaics.
+ */
 
 .home-hero {
   text-align: center;
-  padding: 4rem 2rem 3rem;
-  max-width: 900px;
+  padding: 3rem var(--gutter) 2rem;
+  max-width: 40rem;
   margin: 0 auto;
-  position: relative;
 }
 
+.home-hero__chip {
+  display: inline-block;
+  margin: 0 0 1rem;
+  padding: 0.2rem 0.5rem;
+  background: var(--primary-muted);
+  border: 1px solid var(--primary-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--primary);
+  letter-spacing: 0.02em;
+}
 
 .home-hero h1 {
-  font-size: clamp(2.5rem, 6vw, 4.5rem);
-  font-weight: 900;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-  margin-bottom: 1.25rem;
-  background: linear-gradient(135deg, #ffffff 0%, #c4b5fd 50%, #8b5cf6 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0 0 0.85rem;
+  color: var(--text);
 }
 
-.home-hero p {
-  font-size: 1.1rem;
-  color: var(--text-muted);
-  max-width: 600px;
-  margin: 0 auto 2.5rem;
-  line-height: 1.7;
+.home-hero__lede {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  max-width: 34rem;
+  margin: 0 auto 1.75rem;
+  line-height: 1.6;
+}
+
+.home-hero__lede strong {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .home-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   justify-content: center;
   flex-wrap: wrap;
 }
 
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.7rem 1.5rem;
-  background: linear-gradient(135deg, var(--primary) 0%, #5b21b6 100%);
-  color: white;
-  font-size: 0.88rem;
-  font-weight: 600;
-  border-radius: 8px;
-  text-decoration: none;
-  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.35);
-  cursor: pointer;
-}
-
-.btn-primary:hover {
-  opacity: 0.9;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 28px rgba(139, 92, 246, 0.45);
-}
-
+.btn-primary,
 .btn-secondary {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.4rem;
-  padding: 0.7rem 1.5rem;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border);
-  color: var(--text);
-  font-size: 0.88rem;
-  font-weight: 600;
-  border-radius: 8px;
+  min-height: 2.25rem;
+  padding: 0.45rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
   text-decoration: none;
-  transition: background 0.15s, border-color 0.15s;
   cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.btn-primary {
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-fg);
+  border: 1px solid transparent;
+}
+
+.btn-primary:hover {
+  background: var(--btn-primary-bg-hover);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border-strong);
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: var(--border-hover);
+  background: var(--bg-surface-2);
 }
 
-/* ─── FEATURE CARDS ───────────────────────────────────────────────── */
+/* Stack sections — sole homepage content chrome */
 
-.feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1rem;
-  max-width: 900px;
-  margin: 2.5rem auto;
-  padding: 0 1rem;
+.home-stack {
+  max-width: 40rem;
+  margin: 0 auto 2.75rem;
+  padding: 0 var(--gutter);
 }
 
-.feature-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1.5rem;
-  transition: border-color 0.2s, background 0.2s, transform 0.2s;
-  backdrop-filter: blur(8px);
-  text-decoration: none;
-  display: block;
+.home-stack--end {
+  margin-bottom: 4.5rem;
 }
 
-.feature-card:hover {
-  border-color: var(--border-hover);
-  background: rgba(139, 92, 246, 0.07);
-  transform: translateY(-2px);
+.home-stack__head {
+  margin-bottom: 0.85rem;
 }
 
-.feature-card-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  background: rgba(139, 92, 246, 0.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 1rem;
+.home-stack__kicker {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 0.3rem;
 }
 
-.feature-card-icon svg {
-  width: 20px;
-  height: 20px;
-  stroke: var(--primary-light);
-  fill: none;
-  stroke-width: 1.75;
-}
-
-.feature-card h3 {
-  font-size: 0.95rem;
-  font-weight: 700;
+.home-stack__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
   color: var(--text);
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.35rem;
 }
 
-.feature-card p {
-  font-size: 0.82rem;
-  color: var(--text-muted);
-  line-height: 1.6;
+.home-stack__lede {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
   margin: 0;
+  max-width: 34rem;
 }
 
-/* ─── QUICK START BLOCK ───────────────────────────────────────────── */
-
-.quickstart-block {
-  max-width: 680px;
-  margin: 0 auto 3rem;
-  padding: 0 1rem;
-}
-
-.quickstart-inner {
-  background: var(--bg-code);
+.home-stack__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
-.quickstart-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.6rem 1rem;
-  background: rgba(255,255,255,0.03);
-  border-bottom: 1px solid var(--border);
-}
-
-.quickstart-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
-.quickstart-code {
-  padding: 1rem 1.25rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.85rem;
-  line-height: 1.7;
-  color: var(--text-muted);
-  margin: 0;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-}
-
-.quickstart-code .cmd { color: var(--primary-light); }
-.quickstart-code .comment { color: var(--text-dim); }
-
-/* ─── SECTION CARDS (homepage) ────────────────────────────────────── */
-
-.home-section-grid {
+.home-stack__row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1px;
-  background: var(--border);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden;
-  max-width: 900px;
-  margin: 0 auto 4rem;
+  grid-template-columns: 7.5rem 1fr;
+  gap: 0.75rem 1.25rem;
+  align-items: baseline;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 0;
 }
 
-.home-section-card {
-  background: var(--bg-sidebar);
-  padding: 1.25rem 1.5rem;
-  text-decoration: none;
-  transition: background 0.15s;
+.home-stack__row:last-child {
+  border-bottom: none;
 }
 
-.home-section-card:hover {
-  background: rgba(139,92,246,0.08);
-}
-
-.home-section-card h4 {
-  font-size: 0.88rem;
+.home-stack__row dt {
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 0.35rem;
+  margin: 0;
+  line-height: 1.4;
 }
 
-.home-section-card p {
-  font-size: 0.77rem;
-  color: var(--text-muted);
+.home-stack__row dd {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
 }
 
-/* ─── VERSION BADGE ───────────────────────────────────────────────── */
+.home-stack__row code,
+.home-stack__pre .cmd {
+  font-family: var(--font-mono);
+}
 
-.version-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.6rem;
-  background: rgba(139,92,246,0.12);
-  border: 1px solid rgba(139,92,246,0.25);
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--primary-light);
-  letter-spacing: 0.02em;
-  margin-bottom: 1.5rem;
+.home-stack__row code {
+  font-size: 0.75rem;
+  color: var(--primary);
+  background: var(--primary-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  padding: 0.05em 0.35em;
+}
+
+.home-stack__list--links > li {
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 0;
+}
+
+.home-stack__list--links > li:last-child {
+  border-bottom: none;
+}
+
+.home-stack__link {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 0.75rem 1rem;
   text-decoration: none;
-  cursor: default;
+  transition: background 0.12s;
+}
+
+.home-stack__link:hover {
+  background: var(--primary-muted);
+}
+
+.home-stack__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+  min-width: 0;
+}
+
+.home-stack__label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.home-stack__link:hover .home-stack__label {
+  color: var(--primary);
+}
+
+.home-stack__desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.home-stack__path {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  letter-spacing: -0.01em;
+}
+
+.home-stack__link:hover .home-stack__path {
+  color: var(--primary);
+}
+
+/* Code panel (quick start) — same column, code elevation */
+.home-stack__code {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.home-stack__code-bar {
+  padding: 0.5rem 0.9rem;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.home-stack__pre {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  overflow-x: auto;
+}
+
+.home-stack__pre .cmd {
+  color: var(--primary);
+}
+
+.home-stack__pre .cmt {
+  color: var(--text-dim);
+}
+
+@media (max-width: 560px) {
+  .home-stack__row {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .home-stack__link {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
 }
 
 /* ─── CALLOUT BOXES ───────────────────────────────────────────────── */
 
 .callout {
-  border-radius: 10px;
-  padding: 1rem 1.25rem;
-  margin: 1.5rem 0;
-  border: 1px solid;
-  font-size: 0.88rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1rem;
+  margin: 1.25rem 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
 }
 
 .callout-note {
-  background: rgba(139,92,246,0.07);
-  border-color: rgba(139,92,246,0.25);
-  color: rgba(221,217,245,0.85);
+  border-left-color: var(--primary);
 }
 
 .callout-warning {
-  background: rgba(245,158,11,0.07);
-  border-color: rgba(245,158,11,0.25);
-  color: rgba(253,230,138,0.9);
+  border-left-color: var(--warning);
 }
 
 .callout-tip {
-  background: rgba(16,185,129,0.07);
-  border-color: rgba(16,185,129,0.25);
-  color: rgba(167,243,208,0.9);
+  border-left-color: var(--success);
+}
+
+.callout-error {
+  border-left-color: var(--error);
+}
+
+.callout-info {
+  border-left-color: var(--info);
 }
 
 .callout-title {
-  font-weight: 700;
-  margin-bottom: 0.35rem;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  color: var(--text);
 }
 
 /* ─── FOOTER ──────────────────────────────────────────────────────── */
@@ -1005,11 +1092,10 @@
   right: 0;
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   margin-top: 0.35rem;
   overflow: hidden;
   z-index: 999;
-  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
   max-height: 320px;
   overflow-y: auto;
 }
@@ -1025,7 +1111,7 @@
 }
 
 .search-result-item:hover {
-  background: rgba(139,92,246,0.1);
+  background: var(--primary-muted);
   color: var(--text);
 }
 


### PR DESCRIPTION
## Summary

- Refresh root **README** and docs install/CLI guides for the real portal path: `jsr:@ursamu/cli@0.1.2/create`, mush 1.0.30 pins, `/` + `/play` + `/admin`, first-web superuser.
- Restyle the **docs homepage** to the violet-night tokens from `packages/web/design.md` / `packages/site/design.md` — single editorial `.home-stack` layout (no card mosaic).
- Add root tasks: `deno task docs` (port 3001) and `deno task docs:build`.
- Rebuild `docs/_site` so GitHub Pages content matches source.

## Test plan

- [ ] `deno task docs` serves homepage with stack sections only (Install, Capabilities, Where to go next, Architecture, Get involved)
- [ ] Quick start block shows `jsr:@ursamu/cli@0.1.2/create`
- [ ] Installation + CLI docs pages match README commands
- [ ] Visual: flat surfaces, hairline borders, no glow/gradient cards