### PR TITLE
fix(site): hero logo home-only (not every wiki page)

### DIFF
--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.79
+
+- Hero logo (banner art) is **home only** — wiki/help/play
+  stay compact under the nav (no logo on every wiki page)
+- SSR hides banner on non-home paths; site.js matches
+- Cache-bust SITE_ASSET_V → 20260806wikinologo
+
 ## 0.1.78
 
 - Fix hero logo on `/`: SSR no longer emits a second

--- a/packages/site/deno.json
+++ b/packages/site/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/site",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Public UrsaMU front-end shell \u2014 layout framing, design tokens, swappable skins.",
   "license": "MIT",
   "exports": {

--- a/packages/site/public/js/site.js
+++ b/packages/site/public/js/site.js
@@ -203,15 +203,17 @@
 
   /**
    * Shell chrome: home height vs compact (no title height).
-   * - home + wiki: Figma hero (top bg + banner offset)
-   * - help / login / profile: compact under nav
+   * - home only: Figma hero (logo banner + offset)
+   * - wiki / help / login / profile / play: compact under nav
    */
   function applyShellChrome() {
     if (!shell) return;
     var cfg = siteConfig || {};
-    var heroMode = MODE === "home" || MODE === "wiki";
+    // Hero logo is home-only — wiki pages stay compact.
+    var heroMode = MODE === "home";
     var compactMode = MODE === "login" || MODE === "profile" ||
-      MODE === "help" || MODE === "chargen" || MODE === "play";
+      MODE === "help" || MODE === "chargen" || MODE === "play" ||
+      MODE === "wiki";
 
     if (heroMode) {
       if (cfg.plainBg) shell.classList.add("is-plain");
@@ -228,7 +230,7 @@
       shell.classList.add("is-compact");
       shell.classList.add("is-mode-no-hero");
     } else if (heroMode) {
-      // Same home-height hero chrome (title / offset / bg)
+      // Home-height hero chrome (title / offset / bg)
       shell.classList.remove("is-mode-no-hero");
       var bSrc = String(cfg.bannerImage || "").trim();
       var hTitle = String(cfg.title || "").trim();
@@ -310,13 +312,14 @@
     }
 
     var bannerSrc = String(cfg.bannerImage || "").trim();
-    // Figma: home + wiki share full hero; help stays compact
-    var showHero = MODE === "home" || MODE === "wiki";
+    // Hero logo (banner art) is home-only — not on wiki/help/etc.
+    var showHero = MODE === "home";
     if (banner) {
-      // SPA return to / must unhide after help/play/chargen
       if (showHero) {
         banner.hidden = false;
         banner.removeAttribute("hidden");
+      } else {
+        banner.hidden = true;
       }
     }
     if (bannerImg) {
@@ -349,7 +352,7 @@
         bannerTitle.hidden = true;
       }
     }
-    // Connect under title on home only (Figma wiki has logo, not host)
+    // Connect under title on home only
     var telnetHost = String((cfg && cfg.telnet) || "").trim();
     if (bannerConnect) {
       if (MODE === "home" && heroTitle && telnetHost) {
@@ -714,9 +717,9 @@
     );
     var title = String(page.title || page.path || "").trim();
     if (!bodyHtml.trim() && !title) return;
-    // Wiki uses Figma home-height hero; optional bgImage kept for API
+    // Wiki stays compact (no hero logo). Re-apply chrome after nav.
     if (MODE === "wiki") {
-      pageBgImage = page.bgImage !== false;
+      pageBgImage = false;
       if (siteConfig && Object.keys(siteConfig).length) {
         applyConfig(siteConfig);
       } else {
@@ -740,8 +743,8 @@
   function injectWikiListing(opts) {
     if (!mainEl) return;
     opts = opts || {};
-    // Index / directories still use Figma hero chrome
-    pageBgImage = true;
+    // Wiki index/directories: compact, no hero logo
+    pageBgImage = false;
     if (MODE === "wiki") {
       if (siteConfig && Object.keys(siteConfig).length) {
         applyConfig(siteConfig);
@@ -897,8 +900,8 @@
     } else if (MODE === "wiki") {
       if (leftAside) leftAside.hidden = false;
       if (rightAside) rightAside.hidden = false;
-      // Figma wiki: full hero banner (same as home)
-      if (banner) banner.hidden = false;
+      // Wiki: no hero logo — compact under nav
+      if (banner) banner.hidden = true;
       applyShellChrome();
     } else if (MODE === "help") {
       if (leftAside) leftAside.hidden = false;

--- a/packages/site/src/config.ts
+++ b/packages/site/src/config.ts
@@ -111,7 +111,7 @@ export function markNavActive(
 }
 
 /** Cache-bust query for shipped site CSS (bump when layout/tokens change). */
-export const SITE_ASSET_V = "20260806homelogo";
+export const SITE_ASSET_V = "20260806wikinologo";
 
 /** Resolve stylesheet href for the active skin. */
 export function resolveSkinHref(cfg: SitePluginConfig): string {

--- a/packages/site/src/html.ts
+++ b/packages/site/src/html.ts
@@ -55,6 +55,20 @@ function ensureClass(attrs: string, token: string): string {
 }
 
 /**
+ * True when the request is the public home page (hero logo allowed).
+ * Wiki/help/play/etc. stay compact — no banner art.
+ */
+export function isHomePath(path?: string): boolean {
+  if (path == null || path === "") return true;
+  let p = path.split("?")[0].split("#")[0].trim();
+  if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  if (p === "" || p === "/" || p === "/site" || p === "/site/index.html") {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Apply cfg into the shipped index.html template.
  * Pure string rewrite — keep markers stable in public/index.html.
  */
@@ -71,9 +85,12 @@ export function injectSiteHtml(
   const dataSkin = cfg.skinCss
     ? "custom"
     : (named.startsWith("/") ? "custom" : named);
-  const banner = (cfg.bannerImage ?? "").trim();
-  // Figma no-banner: no image + no hero title → content higher
-  const compact = !banner && !heroTitle;
+  // Banner logo only on home — wiki/help must not flash hero art.
+  const home = isHomePath(opts.path);
+  const banner = home ? (cfg.bannerImage ?? "").trim() : "";
+  const heroTitleOut = home ? heroTitle : "";
+  // Compact when no hero image and no title (non-home always compact)
+  const compact = !banner && !heroTitleOut;
 
   let out = html;
 
@@ -164,13 +181,13 @@ export function injectSiteHtml(
     },
   );
 
-  // Hero H1 — only when title is set (image-only banners hide via CSS)
-  if (heroTitle) {
+  // Hero H1 — home only (image-only banners hide via CSS)
+  if (heroTitleOut) {
     out = out.replace(
       /(<h1\b[^>]*\bdata-site-banner-title\b)([^>]*)(>)[\s\S]*?(<\/h1>)/i,
       (_m, open: string, mid: string, gt: string, close: string) => {
         const m = String(mid).replace(/\s*\bhidden\b/gi, "");
-        const body = `\n          ${esc(heroTitle)}\n        `;
+        const body = `\n          ${esc(heroTitleOut)}\n        `;
         return `${open}${m}${gt}${body}${close}`;
       },
     );
@@ -185,7 +202,7 @@ export function injectSiteHtml(
     );
   }
 
-  // Banner image
+  // Banner image — home only
   if (banner) {
     out = out.replace(
       /(<img\b[^>]*\bdata-site-banner-img\b)([^>]*)(>)/i,
@@ -211,11 +228,29 @@ export function injectSiteHtml(
         return `${open}${m}${close}`;
       },
     );
+  } else {
+    // Non-home: hide entire banner block (no logo flash)
+    out = out.replace(
+      /(<header\b)([^>]*\bdata-site-banner\b[^>]*)(>)/i,
+      (_m, open: string, mid: string, close: string) => {
+        let m = String(mid);
+        if (!/\bhidden\b/i.test(m)) m += " hidden";
+        return `${open}${m}${close}`;
+      },
+    );
+    out = out.replace(
+      /(<img\b[^>]*\bdata-site-banner-img\b)([^>]*)(>)/i,
+      (_m, open: string, mid: string, close: string) => {
+        let m = String(mid).replace(/\bsrc\s*=\s*"[^"]*"/i, "");
+        if (!/\bhidden\b/i.test(m)) m += " hidden";
+        return `${open}${m}${close}`;
+      },
+    );
   }
 
-  // Connect host under hero when title + telnet (no right-rail panel)
+  // Connect host under hero when home + title + telnet
   const telnet = (cfg.telnet ?? "").trim();
-  if (heroTitle && telnet) {
+  if (heroTitleOut && telnet) {
     const href = `telnet://${escAttr(telnet)}`;
     out = out.replace(
       /(<a\b[^>]*\bdata-site-banner-connect\b)([^>]*)(>)[\s\S]*?(<\/a>)/i,
@@ -240,13 +275,13 @@ export function injectSiteHtml(
     );
   }
 
-  // Shell modifiers: plainBg + compact (no image, no title)
+  // Shell modifiers: plainBg + compact (wiki/help = compact)
   if (cfg.plainBg || compact) {
     out = out.replace(
       /(<div\b)([^>]*\bdata-site-shell\b[^>]*)(>)/i,
       (_m, open: string, mid: string, close: string) => {
         let m = String(mid);
-        if (cfg.plainBg) m = ensureClass(m, "is-plain");
+        if (cfg.plainBg || compact) m = ensureClass(m, "is-plain");
         if (compact) m = ensureClass(m, "is-compact");
         return `${open}${m}${close}`;
       },

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -33,7 +33,7 @@ async function loadGameConfig(): Promise<unknown> {
 
 export const plugin: IPlugin = {
   name: "site",
-  version: "0.1.78",
+  version: "0.1.79",
   description:
     "Public front-end shell — layout framing + design tokens + skins.",
 

--- a/packages/site/tests/config.test.ts
+++ b/packages/site/tests/config.test.ts
@@ -173,6 +173,21 @@ Deno.test("injectSiteHtml: skin + title", OPTS, () => {
   assertEquals(out.includes(">Wiki</a>"), true);
   assertEquals(out.includes("Court of Miracles</a>"), true);
 
+  // Wiki path: no hero logo (banner hidden, compact shell)
+  const onWiki = injectSiteHtml(src, {
+    skin: "court",
+    title: "Court of Miracles",
+    bannerImage: "/site/theme/installed/court/imgs/header.png",
+    nav: [{ label: "Home", href: "/site/" }],
+  }, { path: "/wiki/lore" });
+  assertEquals(onWiki.includes("has-image"), false);
+  assertEquals(onWiki.includes("is-compact"), true);
+  const wikiBanner = onWiki.match(
+    /<header\b[^>]*\bdata-site-banner\b[^>]*>/i,
+  );
+  assertEquals(!!wikiBanner, true);
+  assertEquals(/\bhidden\b/i.test(wikiBanner![0]), true);
+
   const onLogin = injectSiteHtml(src, {
     skin: "court",
     title: "Court of Miracles",


### PR DESCRIPTION
## Summary
- Banner/logo art only on `/` (home)
- Wiki/help/play stay compact under nav
- `@ursamu/site@0.1.79` already on JSR and prod

## Test plan
- [x] unit tests
- [x] prod: home has logo, `/wiki/*` banner hidden