### PR TITLE
fix(look): show image when looking at exits

### DIFF
--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts",

--- a/packages/mush/src/verbs/look-ui.ts
+++ b/packages/mush/src/verbs/look-ui.ts
@@ -325,6 +325,29 @@ async function entityItem(
   return item;
 }
 
+/** Resolve a playable image URL for any look target (room/exit/thing). */
+export async function resolveLookMedia(
+  u: IUrsamuSDK,
+  target: IDBObj,
+  alt: string,
+): Promise<UIComponent | null> {
+  const bag = {
+    ...((target as { data?: Record<string, unknown> }).data ?? {}),
+    ...((target.state ?? {}) as Record<string, unknown>),
+  };
+  const fromDisk = await resolveObjectImageUrl(target.id, bag);
+  const fromAttr = await u.attr.get(target.id, "IMAGE");
+  const img = String(
+    fromDisk ||
+      fromAttr ||
+      bag.image ||
+      bag.image_url ||
+      "",
+  ).trim();
+  if (!img || !isPlayableImageUrl(img)) return null;
+  return { type: "media", url: img, alt };
+}
+
 /**
  * Build look components for the web client using theme.look flags.
  */
@@ -340,26 +363,8 @@ export async function buildLookLayout(
     title: ctx.headerTitle,
   });
 
-  const bag = {
-    ...((target as { data?: Record<string, unknown> }).data ?? {}),
-    ...((target.state ?? {}) as Record<string, unknown>),
-  };
-  const fromDisk = await resolveObjectImageUrl(target.id, bag);
-  const fromAttr = await u.attr.get(target.id, "IMAGE");
-  const img = String(
-    fromDisk ||
-      fromAttr ||
-      bag.image ||
-      bag.image_url ||
-      "",
-  ).trim();
-  if (img && isPlayableImageUrl(img)) {
-    components.push({
-      type: "media",
-      url: img,
-      alt: ctx.headerTitle,
-    });
-  }
+  const media = await resolveLookMedia(u, target, ctx.headerTitle);
+  if (media) components.push(media);
 
   components.push({
     type: "text",
@@ -435,7 +440,7 @@ export async function buildLookLayout(
   return components;
 }
 
-/** Non-room look: header + desc + carrying list. */
+/** Non-room look: header + media + desc + carrying list. */
 export async function buildSingleLookLayout(
   ctx: LookUiContext,
 ): Promise<UIComponent[]> {
@@ -443,11 +448,15 @@ export async function buildSingleLookLayout(
   const theme = getLookTheme();
   const components: UIComponent[] = [
     { type: "header", title: ctx.headerTitle },
-    {
-      type: "text",
-      content: webDesc(ctx.description || NO_DESCRIPTION),
-    },
   ];
+
+  const media = await resolveLookMedia(u, target, ctx.headerTitle);
+  if (media) components.push(media);
+
+  components.push({
+    type: "text",
+    content: webDesc(ctx.description || NO_DESCRIPTION),
+  });
 
   if (showContents && target.contents && target.contents.length > 0) {
     const players = target.contents.filter((c) =>

--- a/packages/mush/tests/look_ui.test.ts
+++ b/packages/mush/tests/look_ui.test.ts
@@ -4,6 +4,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   buildLookLayout,
+  buildSingleLookLayout,
   exitCmd,
   getLookTheme,
   prefersUiLayout,
@@ -41,6 +42,48 @@ function mockU(): IUrsamuSDK {
     canEdit: async () => false,
   } as unknown as IUrsamuSDK;
 }
+
+Deno.test(
+  "buildSingleLookLayout: includes media for exits/things",
+  OPTS,
+  async () => {
+    const exit = mockObj({
+      id: "42",
+      name: "North;n",
+      flags: new Set(["exit"]),
+      state: {
+        name: "North;n",
+        description: "A cold passage.",
+        image: "/images/42.jpg",
+      },
+    });
+    // data bag is also checked
+    (exit as { data?: Record<string, unknown> }).data = {
+      image: "/images/42.jpg",
+    };
+    const u = mockU();
+    const comps = await buildSingleLookLayout({
+      u,
+      actor: u.me,
+      target: exit,
+      showContents: false,
+      canEdit: false,
+      exits: [],
+      headerTitle: "North",
+      description: "A cold passage.",
+    });
+    const types = comps.map((c) => c.type);
+    assertEquals(types[0], "header");
+    assertEquals(types.includes("media"), true);
+    const media = comps.find((c) => c.type === "media") as {
+      url?: string;
+      alt?: string;
+    };
+    assertEquals(media?.url, "/images/42.jpg");
+    assertEquals(media?.alt, "North");
+    assertEquals(types.includes("text"), true);
+  },
+);
 
 Deno.test("exitCmd prefers shortest alias", OPTS, () => {
   const e = mockObj({


### PR DESCRIPTION
## Summary
Non-room look (`buildSingleLookLayout`) never attached a `media` component, so exit/thing/player images set via `@image` did not appear on web look.

## Test plan
- [x] look_ui tests (exit media present)
- [ ] Publish mush@1.0.32 and safe-update court