### PR TITLE
fix(web): remove Play tab from staff console

### DIFF
--- a/packages/cli/src/packages.ts
+++ b/packages/cli/src/packages.ts
@@ -26,7 +26,7 @@ export const optionalPackages: PackageOption[] = [
   {
     name: "Staff Web Console",
     pkgName: "@ursamu/web",
-    jsrUrl: "jsr:@ursamu/web@^0.2.71",
+    jsrUrl: "jsr:@ursamu/web@^0.2.72",
     description: "Staff admin SPA at /admin (wiki, DB, settings)",
   },
   {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.72
+
+- Remove **Play** tab from staff console top nav. Game client
+  lives on the public site at `/play`; `/admin/play` redirects
+  there.
+
 ## 0.2.71
 
 - Wiki edit: **Delete** page button (staff confirm →

--- a/packages/web/deno.json
+++ b/packages/web/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/web",
-  "version": "0.2.71",
+  "version": "0.2.72",
   "description": "Staff web console for UrsaMU \u2014 wiki, database, and more.",
   "license": "MIT",
   "exports": "./mod.ts",

--- a/packages/web/design.md
+++ b/packages/web/design.md
@@ -463,7 +463,8 @@ Wiki API notes: engine wiki routes / package docs as applicable.
 ## 11. Game client output (Play)
 
 **Player FE:** site `/play` (`play.js` + `play.css`) — primary client.  
-**Staff console Play** is optional/legacy; same `data.ui` contract.
+**Staff console** does not ship a Play tab; `/admin/play` redirects
+to public `/play`. Same `data.ui` contract if embedding later.
 
 ### Message contract (WS `{ msg, data }`)
 

--- a/packages/web/ui/src/layouts/AppLayout.vue
+++ b/packages/web/ui/src/layouts/AppLayout.vue
@@ -101,7 +101,6 @@ const section = computed<Section>(() => {
     return String(route.params.pluginId ?? "").trim() || "plugin";
   }
   if (n === "dashboard" || n === "") return "dashboard";
-  if (n === "play") return "play";
   if (n.startsWith("wiki")) return "wiki";
   if (n.startsWith("job")) return "jobs";
   if (n.startsWith("bbs")) return "bbs";
@@ -132,8 +131,6 @@ const sectionTitle = computed(() => {
   switch (section.value) {
     case "dashboard":
       return "Dashboard";
-    case "play":
-      return "Play";
     case "wiki":
       return "Wiki";
     case "jobs":
@@ -269,7 +266,6 @@ function ackSectionBadges(sec: Section): void {
  */
 const CORE_PRIMARY: Omit<PrimaryItem, "badge" | "badgeTitle">[] = [
   { id: "dashboard", name: "dashboard", label: "Dashboard", order: 10 },
-  { id: "play", name: "play", label: "Play", order: 15 },
   { id: "db", name: "db", label: "Database", order: 60 },
   { id: "settings", name: "settings", label: "Settings", order: 90 },
 ];
@@ -629,15 +625,6 @@ const sideLinks = computed((): SideLink[] => {
   if (fromPlugin) return fromPlugin;
 
   switch (section.value) {
-    case "play":
-      return [
-        {
-          to: { name: "play" },
-          label: "Client",
-          desc: "Live game output",
-          icon: "›",
-        },
-      ];
     case "wiki":
       return wikiStatusLinks.value;
     case "help":
@@ -1062,8 +1049,6 @@ function primaryIcon(id: string): string {
   switch (id) {
     case "dashboard":
       return "⌂";
-    case "play":
-      return "›";
     case "wiki":
       return "¶";
     case "players":

--- a/packages/web/ui/src/router/index.ts
+++ b/packages/web/ui/src/router/index.ts
@@ -28,10 +28,15 @@ const router = createRouter({
           name: "dashboard",
           component: () => import("@/views/DashboardView.vue"),
         },
+        // Play lives on the public site (/play), not staff console.
         {
           path: "play",
-          name: "play",
-          component: () => import("@/views/PlayView.vue"),
+          redirect: () => {
+            if (typeof window !== "undefined") {
+              window.location.assign("/play");
+            }
+            return { name: "dashboard" };
+          },
         },
         {
           path: "wiki",


### PR DESCRIPTION
## Summary
- Remove **Play** from staff console primary nav
- `/admin/play` redirects to public `/play`
- Bump `@ursamu/web` to **0.2.72**

## Test plan
- [ ] Admin top nav has no Play tab
- [ ] `/admin/play` lands on `/play`
- [ ] Court vendor/web updated after merge