### PR TITLE
docs: surface softcode in guides nav

### DIFF
--- a/docs/_includes/layout.vto
+++ b/docs/_includes/layout.vto
@@ -119,7 +119,11 @@
       </a>
       <a href="/guides/scripting/" class="sidebar-link{{ if it.url === '/guides/scripting/' }} active{{ /if }}">
         <svg class="sidebar-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-        Scripting Guide
+        Scripting (TypeScript)
+      </a>
+      <a href="/guides/softcoding/" class="sidebar-link{{ if it.url === '/guides/softcoding/' }} active{{ /if }}">
+        <svg class="sidebar-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><path d="M8 7h8M8 11h6"/></svg>
+        Softcode (TinyMUX)
       </a>
       <a href="/guides/first-script/" class="sidebar-link{{ if it.url === '/guides/first-script/' }} active{{ /if }}">
         <svg class="sidebar-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
@@ -132,6 +136,10 @@
       <a href="/guides/recipes/" class="sidebar-link{{ if it.url === '/guides/recipes/' }} active{{ /if }}">
         <svg class="sidebar-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
         Recipes
+      </a>
+      <a href="/mush_compatibility/" class="sidebar-link{{ if it.url === '/mush_compatibility/' }} active{{ /if }}">
+        <svg class="sidebar-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+        MUSH Compatibility
       </a>
     </div>
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -39,12 +39,12 @@ admin operations, plugin development, and softcoding.
 
 ## Writing Code
 
-- [**Scripting**](./scripting.md) — Sandbox model, the `u` SDK, ESM vs legacy
-  blocks, aliases and switches.
+- [**Softcode**](./softcoding.md) — TinyMUX evaluator, `&ATTR/softcode`,
+  `@trigger` / `u.trigger` / `u.eval`, $-patterns, parent inheritance.
+- [**Scripting (TypeScript)**](./scripting.md) — Sandbox model, the `u` SDK,
+  ESM vs legacy blocks, aliases and switches.
 - [**Build Your First Script**](./first-script.md) — Step-by-step walkthrough.
 - [**SDK Cookbook**](./sdk-cookbook.md) — Every `u.*` namespace with examples.
-- [**Soft-Coding**](./softcoding.md) — Storing scripts in attributes, parent
-  inheritance, `@trigger` / `u.trigger` / `u.eval`.
 - [**Recipes**](./recipes.md) — Copy-paste patterns for common tasks.
 - [**Game Clock**](./gameclock.md) — `u.sys.gameTime` and the in-game calendar.
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -6,7 +6,13 @@ description: How to write and run scripts in UrsaMU's sandboxed scripting enviro
 
 # Scripting Guide
 
-UrsaMU scripts are TypeScript/JavaScript files that run inside **Web Workers** — completely isolated from the host process. Every script receives a typed SDK object called `u` that provides everything a script needs to interact with the game world.
+UrsaMU scripts are TypeScript/JavaScript files that run inside
+**Web Workers** — isolated from the host process. Every script
+gets a typed SDK object `u` for world interaction.
+
+Looking for classic MUSH softcode (`[func()]`, `%N`,
+`&ATTR/softcode`)? See the
+[Softcode Guide](/guides/softcoding/) instead.
 
 ## How It Works
 

--- a/docs/guides/softcoding.md
+++ b/docs/guides/softcoding.md
@@ -1,15 +1,26 @@
 ---
 layout: layout.vto
-title: Soft-Coding Guide
-description: How to store scripts and data in object attributes and trigger them with @trigger, u.trigger, and u.eval.
+title: Softcode Guide
+description: TinyMUX softcode and attribute scripts — &ATTR, @trigger, u.eval, $-patterns, and the softcode evaluator.
 ---
 
-# Soft-Coding Guide
+# Softcode Guide
 
-Soft-coding is the practice of storing scripts and data directly on in-game
-objects as **attributes**, rather than writing static files. It lets builders
-and players customize room behavior, object interaction, and NPC responses
-entirely from inside the game — no server restart required.
+UrsaMU supports two ways to put behavior on objects:
+
+1. **TinyMUX softcode** — classic MUSH expressions
+   (`[add(1,2)]`, `%N`, `@switch`, `$greet *`) via the
+   softcode evaluator.
+2. **TypeScript attributes** — full sandbox scripts stored
+   on objects (same SDK as `system/scripts/`).
+
+Both live as **attributes** on rooms, players, things, and
+exits. Builders can change them in-game with no restart.
+
+For file-based TypeScript commands, see the
+[Scripting Guide](/guides/scripting/). For the full function
+list, see [MUSH Compatibility](/mush_compatibility/).
+
 ---
 
 ## What is Soft-Coding?

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,8 +65,8 @@ templateEngine: [vto, md]
       <dd>TypeGraph/PGlite by default, Deno KV fallback — query by flags, owner, data</dd>
     </div>
     <div class="home-stack__row">
-      <dt>Softcode</dt>
-      <dd>TinyMUX 2.x evaluator — 250+ functions, ANSI, format handler pipeline</dd>
+      <dt><a href="/guides/softcoding/">Softcode</a></dt>
+      <dd>TinyMUX 2.x evaluator — 250+ functions, attributes, @trigger, $-patterns</dd>
     </div>
     <div class="home-stack__row">
       <dt>Events</dt>
@@ -115,6 +115,15 @@ templateEngine: [vto, md]
           <span class="home-stack__desc">Staff tools, security, channels</span>
         </span>
         <span class="home-stack__path">/guides/admin-guide/</span>
+      </a>
+    </li>
+    <li>
+      <a href="/guides/softcoding/" class="home-stack__link">
+        <span class="home-stack__meta">
+          <span class="home-stack__label">Softcode</span>
+          <span class="home-stack__desc">TinyMUX attrs, @trigger, functions</span>
+        </span>
+        <span class="home-stack__path">/guides/softcoding/</span>
       </a>
     </li>
     <li>


### PR DESCRIPTION
## Summary
- Add **Softcode (TinyMUX)** and **MUSH Compatibility** to the docs sidebar
- Link Softcode from the homepage capabilities list and “Where to go next”
- Put Softcode first under Writing Code on the guides index
- Clarify Softcode vs TypeScript scripting in guide intros

## Why
The softcode guide (`/guides/softcoding/`) was built but not linked from the sidebar or homepage, so it looked like softcode was undocumented.

## Test plan
- [x] Source-only change (Pages workflow rebuilds `_site` on main)
- [ ] After merge: Deploy Documentation workflow runs and softcode appears in live nav