### PR TITLE
feat(mush): interactive cmd UI helpers 1.0.34

### DIFF
--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -428,18 +428,83 @@ and how to register handlers.
 
 ## Structured UI (`u.ui`)
 
-For web client panels (JSON output, not text):
+For web client panels (JSON output, not text). Telnet never receives
+`data.ui` — keep a text fallback.
+
+**Preferred helpers** (from `@ursamu/mush`):
 
 ```typescript
-// Layout — posts a structured result to the web client
+import {
+  sendListLayout,
+  sendCmdLayout,
+  lookAction,
+  cmdAction,
+  headerComp,
+  textComp,
+  actionsComp,
+} from "@ursamu/mush";
+
+// List command (inventory / who / glance pattern)
+sendListLayout(u, {
+  metaType: "inventory",
+  title: "Bag",
+  items: things.map((t) => ({
+    id: t.id,
+    label: u.util.displayName(t, u.me),
+    action: lookAction(`#${t.id}`), // click → look #id
+  })),
+  emptyText: "Nothing.",
+  footerText: `${things.length} items.`,
+});
+
+// Free-form (score pattern)
+sendCmdLayout(u, {
+  metaType: "score",
+  textFallback: "plain telnet card…",
+  components: [
+    headerComp("Score"),
+    textComp("…"),
+    actionsComp("Quick", [
+      { label: "Inventory", action: cmdAction("inventory") },
+    ]),
+  ],
+});
+```
+
+Theme knobs (`config/config.json`):
+
+```json
+"plugins": {
+  "globals": {
+    "theme": {
+      "cmdUi": { "lookOnClick": true },
+      "look": { "showExitAliases": true }
+    }
+  }
+}
+```
+
+`lookOnClick: false` disables auto `look …` actions from
+`lookAction()`.
+
+Low-level API (same contract the helpers emit):
+
+```typescript
 u.ui.layout({
   components: [
     { type: "header", title: "Character Sheet" },
     { type: "table", content: [["Name", u.util.displayName(u.me, u.me)]] }
   ]
 });
+```
 
-// Render a template string
+Component types the `/play` client renders: `header`, `text`,
+`media`, `entity-list`, `actions`, `table`, `list`, `panel`.
+Interactive items use `{ action: { cmd: "…" } }` — the FE sends
+`cmd` as normal player input.
+
+```typescript
+// Template helper (not the layout path)
 const html = u.ui.render("<b>{{name}}</b>", { name: "Alice" });
 ```
 ---

--- a/packages/mush/CHANGELOG.md
+++ b/packages/mush/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.34
+
+- Shared interactive command UI helpers (`cmd-ui.ts`):
+  `sendListLayout`, `sendCmdLayout`, `lookAction`, builders.
+- Theme: `plugins.globals.theme.cmdUi.lookOnClick`
+- Refactor inventory / +i / who / +glance onto helpers
+- **score** web layout with quick actions (inventory, who,
+  look me); telnet text card unchanged
+- Docs: scripting guide Structured UI section
+
 ## 1.0.30
 
 - Web register: first player on empty DB gets

--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts",

--- a/packages/mush/mod.ts
+++ b/packages/mush/mod.ts
@@ -173,6 +173,28 @@ export {
 export { execLook, defaultConformatHandler }                       from "./src/verbs/look.ts";
 export { execHome, execInventory }                                 from "./src/verbs/home.ts";
 export {
+  prefersCmdUi,
+  getCmdUiTheme,
+  cmdAction,
+  lookAction,
+  headerComp,
+  textComp,
+  entityListComp,
+  actionsComp,
+  buildListComponents,
+  renderListText,
+  sendListLayout,
+  sendCmdLayout,
+} from "./src/verbs/cmd-ui.ts";
+export type {
+  CmdAction,
+  CmdEntityItem,
+  CmdActionItem,
+  CmdUiComponent,
+  CmdUiTheme,
+  ListLayoutOpts,
+} from "./src/verbs/cmd-ui.ts";
+export {
   enterObject,
   leaveObject,
 } from "./src/verbs/enter-leave.ts";

--- a/packages/mush/src/verbs/cmd-ui.ts
+++ b/packages/mush/src/verbs/cmd-ui.ts
@@ -1,0 +1,201 @@
+/**
+ * Shared helpers for interactive web command UIs.
+ *
+ * Pattern (mirror look):
+ *   1. Build header + text + entity-list / actions
+ *   2. Items carry `{ action: { cmd } }` for FE click → input
+ *   3. Web: u.ui.layout; telnet: chrome text
+ *   4. Optional theme via plugins.globals.theme.cmdUi
+ */
+import { getConfig } from "@ursamu/core";
+import type { IUrsamuSDK } from "../commands/types.ts";
+import {
+  divider,
+  footer,
+  header,
+} from "../format/handlers.ts";
+
+export type CmdAction = { cmd: string };
+
+export type CmdEntityItem = {
+  id?: string;
+  label: string;
+  sublabel?: string;
+  meta?: string;
+  dbref?: string;
+  role?: string;
+  action?: CmdAction;
+};
+
+export type CmdActionItem = {
+  id?: string;
+  label: string;
+  badge?: string;
+  dbref?: string;
+  action: CmdAction;
+};
+
+export type CmdUiComponent = {
+  type: string;
+  title?: string;
+  content?: unknown;
+  items?: unknown[];
+  url?: string;
+  alt?: string;
+};
+
+export type CmdUiTheme = {
+  /** When true, list helpers may attach look actions (default true). */
+  lookOnClick: boolean;
+};
+
+export type ListLayoutOpts = {
+  /** Layout meta.type for the FE (e.g. "inventory"). */
+  metaType: string;
+  title: string;
+  /** entity-list section title */
+  listTitle?: string;
+  items: CmdEntityItem[];
+  emptyText: string;
+  footerText: string;
+  /** Optional chip row under the list */
+  actions?: CmdActionItem[];
+  /** Telnet body lines (already labeled); if omitted, uses item labels */
+  textLines?: string[];
+};
+
+/** True when this session should get structured play layouts. */
+export function prefersCmdUi(u: IUrsamuSDK): boolean {
+  return u.clientType === "web" && typeof u.ui?.layout === "function";
+}
+
+/** plugins.globals.theme.cmdUi — small knobs shared by list commands. */
+export function getCmdUiTheme(): CmdUiTheme {
+  const raw = (getConfig<Record<string, unknown>>(
+    "plugins.globals.theme.cmdUi",
+  ) ?? {}) as Record<string, unknown>;
+  return {
+    lookOnClick: raw.lookOnClick !== false,
+  };
+}
+
+export function cmdAction(cmd: string): CmdAction {
+  return { cmd: String(cmd).trim() };
+}
+
+/** Look-target action when theme.lookOnClick is on. */
+export function lookAction(
+  nameOrId: string,
+): CmdAction | undefined {
+  if (!getCmdUiTheme().lookOnClick) return undefined;
+  const t = String(nameOrId || "").trim();
+  if (!t) return undefined;
+  return cmdAction(`look ${t}`);
+}
+
+export function headerComp(title: string): CmdUiComponent {
+  return { type: "header", title };
+}
+
+export function textComp(content: string): CmdUiComponent {
+  return { type: "text", content };
+}
+
+export function entityListComp(
+  title: string,
+  items: CmdEntityItem[],
+): CmdUiComponent {
+  return { type: "entity-list", title, items };
+}
+
+export function actionsComp(
+  title: string,
+  items: CmdActionItem[],
+): CmdUiComponent {
+  return { type: "actions", title, items };
+}
+
+/** header → entity-list → optional actions → footer text */
+export function buildListComponents(
+  opts: ListLayoutOpts,
+): CmdUiComponent[] {
+  const n = opts.items.length;
+  const listTitle = opts.listTitle ??
+    (n === 0 ? "Empty" : (n === 1 ? "1 item" : `${n} items`));
+  const comps: CmdUiComponent[] = [
+    headerComp(opts.title),
+    entityListComp(listTitle, opts.items),
+  ];
+  if (opts.actions?.length) {
+    comps.push(actionsComp("Commands", opts.actions));
+  }
+  comps.push(
+    textComp(n === 0 ? opts.emptyText : opts.footerText),
+  );
+  return comps;
+}
+
+/** Telnet chrome for the same list shape. */
+export function renderListText(
+  u: IUrsamuSDK,
+  opts: ListLayoutOpts,
+): string {
+  const width = (u.me.state?.termWidth as number) || 78;
+  const lines: string[] = [];
+  lines.push(header(opts.title, "=", width));
+  if (opts.items.length === 0) {
+    lines.push(`  ${opts.emptyText}`);
+  } else if (opts.textLines?.length) {
+    for (const row of opts.textLines) {
+      lines.push(row.startsWith("  ") ? row : `  ${row}`);
+    }
+  } else {
+    for (const it of opts.items) {
+      const bits = [it.label];
+      if (it.meta) bits.push(it.meta);
+      if (it.sublabel) bits.push(it.sublabel);
+      lines.push(`  ${bits.join("  ")}`);
+    }
+  }
+  lines.push(divider("", "-", width));
+  lines.push(`  ${opts.footerText}`);
+  lines.push(footer("", "=", width));
+  return lines.join("\n");
+}
+
+/**
+ * Web → u.ui.layout; otherwise → u.send(text).
+ * Prefer this over hand-rolling clientType branches.
+ */
+export function sendListLayout(
+  u: IUrsamuSDK,
+  opts: ListLayoutOpts,
+): void {
+  if (prefersCmdUi(u)) {
+    u.ui.layout({
+      components: buildListComponents(opts),
+      meta: { type: opts.metaType },
+    });
+    return;
+  }
+  u.send(renderListText(u, opts));
+}
+
+/** Free-form web layout with telnet fallback string. */
+export function sendCmdLayout(
+  u: IUrsamuSDK,
+  opts: {
+    components: CmdUiComponent[];
+    metaType: string;
+    textFallback: string;
+  },
+): void {
+  if (prefersCmdUi(u)) {
+    u.ui.layout({
+      components: opts.components,
+      meta: { type: opts.metaType },
+    });
+    return;
+  }
+  u.send(opts.textFallback);
+}

--- a/packages/mush/src/verbs/globals/glance.ts
+++ b/packages/mush/src/verbs/globals/glance.ts
@@ -3,7 +3,12 @@
  */
 import { addCmd } from "../../commands/addCmd.ts";
 import type { IUrsamuSDK, IDBObj } from "../../commands/types.ts";
-import { divider, footer, header } from "../../format/handlers.ts";
+import {
+  divider,
+  footer,
+  header,
+} from "../../format/handlers.ts";
+import { lookAction, sendListLayout } from "../cmd-ui.ts";
 import { fmtIdle } from "./time-fmt.ts";
 
 function shortDesc(obj: IDBObj): string {
@@ -52,7 +57,6 @@ export function renderGlanceText(
       const name = u.util.displayName(p, u.me);
       const idle = fmtIdle(p.state?.lastCommand);
       const desc = shortDesc(p);
-      // Approximate columns (color codes don't take visible width)
       lines.push(
         `  ${name.padEnd(26)}${idle.padEnd(6)}${desc}`,
       );
@@ -65,49 +69,6 @@ export function renderGlanceText(
   );
   lines.push(footer("", "=", width));
   return lines.join("\n");
-}
-
-function sendGlanceWeb(
-  u: IUrsamuSDK,
-  roomName: string,
-  players: IDBObj[],
-): void {
-  if (!u.ui?.layout) return;
-  const items = players.map((p) => {
-    const name = plainName(p);
-    return {
-      id: p.id,
-      label: u.util.displayName(p, u.me),
-      meta: fmtIdle(p.state?.lastCommand),
-      sublabel: shortDesc(p) || undefined,
-      action: name
-        ? { type: "cmd" as const, cmd: `look ${name}` }
-        : { type: "cmd" as const, cmd: `look #${p.id}` },
-    };
-  });
-  const n = players.length;
-  u.ui.layout({
-    components: [
-      {
-        type: "header",
-        title: `At a glance — ${roomName}`,
-      },
-      {
-        type: "entity-list",
-        title: n === 0
-          ? "Empty"
-          : (n === 1 ? "1 player" : `${n} players`),
-        items,
-      },
-      {
-        type: "text",
-        content: n === 0
-          ? "No one else is here."
-          : `${n} player${n === 1 ? "" : "s"} here.`,
-      },
-    ],
-    meta: { type: "glance" },
-  });
 }
 
 export async function execGlance(u: IUrsamuSDK): Promise<void> {
@@ -123,9 +84,36 @@ export async function execGlance(u: IUrsamuSDK): Promise<void> {
     })
   );
   const roomName = String(here.name ?? "here");
+  const n = players.length;
+  const textLines = players.map((p) => {
+    const name = u.util.displayName(p, u.me);
+    const idle = fmtIdle(p.state?.lastCommand);
+    const desc = shortDesc(p);
+    return `${name.padEnd(26)}${idle.padEnd(6)}${desc}`;
+  });
 
+  // Web uses list helper; telnet keeps columnar chrome.
   if (u.clientType === "web") {
-    sendGlanceWeb(u, roomName, players);
+    sendListLayout(u, {
+      metaType: "glance",
+      title: `At a glance — ${roomName}`,
+      listTitle: n === 0
+        ? "Empty"
+        : (n === 1 ? "1 player" : `${n} players`),
+      items: players.map((p) => {
+        const name = plainName(p);
+        return {
+          id: p.id,
+          label: u.util.displayName(p, u.me),
+          meta: fmtIdle(p.state?.lastCommand),
+          sublabel: shortDesc(p) || undefined,
+          action: lookAction(name || `#${p.id}`),
+        };
+      }),
+      emptyText: "No one else is here.",
+      footerText: `${n} player${n === 1 ? "" : "s"} here.`,
+      textLines,
+    });
     return;
   }
   u.send(renderGlanceText(u, roomName, players));

--- a/packages/mush/src/verbs/globals/plus-inv.ts
+++ b/packages/mush/src/verbs/globals/plus-inv.ts
@@ -3,7 +3,11 @@
  */
 import { addCmd } from "../../commands/addCmd.ts";
 import type { IUrsamuSDK, IDBObj } from "../../commands/types.ts";
-import { divider, footer, header } from "../../format/handlers.ts";
+import {
+  lookAction,
+  renderListText,
+  sendListLayout,
+} from "../cmd-ui.ts";
 
 function visibleItems(
   raw: IDBObj[],
@@ -32,53 +36,16 @@ export function renderInv(
   who: string,
   items: IDBObj[],
 ): string {
-  const width = (u.me.state?.termWidth as number) || 78;
-  const lines: string[] = [];
-  lines.push(header(`Carried by ${who}`, "=", width));
-  if (items.length === 0) {
-    lines.push("  Nothing.");
-  } else {
-    for (const o of items) {
-      lines.push(`  ${itemLabel(u, o)}`);
-    }
-  }
-  lines.push(divider("", "-", width));
   const n = items.length;
-  lines.push(`  ${n} item${n === 1 ? "" : "s"}.`);
-  lines.push(footer("", "=", width));
-  return lines.join("\n");
-}
-
-function sendInvWeb(
-  u: IUrsamuSDK,
-  who: string,
-  items: IDBObj[],
-): void {
-  if (!u.ui?.layout) return;
-  const list = items.map((o) => ({
-    id: o.id,
-    label: itemLabel(u, o),
-    action: { type: "cmd" as const, cmd: `look #${o.id}` },
-  }));
-  const n = items.length;
-  u.ui.layout({
-    components: [
-      { type: "header", title: `Carried by ${who}` },
-      {
-        type: "entity-list",
-        title: n === 0
-          ? "Empty"
-          : (n === 1 ? "1 item" : `${n} items`),
-        items: list,
-      },
-      {
-        type: "text",
-        content: n === 0
-          ? "Nothing."
-          : `${n} item${n === 1 ? "" : "s"}.`,
-      },
-    ],
-    meta: { type: "inventory" },
+  return renderListText(u, {
+    metaType: "inventory",
+    title: `Carried by ${who}`,
+    items: items.map((o) => ({
+      id: o.id,
+      label: itemLabel(u, o),
+    })),
+    emptyText: "Nothing.",
+    footerText: `${n} item${n === 1 ? "" : "s"}.`,
   });
 }
 
@@ -116,12 +83,19 @@ export async function execPlusInv(u: IUrsamuSDK): Promise<void> {
   const raw = await u.db.search({ location: target.id });
   const items = visibleItems(raw, canEdit);
   const who = u.util.displayName(target, u.me);
+  const n = items.length;
 
-  if (u.clientType === "web") {
-    sendInvWeb(u, who, items);
-    return;
-  }
-  u.send(renderInv(u, who, items));
+  sendListLayout(u, {
+    metaType: "inventory",
+    title: `Carried by ${who}`,
+    items: items.map((o) => ({
+      id: o.id,
+      label: itemLabel(u, o),
+      action: lookAction(`#${o.id}`),
+    })),
+    emptyText: "Nothing.",
+    footerText: `${n} item${n === 1 ? "" : "s"}.`,
+  });
 }
 
 addCmd({

--- a/packages/mush/src/verbs/home.ts
+++ b/packages/mush/src/verbs/home.ts
@@ -1,7 +1,11 @@
 import { gameHooks } from "@ursamu/core";
 import { addCmd } from "../commands/addCmd.ts";
 import type { IUrsamuSDK, IDBObj } from "../commands/types.ts";
-import { divider, footer, header } from "../format/handlers.ts";
+import {
+  lookAction,
+  renderListText,
+  sendListLayout,
+} from "./cmd-ui.ts";
 
 export function execHome(u: IUrsamuSDK): void {
   const actor = u.me;
@@ -34,53 +38,16 @@ export function renderInventoryText(
   items: IDBObj[],
 ): string {
   const who = u.util.displayName(u.me, u.me);
-  const width = (u.me.state?.termWidth as number) || 78;
-  const lines: string[] = [];
-  lines.push(header(`${who}'s Inventory`, "=", width));
-  if (items.length === 0) {
-    lines.push("  You are not carrying anything.");
-  } else {
-    for (const item of items) {
-      lines.push(`  ${itemLabel(u, item)}`);
-    }
-  }
-  lines.push(divider("", "-", width));
   const n = items.length;
-  lines.push(`  ${n} item${n === 1 ? "" : "s"}.`);
-  lines.push(footer("", "=", width));
-  return lines.join("\n");
-}
-
-function sendInventoryWeb(
-  u: IUrsamuSDK,
-  items: IDBObj[],
-): void {
-  if (!u.ui?.layout) return;
-  const who = u.util.displayName(u.me, u.me);
-  const list = items.map((item) => ({
-    id: item.id,
-    label: itemLabel(u, item),
-    action: { type: "cmd" as const, cmd: `look #${item.id}` },
-  }));
-  const n = items.length;
-  u.ui.layout({
-    components: [
-      { type: "header", title: `${who}'s Inventory` },
-      {
-        type: "entity-list",
-        title: n === 0
-          ? "Empty"
-          : (n === 1 ? "1 item" : `${n} items`),
-        items: list,
-      },
-      {
-        type: "text",
-        content: n === 0
-          ? "You are not carrying anything."
-          : `${n} item${n === 1 ? "" : "s"}.`,
-      },
-    ],
-    meta: { type: "inventory" },
+  return renderListText(u, {
+    metaType: "inventory",
+    title: `${who}'s Inventory`,
+    items: items.map((item) => ({
+      id: item.id,
+      label: itemLabel(u, item),
+    })),
+    emptyText: "You are not carrying anything.",
+    footerText: `${n} item${n === 1 ? "" : "s"}.`,
   });
 }
 
@@ -95,11 +62,19 @@ export async function execInventory(u: IUrsamuSDK): Promise<void> {
   if (ctx.handled) return;
 
   const items = carriedItems(u.me);
-  if (u.clientType === "web") {
-    sendInventoryWeb(u, items);
-    return;
-  }
-  u.send(renderInventoryText(u, items));
+  const who = u.util.displayName(u.me, u.me);
+  const n = items.length;
+  sendListLayout(u, {
+    metaType: "inventory",
+    title: `${who}'s Inventory`,
+    items: items.map((item) => ({
+      id: item.id,
+      label: itemLabel(u, item),
+      action: lookAction(`#${item.id}`),
+    })),
+    emptyText: "You are not carrying anything.",
+    footerText: `${n} item${n === 1 ? "" : "s"}.`,
+  });
 }
 
 addCmd({

--- a/packages/mush/src/verbs/social.ts
+++ b/packages/mush/src/verbs/social.ts
@@ -6,6 +6,15 @@ import {
   header,
   resolveGlobalFormat,
 } from "../format/handlers.ts";
+import {
+  actionsComp,
+  cmdAction,
+  headerComp,
+  lookAction,
+  sendCmdLayout,
+  sendListLayout,
+  textComp,
+} from "./cmd-ui.ts";
 
 function formatIdle(lastCmd: unknown): string {
   if (typeof lastCmd !== "number" || isNaN(lastCmd)) return "---";
@@ -69,45 +78,6 @@ function buildDefaultWhoBlock(
   return lines.join("\n");
 }
 
-/** Structured who for /play (entity-list + header). */
-function sendWhoWebLayout(
-  u: IUrsamuSDK,
-  players: IDBObj[],
-): void {
-  if (!u.ui?.layout) return;
-  const items = players.map((p) => {
-    const name = plainName(p) || playerLabel(u, p);
-    const idle = formatIdle(p.state?.lastCommand);
-    const doing = String((p.state?.doing as string) || "");
-    return {
-      id: p.id,
-      label: playerLabel(u, p),
-      meta: idle,
-      sublabel: doing || undefined,
-      action: name
-        ? { type: "cmd" as const, cmd: `look ${name}` }
-        : undefined,
-    };
-  });
-  const n = players.length;
-  u.ui.layout({
-    components: [
-      { type: "header", title: "Who's Online" },
-      {
-        type: "entity-list",
-        title: n === 1 ? "1 player" : `${n} players`,
-        items,
-      },
-      {
-        type: "text",
-        content:
-          `${n} player${n === 1 ? "" : "s"} online.`,
-      },
-    ],
-    meta: { type: "who" },
-  });
-}
-
 export async function execWho(u: IUrsamuSDK): Promise<void> {
   const players = (await u.db.search({ flags: /connected/i }))
     .filter((p) =>
@@ -144,13 +114,33 @@ export async function execWho(u: IUrsamuSDK): Promise<void> {
   const customWho = blockOverride != null &&
     blockOverride !== defaultBlock;
   if (!customWho && u.clientType === "web") {
-    sendWhoWebLayout(u, players);
+    const n = players.length;
+    sendListLayout(u, {
+      metaType: "who",
+      title: "Who's Online",
+      listTitle: n === 1 ? "1 player" : `${n} players`,
+      items: players.map((p) => {
+        const name = plainName(p) || playerLabel(u, p);
+        const doing = String((p.state?.doing as string) || "");
+        return {
+          id: p.id,
+          label: playerLabel(u, p),
+          meta: formatIdle(p.state?.lastCommand),
+          sublabel: doing || undefined,
+          action: lookAction(name),
+        };
+      }),
+      emptyText: "No one is connected.",
+      footerText:
+        `${n} player${n === 1 ? "" : "s"} online.`,
+      textLines: rows,
+    });
     return;
   }
   u.send(text);
 }
 
-export function execScore(u: IUrsamuSDK): void {
+function scoreText(u: IUrsamuSDK): string {
   const me = u.me;
   const name = (me.state.moniker as string) ||
     (me.state.name as string) || me.name;
@@ -164,7 +154,42 @@ export function execScore(u: IUrsamuSDK): void {
   output += `Money: ${
     (me.state.money as number) || 0
   } credits\n`;
-  u.send(output);
+  return output;
+}
+
+export function execScore(u: IUrsamuSDK): void {
+  const me = u.me;
+  const name = (me.state.moniker as string) ||
+    (me.state.name as string) || me.name;
+  const flags = Array.from(me.flags).join(" ");
+  const doing = (me.state.doing as string) || "Nothing.";
+  const money = (me.state.money as number) || 0;
+  const body =
+    `DBRef: #${me.id}\nFlags: ${flags}\n` +
+    `Doing: ${doing}\nMoney: ${money} credits`;
+
+  sendCmdLayout(u, {
+    metaType: "score",
+    textFallback: scoreText(u),
+    components: [
+      headerComp(`Player Scorecard: ${name}`),
+      textComp(body),
+      actionsComp("Quick", [
+        {
+          label: "Inventory",
+          action: cmdAction("inventory"),
+        },
+        {
+          label: "Who",
+          action: cmdAction("who"),
+        },
+        {
+          label: "Look me",
+          action: cmdAction("look me"),
+        },
+      ]),
+    ],
+  });
 }
 
 export async function execDoing(u: IUrsamuSDK): Promise<void> {
@@ -276,6 +301,9 @@ addCmd({
   lock: "connected",
   category: "Information",
   help: `score  — Display your character scorecard.
+
+Web play shows a layout with quick actions (inventory, who,
+look me). Telnet gets the classic text card.
 
 Examples:
   score`,

--- a/packages/mush/tests/cmd_ui.test.ts
+++ b/packages/mush/tests/cmd_ui.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared interactive command UI helpers.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  buildListComponents,
+  cmdAction,
+  getCmdUiTheme,
+  lookAction,
+  prefersCmdUi,
+  renderListText,
+  sendListLayout,
+} from "../src/verbs/cmd-ui.ts";
+import type { IUrsamuSDK } from "../src/commands/types.ts";
+import { setConfig } from "@ursamu/core";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function mockU(opts: {
+  clientType?: string;
+  layouts?: unknown[];
+  sent?: string[];
+} = {}): IUrsamuSDK {
+  const layouts = opts.layouts ?? [];
+  const sent = opts.sent ?? [];
+  return {
+    clientType: opts.clientType ?? "web",
+    me: {
+      id: "1",
+      name: "Tester",
+      flags: new Set(["player", "connected"]),
+      state: { name: "Tester", termWidth: 78 },
+      location: "r1",
+      contents: [],
+    },
+    ui: {
+      layout: (o: unknown) => {
+        layouts.push(o);
+      },
+      panel: () => ({}),
+      render: (t: string) => t,
+    },
+    send: (m: string) => {
+      sent.push(m);
+    },
+    util: {
+      displayName: (o: { name?: string }) => o.name ?? "?",
+    },
+  } as unknown as IUrsamuSDK;
+}
+
+Deno.test("prefersCmdUi: web with layout only", OPTS, () => {
+  assertEquals(prefersCmdUi(mockU({ clientType: "web" })), true);
+  assertEquals(
+    prefersCmdUi(mockU({ clientType: "telnet" })),
+    false,
+  );
+});
+
+Deno.test("buildListComponents: header list text", OPTS, () => {
+  const comps = buildListComponents({
+    metaType: "demo",
+    title: "Demo",
+    items: [
+      {
+        label: "Sword",
+        action: cmdAction("look #9"),
+      },
+    ],
+    emptyText: "Nothing.",
+    footerText: "1 item.",
+  });
+  assertEquals(comps.map((c) => c.type), [
+    "header",
+    "entity-list",
+    "text",
+  ]);
+  assertEquals(comps[0].title, "Demo");
+  const list = comps[1];
+  assertEquals(
+    (list.items as { action?: { cmd: string } }[])[0]
+      .action?.cmd,
+    "look #9",
+  );
+});
+
+Deno.test("lookAction respects theme.lookOnClick", OPTS, () => {
+  setConfig("plugins.globals.theme.cmdUi", {
+    lookOnClick: false,
+  });
+  assertEquals(getCmdUiTheme().lookOnClick, false);
+  assertEquals(lookAction("Alice"), undefined);
+  setConfig("plugins.globals.theme.cmdUi", {
+    lookOnClick: true,
+  });
+  assertEquals(lookAction("Alice")?.cmd, "look Alice");
+  setConfig("plugins.globals.theme.cmdUi", {});
+});
+
+Deno.test("sendListLayout: web uses layout not send", OPTS, () => {
+  const layouts: unknown[] = [];
+  const sent: string[] = [];
+  const u = mockU({ clientType: "web", layouts, sent });
+  sendListLayout(u, {
+    metaType: "inventory",
+    title: "Bag",
+    items: [{ label: "Key", action: cmdAction("look #3") }],
+    emptyText: "Empty",
+    footerText: "1 item.",
+  });
+  assertEquals(layouts.length, 1);
+  assertEquals(sent.length, 0);
+  const body = layouts[0] as {
+    meta: { type: string };
+    components: unknown[];
+  };
+  assertEquals(body.meta.type, "inventory");
+  assertEquals(body.components.length, 3);
+});
+
+Deno.test("sendListLayout: telnet uses text chrome", OPTS, () => {
+  const layouts: unknown[] = [];
+  const sent: string[] = [];
+  const u = mockU({ clientType: "telnet", layouts, sent });
+  sendListLayout(u, {
+    metaType: "inventory",
+    title: "Bag",
+    items: [{ label: "Key" }],
+    emptyText: "Empty",
+    footerText: "1 item.",
+  });
+  assertEquals(layouts.length, 0);
+  assertEquals(sent.length, 1);
+  assertEquals(sent[0].includes("Key"), true);
+  assertEquals(sent[0].includes("1 item."), true);
+});
+
+Deno.test("renderListText: empty list", OPTS, () => {
+  const u = mockU({ clientType: "telnet" });
+  const t = renderListText(u, {
+    metaType: "x",
+    title: "Bag",
+    items: [],
+    emptyText: "Nothing here.",
+    footerText: "0 items.",
+  });
+  assertEquals(t.includes("Nothing here."), true);
+  assertEquals(t.includes("0 items."), true);
+});


### PR DESCRIPTION
## Summary
- Shared `sendListLayout` / `sendCmdLayout` for web play UIs
- Inventory, who, glance, +i refactored onto helpers
- **score** interactive quick actions on web
- Theme `plugins.globals.theme.cmdUi.lookOnClick`
- Docs update in scripting guide

## Test plan
- [x] cmd_ui / who / inventory / globals_cmds tests
- [ ] JSR publish + court prod pin