### PR TITLE
fix(web): align IPlugin.version with 0.2.72

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -14,7 +14,7 @@ import { adminSettingsHandler } from "./settings-api.ts";
 
 export const plugin: IPlugin = {
   name: "web",
-  version: "0.2.60",
+  version: "0.2.72",
   description:
     "Staff web console (Vue 3) — WebSocket-first API + UI.",
 


### PR DESCRIPTION
Hardcoded plugin version was still 0.2.60 after Play-tab bump.