### PR TITLE
feat(cofd): +cg/wipe staff character wipe

### DIFF
--- a/packages/cofd/deno.json
+++ b/packages/cofd/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/cofd-plugin",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Chronicles of Darkness 2e plugin for UrsaMU \u2014 sheets, chargen, d10 dice, IC/OOC, +time, CtL overlay.",
   "license": "MIT",
   "exports": "./index.ts",

--- a/packages/cofd/help/cg.md
+++ b/packages/cofd/help/cg.md
@@ -5,7 +5,8 @@ SYNTAX
   +cg/set <trait>=<value>   Set a trait or option.
   +cg/list [<topic>]        Show available options for a field.
   +cg/back                  Return to previous stage.
-  +cg/reset                 Start over with a blank Mortal sheet.
+  +cg/reset                 You: wipe sheet + draft, restart.
+  +cg/wipe <p>[=reason]     Staff: full wipe of a character bit.
   +cg/submit                Validate current stage and advance.
 STAGES
   1. Identity     Concept, Virtue, Vice.
@@ -17,4 +18,5 @@ STAGES
 AFTER FINAL /SUBMIT
   Staff reviews with +sheet <you>, then +approve or
   +deny=<reason>. Until approved, edit via +cg.
-SEE ALSO: help sheet, help approve, help deny, help templates, help changeling
+SEE ALSO: help sheet, help approve, help deny, help cg/wipe,
+  help templates, help changeling

--- a/packages/cofd/help/cg/wipe.md
+++ b/packages/cofd/help/cg/wipe.md
@@ -1,0 +1,30 @@
+---
+dark: true
+---
+See also: +help cg (overview)
+
++CG/WIPE  -- Staff: full character bit wipe.
+
+SYNTAX
+  +cg/wipe <player>[=<reason>]
+
+PERMISSIONS
+  Connected staff (admin / wizard / storyteller+).
+
+CLEARS
+  Live sheet (data.cofd)
+  Chargen draft (data.cofd_cg) then seeds fresh draft
+  approved flag
+  Sight flags fae and forsaken
+  Comments open CGEN job if present
+
+NOTES
+  Reason required when wiping another player.
+  Player is notified in-game and by @mail.
+  Self wipe: +cg/reset (no reason needed).
+
+EXAMPLES
+  +cg/wipe Alice=Requested full rebuild
+  +cg/wipe #12=ST retcon after chronicle break
+
+SEE ALSO: +help cg, +help approve, +help deny

--- a/packages/cofd/src/chargen/index.ts
+++ b/packages/cofd/src/chargen/index.ts
@@ -5,3 +5,4 @@ export * from "./list.ts";
 export * from "./gifts.ts";
 export * from "./contracts.ts";
 export * from "./submit.ts";
+export * from "./wipe_core.ts";

--- a/packages/cofd/src/chargen/wipe_core.ts
+++ b/packages/cofd/src/chargen/wipe_core.ts
@@ -1,0 +1,215 @@
+/**
+ * Full character wipe — live sheet, chargen draft, approval,
+ * and splat sight flags. Used by staff +cg/wipe and self +cg/reset.
+ */
+
+import { dbojs, send, sessions } from "@ursamu/mush";
+import { initCgState } from "./state.ts";
+import { SIGHT_FLAGS } from "../support/sight.ts";
+import {
+  commentCgenJob,
+  type JobTouchResult,
+} from "../commands/approve_job.ts";
+import { sendCofdMail } from "../integrations/mail.ts";
+
+export type WipeOpts = {
+  playerId: string;
+  staffId?: string;
+  staffName?: string;
+  reason?: string;
+  /** Leave a fresh +cg draft (default true). */
+  startDraft?: boolean;
+  /** Notify target (default true). */
+  notify?: boolean;
+};
+
+export type WipeResult =
+  | {
+    ok: true;
+    name: string;
+    hadLive: boolean;
+    hadDraft: boolean;
+    wasApproved: boolean;
+    job: JobTouchResult | null;
+  }
+  | { ok: false; error: string };
+
+function bareId(id: string): string {
+  return String(id ?? "").replace(/^#/, "").trim();
+}
+
+function flagsOf(raw: unknown): Set<string> {
+  if (raw instanceof Set) {
+    return new Set(
+      [...raw].map((s) => String(s).toLowerCase()),
+    );
+  }
+  if (Array.isArray(raw)) {
+    return new Set(raw.map(String).map((s) => s.toLowerCase()));
+  }
+  return new Set(
+    String(raw ?? "")
+      .split(/[,\s]+/)
+      .filter(Boolean)
+      .map((s) => s.toLowerCase()),
+  );
+}
+
+function flagsToStr(flags: Set<string>): string {
+  return [...flags].join(" ");
+}
+
+function playerName(row: {
+  data?: Record<string, unknown>;
+  name?: string;
+}): string {
+  const d = row.data || {};
+  return String(d.name ?? row.name ?? "Unknown").trim() ||
+    "Unknown";
+}
+
+async function notifyPlayer(
+  playerId: string,
+  msg: string,
+): Promise<void> {
+  try {
+    const socks = sessions.list()
+      .filter((s) => {
+        const a = (s as unknown as { actorId?: string }).actorId;
+        return bareId(String(a ?? "")) === bareId(playerId);
+      })
+      .map((s) => s.socketId)
+      .filter(Boolean);
+    if (socks.length) send(socks, msg, {});
+  } catch (e: unknown) {
+    console.error("[cofd] wipe notify failed:", e);
+  }
+}
+
+/**
+ * Wipe live sheet + chargen + approved + sight flags.
+ * Optionally seeds a fresh +cg draft.
+ */
+export async function wipeCharacter(
+  opts: WipeOpts,
+): Promise<WipeResult> {
+  const playerId = bareId(opts.playerId);
+  if (!playerId) {
+    return { ok: false, error: "playerId required" };
+  }
+
+  const row = await dbojs.queryOne({ id: playerId });
+  if (!row) {
+    return { ok: false, error: "Player not found." };
+  }
+
+  const name = playerName(
+    row as { data?: Record<string, unknown>; name?: string },
+  );
+  const dataBag = (row.data && typeof row.data === "object")
+    ? row.data as Record<string, unknown>
+    : {};
+  const stateBag = (row as { state?: Record<string, unknown> })
+    .state;
+  const cgRaw = dataBag.cofd_cg ?? stateBag?.cofd_cg;
+  const hadLive = !!(dataBag.cofd || stateBag?.cofd);
+  const hadDraft = !!(
+    cgRaw && typeof cgRaw === "object" &&
+    (cgRaw as { sheet?: unknown }).sheet
+  );
+  const flags = flagsOf(row.flags);
+  const wasApproved = flags.has("approved");
+
+  if (!hadLive && !hadDraft && !wasApproved) {
+    return {
+      ok: false,
+      error:
+        `${name} has no live sheet, chargen draft, ` +
+        `or approved flag to wipe.`,
+    };
+  }
+
+  const jobNum = cgRaw && typeof cgRaw === "object"
+    ? (cgRaw as { submittedJob?: number }).submittedJob
+    : undefined;
+
+  const startDraft = opts.startDraft !== false;
+  const nextData = { ...dataBag };
+  delete nextData.cofd;
+  if (startDraft) {
+    nextData.cofd_cg = initCgState();
+  } else {
+    delete nextData.cofd_cg;
+  }
+
+  await dbojs.modify({ id: playerId }, "$set", {
+    data: nextData,
+  });
+  try {
+    await dbojs.modify({ id: playerId }, "$unset", {
+      "data.cofd": "",
+      ...(startDraft ? {} : { "data.cofd_cg": "" }),
+    });
+  } catch {
+    /* adapters may ignore path unset */
+  }
+
+  flags.delete("approved");
+  for (const f of SIGHT_FLAGS) flags.delete(f);
+  await dbojs.modify({ id: playerId }, "$set", {
+    flags: flagsToStr(flags),
+  });
+
+  const staffName = (opts.staffName || "Staff").trim() ||
+    "Staff";
+  const staffId = bareId(opts.staffId || "0") || "0";
+  const reason = (opts.reason || "").trim();
+
+  let job: JobTouchResult | null = null;
+  if (jobNum != null) {
+    job = await commentCgenJob(
+      jobNum,
+      playerId,
+      staffId,
+      staffName,
+      reason
+        ? `Character wiped by staff. ${reason}`
+        : "Character wiped by staff — full reset.",
+    );
+  }
+
+  if (opts.notify !== false) {
+    const why = reason ? ` Reason: ${reason}` : "";
+    await notifyPlayer(
+      playerId,
+      `%chYour Chronicles of Darkness character was ` +
+        `fully reset by ${staffName}.%cn${why}\n` +
+        `Live sheet and approval cleared. ` +
+        `Start again with %ch+cg%cn.`,
+    );
+    await sendCofdMail({
+      to: playerId,
+      subject: `Character wiped: ${name}`,
+      body: [
+        `Your Chronicles of Darkness character was ` +
+          `fully reset by ${staffName}.`,
+        reason ? `\nReason:\n${reason}` : "",
+        ``,
+        `Removed: live sheet, chargen draft, approved flag,`,
+        `and splat sight flags (fae / forsaken).`,
+        ``,
+        `Start over in-game with: +cg`,
+        `Or open the Character tab on the web.`,
+      ].filter(Boolean).join("\n"),
+    });
+  }
+
+  return {
+    ok: true,
+    name,
+    hadLive,
+    hadDraft,
+    wasApproved,
+    job,
+  };
+}

--- a/packages/cofd/src/commands/chargen.ts
+++ b/packages/cofd/src/commands/chargen.ts
@@ -19,10 +19,13 @@ import {
   addContract,
   removeContract,
   submitCgDraft,
+  wipeCharacter,
   type CofdCgState,
 } from "../chargen/index.ts";
 import { renderCgList } from "../chargen/list.ts";
 import { renderInfo } from "../info/index.ts";
+import { wipeExec } from "./wipe.ts";
+import { SIGHT_FLAGS } from "../support/sight.ts";
 
 /** Staff may still use +cg (review / testing). */
 function isStaff(actor: IDBObj): boolean {
@@ -52,6 +55,11 @@ export async function cgExec(u: IUrsamuSDK) {
   // cofd_cg and later copied to the live sheet via +approve. Without this,
   // a player can plant %c color codes in their own concept/description.
   const rawArg = u.util.stripSubs(u.cmd.args[1] ?? "").trim();
+
+  // Staff full wipe of another (or self) character bit
+  if (sw === "wipe") {
+    return await wipeExec(u);
+  }
 
   // Web /play: open Character tab instead of terminal stepper.
   // (Play client also intercepts +cg client-side; this covers any path
@@ -116,25 +124,44 @@ export async function cgExec(u: IUrsamuSDK) {
   // Load existing character generation state
   let cgState = target.state?.cofd_cg as CofdCgState | undefined;
 
-  // Reset switch — staff only once approved (non-staff blocked above).
+  // Reset switch — self only. Staff wiping others: +cg/wipe.
+  // Staff may still reset themselves when approved (blocked for
+  // non-staff above).
   if (sw === "reset" || sw === "restart") {
-    cgState = initCgState();
-    await u.db.modify(target.id, "$set", { "data.cofd_cg": cgState });
-    await u.db.modify(target.id, "$unset", { "data.cofd": "" });
-    if (target.flags?.has("approved") && u.setFlags) {
-      await u.setFlags(target.id, "!approved");
-      target.flags.delete("approved");
+    const result = await wipeCharacter({
+      playerId: target.id,
+      staffId: u.me.id,
+      staffName: u.util.displayName(u.me, u.me),
+      startDraft: true,
+      notify: false,
+    });
+    if (!result.ok) {
+      // Nothing to wipe — still seed a draft
+      cgState = initCgState();
+      await u.db.modify(target.id, "$set", {
+        "data.cofd_cg": cgState,
+      });
+    } else {
+      cgState = initCgState();
+      if (target.state) {
+        delete target.state.cofd;
+        target.state.cofd_cg = cgState;
+      }
+      target.flags?.delete("approved");
+      for (const f of SIGHT_FLAGS) target.flags?.delete(f);
     }
     u.send(await header("Character Generation: Reset"));
     u.send(
       "Your character generation state has been reset " +
-        "to a fresh Mortal sheet.",
+        "to a fresh Mortal sheet." +
+        (result.ok && result.wasApproved
+          ? " Approval cleared."
+          : ""),
     );
-    // getStageInstructions already ends with a footer.
     u.send(
       await getStageInstructions(
         u.util.displayName(target, u.me),
-        cgState,
+        cgState!,
       ),
     );
     return;

--- a/packages/cofd/src/commands/index.ts
+++ b/packages/cofd/src/commands/index.ts
@@ -6,6 +6,7 @@ export {
   denyExec,
   unapproveExec,
 } from "./approve.ts";
+export { wipeExec } from "./wipe.ts";
 export { icExec, oocExec } from "./ic_ooc.ts";
 export { notesExec } from "./notes.ts";
 export { viewsExec } from "./views.ts";

--- a/packages/cofd/src/commands/register.ts
+++ b/packages/cofd/src/commands/register.ts
@@ -379,28 +379,26 @@ addCmd({
   pattern: /^\+cg(?:\/(\S+))?\s*(.*)/i,
   lock: "connected",
   category: "Cofd",
-  help: `+cg [<switch>] [<args>]  -- Guided character generation experience.
+  help: `+cg [<switch>] [<args>]  -- Guided character generation.
 
 Switches:
-  /reset        -- Start over with a clean character sheet.
-  /set <k>=<v>  -- Set character generation fields/traits.
-  /back         -- Return to the previous stage.
-  /submit       -- Validate the current stage and advance (or finalize sheet).
-  /list [<t>]   -- Show available options. No arg lists topics. Topics:
-                   virtues, vices, templates, seemings, kiths [<seeming>],
-                   courts, merits [<category>].
-  /info <name>  -- Detail lookup. Works for any merit, condition, tilt,
-                   dread power, virtue, vice, seeming, kith, or court.
+  /reset              -- You: wipe your sheet + draft and restart.
+  /wipe <p>[=reason]  -- Staff: full wipe of another character.
+  /set <k>=<v>        -- Set chargen fields/traits.
+  /back               -- Previous stage.
+  /submit             -- Validate stage / finalize draft.
+  /list [<t>]         -- Options index or topic list.
+  /info <name>        -- Merit/condition/template detail.
 
-Example usage:
+Staff wipe removes live sheet, chargen draft, approved flag,
+and fae/forsaken, then seeds a fresh +cg draft. Reason required
+when wiping someone else.
+
+Examples:
   +cg
-  +cg/list
-  +cg/list virtues
-  +cg/set name=John Doe
-  +cg/set concept=Hacker
+  +cg/reset
+  +cg/wipe Alice=Player requested full rebuild
   +cg/set template=mortal
-  +cg/submit
-  +cg/set Strength=3
   +cg/submit`,
   exec: cgExec,
 });

--- a/packages/cofd/src/commands/wipe.ts
+++ b/packages/cofd/src/commands/wipe.ts
@@ -1,0 +1,105 @@
+// +cg/wipe — staff full character reset (sheet + chargen + approval).
+
+import { header, footer, type IUrsamuSDK } from "@ursamu/ursamu";
+import { wipeCharacter } from "../chargen/wipe_core.ts";
+import { parseTargetAndNotes } from "./approve_job.ts";
+
+function isStaff(u: IUrsamuSDK): boolean {
+  const f = u.me.flags;
+  if (!f) return false;
+  return (
+    f.has("staff") ||
+    f.has("storyteller") ||
+    f.has("wizard") ||
+    f.has("admin") ||
+    f.has("superuser")
+  );
+}
+
+export async function wipeExec(u: IUrsamuSDK): Promise<void> {
+  if (!isStaff(u)) {
+    u.send("Permission denied. Staff only.");
+    return;
+  }
+
+  const arg = u.util.stripSubs(u.cmd.args[1] ?? "").trim();
+  const { who, notes } = parseTargetAndNotes(arg);
+
+  if (!who) {
+    u.send(
+      "Usage: %ch+cg/wipe <player>[=<reason>]%cn\n" +
+        "Fully clears live sheet, chargen draft, approved " +
+        "flag, and fae/forsaken. Seeds a fresh +cg draft.\n" +
+        "Reason is required when wiping another player.",
+    );
+    return;
+  }
+
+  const target = await u.util.target(u.me, who, true);
+  if (!target) {
+    u.send(`No player matches '${who}'.`);
+    return;
+  }
+
+  const self = target.id === u.me.id;
+  if (!self && !notes) {
+    u.send(
+      "A reason is required: " +
+        "%ch+cg/wipe <player>=<reason>%cn",
+    );
+    return;
+  }
+
+  if (
+    !self &&
+    !(await u.canEdit(u.me, target))
+  ) {
+    u.send("Permission denied on that target.");
+    return;
+  }
+
+  const staffName = u.util.displayName(u.me, u.me);
+  const result = await wipeCharacter({
+    playerId: target.id,
+    staffId: u.me.id,
+    staffName,
+    reason: notes || undefined,
+    startDraft: true,
+    notify: !self,
+  });
+
+  if (!result.ok) {
+    u.send(`%cr${result.error}%cn`);
+    return;
+  }
+
+  if (self && target.state) {
+    delete target.state.cofd;
+    target.flags?.delete("approved");
+    target.flags?.delete("fae");
+    target.flags?.delete("forsaken");
+  }
+
+  const bits: string[] = [];
+  if (result.hadLive) bits.push("live sheet");
+  if (result.hadDraft) bits.push("chargen draft");
+  if (result.wasApproved) bits.push("approved");
+  bits.push("sight flags");
+
+  const lines = [
+    await header("Character Wiped"),
+    `${result.name} — full reset.`,
+    `Cleared: ${bits.join(", ")}.`,
+    `Fresh +cg draft seeded.`,
+  ];
+  if (result.job?.number != null) {
+    lines.push(
+      result.job.commented
+        ? `Comment left on CGEN job #${result.job.number}.`
+        : `CGEN job #${result.job.number} noted.`,
+    );
+  }
+  if (notes) lines.push(`Reason: ${notes}`);
+  lines.push(await footer());
+  u.send(lines.join("\n"));
+}

--- a/packages/cofd/tests/cg_wipe.test.ts
+++ b/packages/cofd/tests/cg_wipe.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Staff +cg/wipe — full character bit reset.
+ */
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "@std/assert";
+import { mockU, mockPlayer } from "./helpers/mockU.ts";
+import { wipeExec } from "../src/commands/wipe.ts";
+import { wipeCharacter } from "../src/chargen/wipe_core.ts";
+import { dbojs } from "@ursamu/mush";
+import type { CofdCgState } from "../src/chargen/index.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+async function wireDb(
+  target: ReturnType<typeof mockPlayer>,
+) {
+  await dbojs.delete({ id: target.id }).catch(() => {});
+  await dbojs.create({
+    id: target.id,
+    name: target.name,
+    flags: [...target.flags].join(" "),
+    data: {
+      ...(target.state as Record<string, unknown>),
+    },
+  });
+}
+
+Deno.test(
+  "wipeCharacter clears live sheet, draft, approved, sight",
+  OPTS,
+  async () => {
+    const id = "wipe_actor_1";
+    await dbojs.delete({ id }).catch(() => {});
+    await dbojs.create({
+      id,
+      name: "Alice",
+      flags: "player connected approved fae",
+      data: {
+        name: "Alice",
+        cofd: {
+          template: "changeling",
+          concept: "Lost",
+          attributes: { strength: 3 },
+        },
+        cofd_cg: {
+          stage: 4,
+          sheet: { template: "changeling" },
+          isSubmitted: true,
+          isApproved: false,
+        } as CofdCgState,
+      },
+    });
+
+    const result = await wipeCharacter({
+      playerId: id,
+      staffId: "99",
+      staffName: "Wiz",
+      reason: "Rebuild",
+      notify: false,
+    });
+    assertEquals(result.ok, true);
+    if (!result.ok) return;
+    assertEquals(result.hadLive, true);
+    assertEquals(result.hadDraft, true);
+    assertEquals(result.wasApproved, true);
+
+    const row = await dbojs.queryOne({ id });
+    const data = (row as { data?: Record<string, unknown> })
+      ?.data ?? {};
+    assertEquals(data.cofd, undefined);
+    const cg = data.cofd_cg as CofdCgState;
+    assertEquals(!!cg?.sheet, true);
+    assertEquals(cg.stage, 1);
+    assertEquals(cg.isSubmitted, false);
+
+    const flags = String(
+      (row as { flags?: string }).flags ?? "",
+    ).toLowerCase();
+    assertEquals(flags.includes("approved"), false);
+    assertEquals(flags.includes("fae"), false);
+
+    await dbojs.delete({ id }).catch(() => {});
+  },
+);
+
+Deno.test(
+  "wipeExec requires staff and reason for others",
+  OPTS,
+  async () => {
+    const staff = mockPlayer({
+      id: "wipe_staff",
+      name: "Wiz",
+      flags: new Set(["player", "connected", "admin"]),
+    });
+    const victim = mockPlayer({
+      id: "wipe_vic",
+      name: "Bob",
+      flags: new Set([
+        "player",
+        "connected",
+        "approved",
+      ]),
+      state: {
+        name: "Bob",
+        cofd: { template: "mortal" },
+      },
+    });
+    await wireDb(victim);
+
+    const uNoReason = mockU({
+      me: staff,
+      args: ["wipe", "Bob"],
+    });
+    uNoReason.util.target = async () => victim as never;
+    uNoReason.util.displayName = (o) => o.name ?? "?";
+    uNoReason.canEdit = async () => true;
+    await wipeExec(uNoReason as never);
+    assertStringIncludes(
+      (uNoReason as { _sent: string[] })._sent.join("\n"),
+      "reason is required",
+    );
+
+    const uOk = mockU({
+      me: staff,
+      args: ["wipe", "Bob=Full rebuild"],
+    });
+    uOk.util.target = async () => victim as never;
+    uOk.util.displayName = (o) => o.name ?? "?";
+    uOk.canEdit = async () => true;
+    // header/footer may need stubs
+    (uOk.util as Record<string, unknown>).center =
+      (s: string) => s;
+    await wipeExec(uOk as never);
+    const out = (uOk as { _sent: string[] })._sent.join("\n");
+    assertStringIncludes(out, "Wiped");
+
+    await dbojs.delete({ id: victim.id }).catch(() => {});
+    await dbojs.delete({ id: staff.id }).catch(() => {});
+  },
+);
+
+Deno.test(
+  "wipeExec rejects non-staff",
+  OPTS,
+  async () => {
+    const u = mockU({
+      me: mockPlayer({
+        flags: new Set(["player", "connected"]),
+      }),
+      args: ["wipe", "Alice=nope"],
+    });
+    await wipeExec(u as never);
+    assertStringIncludes(
+      (u as { _sent: string[] })._sent.join("\n"),
+      "Permission denied",
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- **+cg/wipe <player>[=reason]** (staff) — full wipe of live sheet, chargen, approved, sight flags; seeds fresh draft
- **+cg/reset** (self) — same wipe core; strips fae/forsaken too
- Help: `help cg/wipe`

## Test plan
- [x] cg_wipe tests
- [ ] Publish cofd-plugin@1.2.11 and court pin