### PR TITLE
feat(channels): 1.2.4 web hub + court delivery

### DIFF
--- a/packages/channels/CHANGELOG.md
+++ b/packages/channels/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to `@ursamu/channels` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.4] - 2026-08-09
+
+### Changed
+
+- Monorepo source synced with court/JSR web hub (1.2.0–1.2.3):
+  channel chat bubbles, dense `/play` hub, colored badges
+- Dual room join (name + id) for Discord inject delivery
+- Staff REST list returns `{ items, channels }`; history via
+  `/messages` as well as `/history`
+
+## [1.2.3] - 2026-08-07
+
+### Fixed
+
+- Channel badge keeps MUSH color codes (no uppercase/truncate)
+  so web clients can render colored headers
+
+## [1.2.2] - 2026-08-07
+
+### Added
+
+- Web channel speech uses chat bubbles (like say/pose/OOC)
+  with channel badge, avatar, and pose/say modes
+
+## [1.2.1] - 2026-08-07
+
+### Changed
+
+- Dense `/play` hub (mail/jobs grid): alias | on/off | channel |
+  title·online; available | count | flags | join as
+- Compact alias tools (mute/who/leave with alias badge)
+- Web who UI (`alias who`, `allcom who`, `@cwho`) and history
+  panels (`@chanhistory` / `@chantranscript`)
+- Hub refresh after clearcom / comtitle
+
+## [1.2.0] - 2026-08-05
+
+### Added
+
+- Interactive `/play` hub for `@channel`, `clist`, `comlist`
+- Click-to-join, speak fill, mute, leave
+
 ## [1.1.0] - 2026-08-04
 
 ### Added

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -3,18 +3,33 @@
 MUX-style chat channels for UrsaMU: player aliases, staff admin,
 history, and optional connect/join announcements.
 
-**Current version: 1.0.0** (stable). See `CHANGELOG.md`.
+**Current version: 1.2.1**. See `CHANGELOG.md`.
 
 ## 1.0 contract (public API)
+
+### Web UI (`/play`)
+
+`@channel`, `+channels`, `@clist`, and `comlist` open a dense
+interactive hub on web clients (same grid density as mail/jobs):
+
+- **Your aliases** — click to speak (prompt fill); role = on/off
+- **Alias tools** — mute / who / leave (badge = alias)
+- **Available** — one-click join (default alias); online + flags
+- **Who** — `alias who`, `allcom who`, `@cwho` as entity lists
+- **History** — `@chanhistory` / `@chantranscript` as panels
+- **Staff** — create / set / history / who / full list fills
+
+Telnet keeps classic text listings.
 
 ### Supported player commands
 
 | Command | Purpose |
 |---------|---------|
+| `@channel` / `+channels` | Channel hub (web UI) |
 | `addcom <alias>=<channel>` | Join with alias |
 | `delcom <alias>` | Drop one alias |
 | `clearcom` | Drop all aliases |
-| `comlist` | List your aliases |
+| `comlist` | List your aliases (web hub) |
 | `allcom on\|off\|who` | Bulk mute / unmute / who |
 | `comtitle <alias>=<title>` | Per-channel title |
 | `<alias> <text>` | Speak |
@@ -84,7 +99,7 @@ Or list `"@ursamu/channels"` in `server.plugins`.
 
 - `jsr:@ursamu/mush` >= 1.0.0
 - `jsr:@ursamu/core` >= 1.0.0
-- `jsr:@ursamu/help` >= 0.1.9 (help files)
+- `jsr:@ursamu/help` >= 1.2.1 (help files)
 
 ### Explicit non-goals (not TinyMUX 2.12)
 

--- a/packages/channels/deno.json
+++ b/packages/channels/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/channels",
-  "version": "1.1.0",
+  "version": "1.2.4",
   "exports": {
     ".": "./mod.ts",
     "./channel-events": "./src/channel-events.ts"
@@ -20,8 +20,9 @@
     "@std/assert": "jsr:@std/assert@^0.224.0",
     "@ursamu/mush": "jsr:@ursamu/mush@^1.0.0",
     "@ursamu/core": "jsr:@ursamu/core@^1.0.0",
-    "@ursamu/help-plugin": "jsr:@ursamu/help@^0.1.9",
-    "@ursamu/help": "jsr:@ursamu/help@^0.1.9"
+    "@ursamu/help-plugin": "jsr:@ursamu/help@^1.2.1",
+    "@ursamu/help": "jsr:@ursamu/help@^1.2.1",
+    "@ursamu/help/register": "jsr:@ursamu/help@^1.2.1/register"
   },
   "publish": {
     "include": [

--- a/packages/channels/mod.ts
+++ b/packages/channels/mod.ts
@@ -10,7 +10,7 @@
 
 import { DBO, gameHooks, getConfig } from "@ursamu/mush";
 import { addMiddleware, sessions } from "@ursamu/core";
-import { registerHelpDir } from "@ursamu/help-plugin";
+import { registerHelpDir } from "@ursamu/help/register";
 import type { IPlugin, SessionEvent } from "@ursamu/mush";
 import type { IMiddlewareFn } from "@ursamu/core";
 
@@ -166,9 +166,9 @@ const onStaffReady = (): void => {
 
 export const channelsPlugin: IPlugin = {
   name: "@ursamu/channels",
-  version: "1.1.0",
+  version: "1.2.4",
   description:
-    "Channel system: chat, aliases, history, staff REST/UI.",
+    "Channel system: chat, aliases, history, web hub, staff REST.",
 
   init: () => {
     import("./src/commands/verbs.ts");

--- a/packages/channels/src/chan-deliver.ts
+++ b/packages/channels/src/chan-deliver.ts
@@ -1,0 +1,133 @@
+/**
+ * Deliver a channel line to listeners — telnet text + web chat UI.
+ */
+import { rooms, sessions, send, sendPayload } from "@ursamu/core";
+
+export type ChanSpeechKind = "say" | "pose" | "semi";
+
+export type ChanChatOpts = {
+  kind: ChanSpeechKind;
+  /** Display name (moniker ok). */
+  name: string;
+  /**
+   * Bubble body only:
+   *  say  → spoken words (no quotes / "says")
+   *  pose → action after name
+   *  semi → action glued to name
+   */
+  text: string;
+  /** Channel badge, e.g. PUBLIC */
+  tag: string;
+  /** Full channel name */
+  channel: string;
+  actorId: string;
+  avatar?: string | null;
+};
+
+function socketIdsForChannel(chanName: string): string[] {
+  const keys = new Set<string>([
+    chanName,
+    chanName.toLowerCase(),
+  ]);
+  const seen = new Set<string>();
+  for (const key of keys) {
+    try {
+      for (const sid of rooms.members(key)) seen.add(sid);
+    } catch {
+      /* ignore */
+    }
+  }
+  return [...seen];
+}
+
+/**
+ * Channel badge text for web UI.
+ * Preserves MUSH color codes so the client can render them
+ * (do not uppercase / truncate — that mangles %c sequences).
+ */
+export function channelTagFromHeader(
+  header: string,
+  fallback: string,
+): string {
+  const h = String(header || "").trim();
+  if (h) return h;
+  return String(fallback || "CHAN").trim() || "CHAN";
+}
+
+/** Plain badge label for aria / logs (codes stripped). */
+export function plainChannelTag(
+  header: string,
+  fallback: string,
+): string {
+  const raw = channelTagFromHeader(header, fallback);
+  const plain = raw
+    .replace(/%c[nNrRgGyYbBmMcCwWxXhHuUiI]/gi, "")
+    .replace(/%c?<#([0-9a-fA-F]{6})>/gi, "")
+    .replace(/<#([0-9a-fA-F]{6})>/g, "")
+    .replace(/%x[nNrRgGyYbBmMcCwWxXhHuUiI]/gi, "")
+    .replace(/%[nrtbR]/g, "")
+    // deno-lint-ignore no-control-regex
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .trim();
+  return plain || String(fallback || "CHAN");
+}
+
+/**
+ * Telnet: classic "HEADER body" line.
+ * Web: structured chat bubble (same family as say/pose/OOC).
+ */
+export function deliverChannelSpeech(opts: {
+  chanName: string;
+  telnetLine: string;
+  chat: ChanChatOpts;
+}): void {
+  const members = socketIdsForChannel(opts.chanName);
+  if (!members.length) {
+    // Still try broadcast by name (legacy)
+    try {
+      rooms.broadcast(opts.chanName, opts.telnetLine);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  const ui = {
+    type: "chat",
+    kind: "channel",
+    channelMode: opts.chat.kind,
+    tag: opts.chat.tag,
+    channel: opts.chat.channel,
+    actorId: opts.chat.actorId,
+    name: opts.chat.name,
+    avatar: opts.chat.avatar ?? null,
+    text: opts.chat.text,
+    at: Date.now(),
+  };
+
+  for (const sid of members) {
+    const ct = sessions.get(sid)?.meta?.clientType;
+    if (ct === "web") {
+      sendPayload(sid, "", { ui });
+    } else {
+      send([sid], opts.telnetLine);
+    }
+  }
+}
+
+/** Plain system line (join/leave) — text for all, no bubble. */
+export function deliverChannelPlain(
+  chanName: string,
+  line: string,
+): void {
+  const members = socketIdsForChannel(chanName);
+  if (!members.length) {
+    try {
+      rooms.broadcast(chanName, line);
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+  send(members, line);
+}

--- a/packages/channels/src/commands/chan-ui.ts
+++ b/packages/channels/src/commands/chan-ui.ts
@@ -1,0 +1,606 @@
+/**
+ * Dense web layouts for channels (/play) — mail/jobs density.
+ *
+ * Telnet keeps classic text listings from exec.ts.
+ * Middleware (alias who/on/off) can emit layouts via emitLayout().
+ */
+import { sendPayload, sessions } from "@ursamu/core";
+import type { IUrsamuSDK } from "@ursamu/mush";
+import type { IChanEntry, IChannel } from "../types.ts";
+
+export function prefersWebUi(u: IUrsamuSDK): boolean {
+  return u.clientType === "web" &&
+    typeof (u as { ui?: { layout?: unknown } }).ui?.layout ===
+      "function";
+}
+
+/** True when the socket is a web /play client. */
+export function socketIsWeb(socketId: string): boolean {
+  try {
+    const s = sessions.get(socketId) as
+      | { meta?: { clientType?: string } }
+      | undefined;
+    return s?.meta?.clientType === "web";
+  } catch {
+    return false;
+  }
+}
+
+/** Emit a layout payload without a full IUrsamuSDK (middleware). */
+export function emitLayout(
+  socketId: string,
+  components: unknown[],
+  metaType: string,
+  textFallback = "",
+): void {
+  if (!socketIsWeb(socketId)) return;
+  sendPayload(socketId, textFallback, {
+    ui: {
+      type: "layout",
+      components,
+      meta: { type: metaType },
+    },
+  });
+}
+
+export function act(cmd: string): { cmd: string } {
+  return { cmd };
+}
+
+export function fill(text: string): { fill: string } {
+  return { fill: text };
+}
+
+function isStaff(u: IUrsamuSDK): boolean {
+  const f = u.me.flags;
+  return f.has("admin") || f.has("wizard") ||
+    f.has("superuser");
+}
+
+function myAliases(u: IUrsamuSDK): IChanEntry[] {
+  return ((u.me.state as Record<string, unknown>).channels as
+    | IChanEntry[]
+    | undefined) ?? [];
+}
+
+function joinedAlias(
+  aliases: IChanEntry[],
+  chanName: string,
+): IChanEntry | undefined {
+  const n = chanName.toLowerCase();
+  return aliases.find((e) =>
+    String(e.channel || "").toLowerCase() === n
+  );
+}
+
+function defaultAlias(chan: IChannel): string {
+  const a = String(chan.alias || "").trim();
+  if (a) return a.toLowerCase();
+  return String(chan.name || "ch")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, 6) || "ch";
+}
+
+function flagsOf(chan: IChannel): string {
+  return `${chan.hidden ? "H" : "-"}${
+    chan.masking ? "M" : "-"
+  }${chan.logHistory ? "L" : "-"}${
+    chan.announce ? "A" : "-"
+  }`;
+}
+
+function onlineOf(
+  channels: ChanListRow[],
+  chanName: string,
+): number | undefined {
+  const n = chanName.toLowerCase();
+  const row = channels.find((c) =>
+    String(c.name || "").toLowerCase() === n
+  );
+  return row?.online;
+}
+
+function sendLayout(
+  u: IUrsamuSDK,
+  components: unknown[],
+  metaType: string,
+  textFallback: string,
+): void {
+  if (prefersWebUi(u)) {
+    u.ui.layout({
+      components,
+      meta: { type: metaType },
+    });
+    return;
+  }
+  u.send(textFallback);
+}
+
+export type ChanListRow = IChannel & {
+  online?: number;
+};
+
+type Act = {
+  label: string;
+  badge?: string;
+  action: { cmd?: string; fill?: string };
+};
+
+/** Full hub: my aliases + available + tools. */
+export function sendChannelsHub(
+  u: IUrsamuSDK,
+  opts: {
+    channels: ChanListRow[];
+    mode?: "hub" | "list" | "mine";
+  },
+): void {
+  const aliases = myAliases(u);
+  const staff = isStaff(u);
+  const mode = opts.mode || "hub";
+  const channels = opts.channels.filter((c) => {
+    if (!c.hidden) return true;
+    return staff;
+  });
+
+  // alias | on/off | channel | title · N online
+  const mineItems = aliases.map((e) => {
+    const on = e.active !== false;
+    const online = onlineOf(channels, e.channel);
+    const title = e.title ? String(e.title).slice(0, 24) : "";
+    const sub = [
+      title,
+      online != null ? `${online} online` : "",
+    ].filter(Boolean).join(" · ") || "—";
+    return {
+      id: e.alias,
+      label: e.alias,
+      role: on ? "on" : "off",
+      meta: e.channel,
+      sublabel: sub,
+      action: fill(`${e.alias} `),
+    };
+  });
+
+  // Compact controls: toggle (badge) · who · leave  per alias
+  const mineActs: Act[] = [];
+  for (const e of aliases.slice(0, 12)) {
+    const on = e.active !== false;
+    mineActs.push(
+      {
+        label: on ? "mute" : "unmute",
+        badge: e.alias,
+        action: act(`${e.alias} ${on ? "off" : "on"}`),
+      },
+      {
+        label: "who",
+        badge: e.alias,
+        action: act(`${e.alias} who`),
+      },
+      {
+        label: "leave",
+        badge: e.alias,
+        action: act(`@channel/leave ${e.alias}`),
+      },
+    );
+  }
+
+  // name | N online | flags | join as alias
+  const availItems = channels
+    .filter((c) => !joinedAlias(aliases, c.name))
+    .map((c) => {
+      const alias = defaultAlias(c);
+      const fl = flagsOf(c);
+      return {
+        id: c.id || c.name,
+        label: c.name,
+        role: c.online != null
+          ? `${c.online}`
+          : "—",
+        meta: fl !== "----" ? fl : "join",
+        sublabel: `as ${alias}` +
+          (c.header ? ` · ${c.header}` : ""),
+        action: act(
+          `@channel/join ${c.name}=${alias}`,
+        ),
+      };
+    });
+
+  // Full list mode (clist/full): every channel as dense row
+  const listItems = mode === "list"
+    ? channels.map((c) => {
+      const joined = joinedAlias(aliases, c.name);
+      const fl = flagsOf(c);
+      return {
+        id: c.id || c.name,
+        label: c.name,
+        role: c.online != null
+          ? `${c.online}`
+          : "—",
+        meta: fl,
+        sublabel: joined
+          ? `joined · ${joined.alias}`
+          : `as ${defaultAlias(c)}`,
+        action: joined
+          ? fill(`${joined.alias} `)
+          : act(
+            `@channel/join ${c.name}=${defaultAlias(c)}`,
+          ),
+      };
+    })
+    : [];
+
+  const topActs: Act[] = [
+    { label: "Refresh", action: act("@channel") },
+    { label: "My aliases", action: act("comlist") },
+    { label: "All on", action: act("allcom on") },
+    { label: "All off", action: act("allcom off") },
+    {
+      label: "Join…",
+      action: fill("@channel/join Channel=alias"),
+    },
+    {
+      label: "Speak…",
+      action: fill(
+        aliases[0] ? `${aliases[0].alias} ` : "pub ",
+      ),
+    },
+    {
+      label: "Title…",
+      action: fill("@comtitle alias=title"),
+    },
+  ];
+
+  if (staff) {
+    topActs.push(
+      {
+        label: "Create…",
+        action: fill("@chancreate "),
+      },
+      {
+        label: "History…",
+        action: fill("@chanhistory "),
+      },
+      {
+        label: "Set…",
+        action: fill("@chanset chan/prop=val"),
+      },
+      {
+        label: "Full list",
+        action: act("@clist/full"),
+      },
+      {
+        label: "Who…",
+        action: fill("@cwho "),
+      },
+    );
+  }
+
+  const onN = aliases.filter((e) => e.active !== false).length;
+  const countLine = aliases.length
+    ? `${aliases.length} alias(es) · ${onN} on · ` +
+      `${channels.length} channel(s)`
+    : `${channels.length} channel(s) · join below`;
+
+  const components: unknown[] = [
+    { type: "header", title: "Channels" },
+    { type: "text", content: countLine },
+    {
+      type: "actions",
+      title: "Commands",
+      items: topActs.slice(0, 14),
+    },
+  ];
+
+  if (mode === "list") {
+    components.push({
+      type: "entity-list",
+      title: channels.length
+        ? `All channels (${channels.length})`
+        : "No channels",
+      items: listItems,
+    });
+  } else {
+    if (mode !== "list") {
+      components.push({
+        type: "entity-list",
+        title: aliases.length
+          ? `Your aliases (${aliases.length})`
+          : "No aliases yet",
+        items: mineItems.length
+          ? mineItems
+          : [{
+            id: "none",
+            label: "(join below)",
+            role: "—",
+            meta: "—",
+            sublabel: "click a channel to join",
+          }],
+      });
+      if (mineActs.length) {
+        components.push({
+          type: "actions",
+          title: "Alias tools",
+          items: mineActs.slice(0, 36),
+        });
+      }
+    }
+
+    if (mode !== "mine") {
+      components.push({
+        type: "entity-list",
+        title: availItems.length
+          ? `Available (${availItems.length})`
+          : "No open channels",
+        items: availItems.length
+          ? availItems
+          : [{
+            id: "none-a",
+            label: "(all joined or none)",
+            role: "—",
+            meta: "—",
+            sublabel: "—",
+          }],
+      });
+    }
+  }
+
+  const textLines = [
+    "--- Channels ---",
+    ...aliases.map((e) =>
+      `  ${e.alias} → ${e.channel}` +
+      (e.active === false ? " [off]" : " [on]")
+    ),
+    "--- Available ---",
+    ...channels.map((c) =>
+      `  ${c.name}` +
+        (joinedAlias(aliases, c.name)
+          ? " (joined)"
+          : ` (join as ${defaultAlias(c)})`)
+    ),
+    "  @channel/join Name=alias  ·  comlist  ·  alias text",
+  ];
+
+  sendLayout(
+    u,
+    components,
+    mode === "list"
+      ? "channels-list"
+      : mode === "mine"
+      ? "channels-mine"
+      : "channels-hub",
+    textLines.join("\n"),
+  );
+}
+
+/** Compact “my aliases only” (comlist). */
+export function sendMyAliasesUi(
+  u: IUrsamuSDK,
+  textFallback: string,
+): void {
+  if (!prefersWebUi(u)) {
+    u.send(textFallback);
+    return;
+  }
+  sendChannelsHub(u, {
+    channels: [],
+    mode: "mine",
+  });
+}
+
+export type WhoRow = {
+  name: string;
+  status?: string;
+  isPlayer?: boolean;
+};
+
+/** Build who layout parts (shared by SDK + middleware). */
+export function buildWhoLayout(
+  opts: {
+    channel: string;
+    rows: WhoRow[];
+    alias?: string;
+  },
+): {
+  components: unknown[];
+  metaType: string;
+  text: string;
+} {
+  const ch = opts.channel;
+  const items = opts.rows.map((r, i) => ({
+    id: `${i}-${r.name}`,
+    label: r.name,
+    role: r.status || "on",
+    meta: r.isPlayer === false ? "obj" : "player",
+    sublabel: ch,
+  }));
+
+  const acts: Act[] = [
+    { label: "Hub", action: act("@channel") },
+    {
+      label: "Refresh",
+      action: act(
+        opts.alias
+          ? `${opts.alias} who`
+          : `@cwho ${ch}`,
+      ),
+    },
+  ];
+  if (opts.alias) {
+    acts.unshift({
+      label: "Speak…",
+      action: fill(`${opts.alias} `),
+    });
+  }
+
+  const count = items.length
+    ? `${items.length} on ${ch}`
+    : `Nobody on ${ch}`;
+
+  return {
+    metaType: "channels-who",
+    text: [
+      `Who on ${ch}:`,
+      ...opts.rows.map((r) =>
+        `  ${r.name}` +
+        (r.status ? ` [${r.status}]` : "")
+      ),
+    ].join("\n"),
+    components: [
+      { type: "header", title: `Who · ${ch}` },
+      { type: "text", content: count },
+      {
+        type: "entity-list",
+        title: "Present",
+        items: items.length
+          ? items
+          : [{
+            id: "empty",
+            label: "(empty)",
+            role: "—",
+            meta: "—",
+            sublabel: ch,
+          }],
+      },
+      {
+        type: "actions",
+        title: "Channel",
+        items: acts,
+      },
+    ],
+  };
+}
+
+/** Who-on-channel — dense list + back to hub. */
+export function sendChannelWhoUi(
+  u: IUrsamuSDK,
+  opts: {
+    channel: string;
+    rows: WhoRow[];
+    alias?: string;
+  },
+): void {
+  const built = buildWhoLayout(opts);
+  sendLayout(u, built.components, built.metaType, built.text);
+}
+
+/** Middleware path — emit who layout to a web socket. */
+export function emitChannelWho(
+  socketId: string,
+  opts: {
+    channel: string;
+    rows: WhoRow[];
+    alias?: string;
+  },
+): boolean {
+  if (!socketIsWeb(socketId)) return false;
+  const built = buildWhoLayout(opts);
+  emitLayout(
+    socketId,
+    built.components,
+    built.metaType,
+    built.text,
+  );
+  return true;
+}
+
+export type HistLine = {
+  timestamp: number;
+  message: string;
+  playerName?: string;
+};
+
+/** Channel history — panels for each line (readable wrap). */
+export function sendChannelHistoryUi(
+  u: IUrsamuSDK,
+  opts: {
+    channel: string;
+    lines: HistLine[];
+  },
+): void {
+  const ch = opts.channel;
+  const comps: unknown[] = [
+    {
+      type: "header",
+      title: `History · ${ch}`,
+    },
+    {
+      type: "text",
+      content: opts.lines.length
+        ? `Last ${opts.lines.length} line(s)`
+        : "No history logged.",
+    },
+  ];
+
+  for (let i = 0; i < opts.lines.length; i++) {
+    const line = opts.lines[i];
+    const when = Number.isFinite(line.timestamp)
+      ? new Date(line.timestamp).toUTCString()
+      : "";
+    const who = line.playerName
+      ? String(line.playerName).slice(0, 24)
+      : "";
+    const title = [
+      `#${i + 1}`,
+      who,
+      when,
+    ].filter(Boolean).join(" · ");
+    comps.push({
+      type: "panel",
+      title: title || `Line ${i + 1}`,
+      content: String(line.message || "").slice(0, 2000),
+    });
+  }
+
+  comps.push({
+    type: "actions",
+    title: "Channel",
+    items: [
+      { label: "Hub", action: act("@channel") },
+      {
+        label: "More…",
+        action: fill(`@chanhistory ${ch}=`),
+      },
+      {
+        label: "Refresh",
+        action: act(
+          `@chanhistory ${ch}=${Math.max(opts.lines.length, 20)}`,
+        ),
+      },
+    ],
+  });
+
+  sendLayout(
+    u,
+    comps,
+    "channels-history",
+    [
+      `History ${ch}:`,
+      ...opts.lines.map((l) =>
+        `  [${new Date(l.timestamp).toUTCString()}] ` +
+        l.message
+      ),
+    ].join("\n"),
+  );
+}
+
+/** After join/leave/mute — rebuild hub with fresh channel list. */
+export async function refreshChannelsHub(
+  u: IUrsamuSDK,
+): Promise<void> {
+  if (!prefersWebUi(u)) return;
+  const list = (await u.chan.list()) as ChanListRow[];
+  try {
+    const { rooms } = await import("jsr:@ursamu/core@^1.0.0");
+    for (const c of list) {
+      try {
+        c.online = rooms.members(c.name).length;
+      } catch {
+        c.online = undefined;
+      }
+    }
+  } catch {
+    /* core rooms optional */
+  }
+  sendChannelsHub(u, { channels: list, mode: "hub" });
+}

--- a/packages/channels/src/commands/exec.ts
+++ b/packages/channels/src/commands/exec.ts
@@ -2,6 +2,35 @@ import { DBO, getConfig } from "@ursamu/mush";
 import type { IUrsamuSDK } from "@ursamu/mush";
 import type { IChanEntry } from "../types.ts";
 import { announceChannelMember } from "../announce.ts";
+import {
+  prefersWebUi,
+  refreshChannelsHub,
+  sendChannelHistoryUi,
+  sendChannelWhoUi,
+  sendChannelsHub,
+  sendMyAliasesUi,
+  type ChanListRow,
+  type WhoRow,
+} from "./chan-ui.ts";
+
+async function listWithOnline(
+  u: IUrsamuSDK,
+): Promise<ChanListRow[]> {
+  const list = (await u.chan.list()) as ChanListRow[];
+  try {
+    const { rooms } = await import("jsr:@ursamu/core@^1.0.0");
+    for (const c of list) {
+      try {
+        c.online = rooms.members(c.name).length;
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    /* core optional */
+  }
+  return list;
+}
 
 export async function execChannel(u: IUrsamuSDK): Promise<void> {
   const sw = (u.cmd.args[0] || "").toLowerCase().trim();
@@ -23,6 +52,7 @@ export async function execChannel(u: IUrsamuSDK): Promise<void> {
     const who = String(u.me.state.name || u.me.name || u.me.id);
     await announceChannelMember(chan, who, "join");
     u.send(`You have joined channel ${chan} with alias ${alias}.`);
+    await refreshChannelsHub(u);
     return;
   }
 
@@ -42,11 +72,12 @@ export async function execChannel(u: IUrsamuSDK): Promise<void> {
     }
     await u.chan.leave(arg);
     u.send(`You have left the channel with alias ${arg}.`);
+    await refreshChannelsHub(u);
     return;
   }
 
   const cmdName = u.cmd.name.toLowerCase().replace(/^@/, "");
-  const list = (await u.chan.list()) as any[];
+  const list = await listWithOnline(u);
 
   if (
     cmdName === "clist" ||
@@ -56,6 +87,15 @@ export async function execChannel(u: IUrsamuSDK): Promise<void> {
   ) {
     const isFull = sw === "full";
     const isHeaders = sw === "headers";
+
+    // Web: interactive hub (full/headers still get richer meta).
+    if (prefersWebUi(u) && !isHeaders) {
+      sendChannelsHub(u, {
+        channels: list,
+        mode: isFull ? "list" : "hub",
+      });
+      return;
+    }
 
     if (isFull) {
       // Real fields only (no Obj/Charge/Balance/Messages economy stubs).
@@ -75,8 +115,7 @@ export async function execChannel(u: IUrsamuSDK): Promise<void> {
           chan.announce ? "A" : "-"
         }`;
         const own = chan.owner || "God";
-        const { rooms } = await import("@ursamu/core");
-        const users = rooms.members(chan.name).length;
+        const users = chan.online ?? 0;
         u.send(
           `--- ${u.util.ljust(chan.name, 12)} ` +
             `${u.util.ljust(flagsStr, 10)} ` +
@@ -126,6 +165,12 @@ export async function execChannel(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
+  // Default @channel — hub on web, short list on telnet.
+  if (prefersWebUi(u)) {
+    sendChannelsHub(u, { channels: list, mode: "hub" });
+    return;
+  }
+
   u.send("--- Channels ---");
   for (const chan of list as { name: string; alias?: string }[]) {
     u.send(`${chan.name} [${chan.alias || "No Alias"}]`);
@@ -156,6 +201,17 @@ export async function execChanhistory(u: IUrsamuSDK): Promise<void> {
     u.send(`No history available for channel %ch${name}%cn.`);
     return;
   }
+  if (prefersWebUi(u)) {
+    sendChannelHistoryUi(u, {
+      channel: name,
+      lines: history.map((entry) => ({
+        timestamp: entry.timestamp,
+        message: entry.message,
+        playerName: (entry as { playerName?: string }).playerName,
+      })),
+    });
+    return;
+  }
   u.send(`--- Channel History: ${name} (last ${history.length}) ---`);
   for (const entry of history) {
     u.send(`[${new Date(entry.timestamp).toUTCString()}] ${entry.message}`);
@@ -181,6 +237,17 @@ export async function execChantranscript(u: IUrsamuSDK): Promise<void> {
   }
   if (history.length === 0) {
     u.send(`No history available for channel %ch${name}%cn.`);
+    return;
+  }
+  if (prefersWebUi(u)) {
+    sendChannelHistoryUi(u, {
+      channel: name,
+      lines: history.map((entry) => ({
+        timestamp: entry.timestamp,
+        message: entry.message,
+        playerName: (entry as { playerName?: string }).playerName,
+      })),
+    });
     return;
   }
   u.send(`--- Transcript: ${name} (${lines} lines) ---`);
@@ -415,6 +482,7 @@ async function doAddcom(u: IUrsamuSDK, arg: string): Promise<void> {
   const who = String(u.me.state.name || u.me.name || u.me.id);
   await announceChannelMember(channel, who, "join");
   u.send(`Added alias %ch${alias}%cn for channel %ch${channel}%cn.`);
+  await refreshChannelsHub(u);
 }
 
 async function doDelcom(u: IUrsamuSDK, arg: string): Promise<void> {
@@ -433,6 +501,7 @@ async function doDelcom(u: IUrsamuSDK, arg: string): Promise<void> {
   }
   await u.chan.leave(arg);
   u.send(`Removed channel alias %ch${arg}%cn.`);
+  await refreshChannelsHub(u);
 }
 
 async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
@@ -448,7 +517,7 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
       if (entry.alias && !entry.active) {
         entry.active = true;
         count++;
-        const { sessions, rooms } = await import("@ursamu/core");
+        const { sessions, rooms } = await import("jsr:@ursamu/core@^1.0.0");
         const playerSessions = sessions.list().filter(
           (s) => s.sessionId === u.me.id || (s as any).actorId === u.me.id,
         );
@@ -459,10 +528,13 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
     }
     if (count > 0) {
       await u.db.modify(u.me.id, "$set", { "data.channels": channels });
+      // Keep hydrated state in sync for web hub.
+      (u.me.state as Record<string, unknown>).channels = channels;
       u.send(`Turned on all channel aliases (${count} channel(s)).`);
     } else {
       u.send("All channels are already on.");
     }
+    await refreshChannelsHub(u);
     return;
   }
 
@@ -472,7 +544,7 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
       if (entry.alias && entry.active) {
         entry.active = false;
         count++;
-        const { sessions, rooms } = await import("@ursamu/core");
+        const { sessions, rooms } = await import("jsr:@ursamu/core@^1.0.0");
         const playerSessions = sessions.list().filter(
           (s) => s.sessionId === u.me.id || (s as any).actorId === u.me.id,
         );
@@ -483,10 +555,12 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
     }
     if (count > 0) {
       await u.db.modify(u.me.id, "$set", { "data.channels": channels });
+      (u.me.state as Record<string, unknown>).channels = channels;
       u.send(`Turned off all channel aliases (${count} channel(s)).`);
     } else {
       u.send("All channels are already off.");
     }
+    await refreshChannelsHub(u);
     return;
   }
 
@@ -495,43 +569,43 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
       u.send("You have no channel aliases.");
       return;
     }
-    const { rooms, sessions } = await import("@ursamu/core");
-    const { dbojs } = await import("@ursamu/mush");
-    for (const entry of channels) {
-      const sockets = rooms.members(entry.channel);
-      const playerIds = new Set<string>();
-      for (const socketId of sockets) {
-        const s = sessions.get(socketId);
-        const actorId = (s as any)?.actorId;
-        if (actorId) playerIds.add(actorId);
-      }
-      const players: string[] = [];
-      const objects: string[] = [];
-      for (const id of playerIds) {
-        const dbObj = await dbojs.queryOne({ id });
-        if (dbObj) {
-          const name = (dbObj.data?.name as string) || dbObj.id;
-          // IDBOBJ.flags is a space-delimited string
-          const isPlayer = String(dbObj.flags ?? "")
-            .split(/\s+/)
-            .includes("player");
-          if (isPlayer) {
-            players.push(name);
-          } else {
-            objects.push(name);
-          }
+    const { rooms, sessions } = await import("jsr:@ursamu/core@^1.0.0");
+    const { dbojs } = await import("jsr:@ursamu/mush@^1.0.0");
+    // Web: one dense who panel per channel (first with people, else first).
+    if (prefersWebUi(u)) {
+      for (const entry of channels) {
+        const rows = await whoRowsFor(
+          entry.channel,
+          rooms,
+          sessions,
+          dbojs,
+        );
+        if (rows.length || entry === channels[0]) {
+          sendChannelWhoUi(u, {
+            channel: entry.channel,
+            rows,
+            alias: entry.alias,
+          });
+          // Only first channel with members (or first alias)
+          if (rows.length) return;
         }
       }
-      players.sort();
-      objects.sort();
-
+      return;
+    }
+    for (const entry of channels) {
+      const rows = await whoRowsFor(
+        entry.channel,
+        rooms,
+        sessions,
+        dbojs,
+      );
       u.send("-- Players --");
-      for (const p of players) {
-        u.send(p);
+      for (const r of rows.filter((x) => x.isPlayer !== false)) {
+        u.send(r.name);
       }
       u.send("-- Objects --");
-      for (const o of objects) {
-        u.send(o);
+      for (const r of rows.filter((x) => x.isPlayer === false)) {
+        u.send(r.name);
       }
       u.send(`-- ${entry.channel} --`);
     }
@@ -540,17 +614,28 @@ async function doAllcom(u: IUrsamuSDK, arg?: string): Promise<void> {
 
   if (!channels.length) {
     u.send("You have no channel aliases.");
+    if (prefersWebUi(u)) {
+      sendMyAliasesUi(u, "You have no channel aliases.");
+    }
     return;
   }
-  u.send("--- Your Channel Aliases ---");
-  for (const entry of channels) {
-    const status = entry.active === false ? "%cr[off]%cn" : "%cg[on]%cn";
-    const title = entry.title ? ` <${entry.title}>` : "";
-    u.send(
-      `  %ch${entry.alias || "?"}%cn → ${entry.channel}${title} ${status}`,
-    );
+  const lines = [
+    "--- Your Channel Aliases ---",
+    ...channels.map((entry) => {
+      const status = entry.active === false
+        ? "%cr[off]%cn"
+        : "%cg[on]%cn";
+      const title = entry.title ? ` <${entry.title}>` : "";
+      return `  %ch${entry.alias || "?"}%cn → ${entry.channel}` +
+        `${title} ${status}`;
+    }),
+    "----------------------------",
+  ];
+  if (prefersWebUi(u)) {
+    sendMyAliasesUi(u, lines.join("\n"));
+    return;
   }
-  u.send("----------------------------");
+  for (const line of lines) u.send(line);
 }
 
 async function doClearcom(u: IUrsamuSDK): Promise<void> {
@@ -562,6 +647,7 @@ async function doClearcom(u: IUrsamuSDK): Promise<void> {
     if (entry.alias) await u.chan.leave(entry.alias);
   }
   u.send("All channel aliases removed.");
+  await refreshChannelsHub(u);
 }
 
 async function doComtitle(u: IUrsamuSDK, arg: string): Promise<void> {
@@ -588,11 +674,13 @@ async function doComtitle(u: IUrsamuSDK, arg: string): Promise<void> {
   }
   entry.title = title || undefined;
   await u.db.modify(u.me.id, "$set", { "data.channels": channels });
+  (u.me.state as Record<string, unknown>).channels = channels;
   u.send(
     title
       ? `Title on %ch${alias}%cn set to: ${title}`
       : `Title on %ch${alias}%cn cleared.`,
   );
+  await refreshChannelsHub(u);
 }
 
 export async function execCemit(u: IUrsamuSDK): Promise<void> {
@@ -629,7 +717,7 @@ export async function execCemit(u: IUrsamuSDK): Promise<void> {
   }
 
   const header = sw === "noheader" ? "" : chan.header + " ";
-  const { rooms } = await import("@ursamu/core");
+  const { rooms } = await import("jsr:@ursamu/core@^1.0.0");
   rooms.broadcast(chan.name, `${header}${msg}`);
 }
 
@@ -673,8 +761,8 @@ export async function execCboot(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
-  const { sessions, rooms } = await import("@ursamu/core");
-  const { dbojs } = await import("@ursamu/mush");
+  const { sessions, rooms } = await import("jsr:@ursamu/core@^1.0.0");
+  const { dbojs } = await import("jsr:@ursamu/mush@^1.0.0");
   const targetObj = await dbojs.queryOne({ id: target.id });
   if (targetObj && targetObj.data?.channels) {
     const chs = targetObj.data.channels as IChanEntry[];
@@ -749,8 +837,8 @@ export async function execCwho(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
-  const { rooms, sessions } = await import("@ursamu/core");
-  const { dbojs } = await import("@ursamu/mush");
+  const { rooms, sessions } = await import("jsr:@ursamu/core@^1.0.0");
+  const { dbojs } = await import("jsr:@ursamu/mush@^1.0.0");
 
   const sockets = rooms.members(chan.name);
   const playerIds = new Set<string>();
@@ -758,6 +846,51 @@ export async function execCwho(u: IUrsamuSDK): Promise<void> {
     const s = sessions.get(socketId);
     const actorId = (s as any)?.actorId;
     if (actorId) playerIds.add(actorId);
+  }
+
+  if (prefersWebUi(u)) {
+    const rows: WhoRow[] = [];
+    if (sw === "all") {
+      const allPlayers = await dbojs.query({
+        "data.channels": { $exists: true },
+      });
+      for (const p of allPlayers) {
+        const chs = (p.data?.channels || []) as IChanEntry[];
+        const found = chs.find(
+          (c) =>
+            c.channel.toLowerCase() ===
+              chan.name.toLowerCase(),
+        );
+        if (!found) continue;
+        const isPlayer = String(p.flags ?? "")
+          .split(/\s+/)
+          .includes("player");
+        rows.push({
+          name: String(p.data?.name || p.id),
+          status: playerIds.has(p.id) ? "on" : "off",
+          isPlayer,
+        });
+      }
+    } else {
+      for (const id of playerIds) {
+        const p = await dbojs.queryOne({ id });
+        if (!p) continue;
+        const isPlayer = String(p.flags ?? "")
+          .split(/\s+/)
+          .includes("player");
+        rows.push({
+          name: String(p.data?.name || p.id),
+          status: "on",
+          isPlayer,
+        });
+      }
+    }
+    rows.sort((a, b) => a.name.localeCompare(b.name));
+    sendChannelWhoUi(u, {
+      channel: chan.name,
+      rows,
+    });
+    return;
   }
 
   u.send("Name Status Player");
@@ -801,4 +934,45 @@ export async function execCwho(u: IUrsamuSDK): Promise<void> {
       }
     }
   }
+}
+
+/** Shared who-row builder for allcom who / alias who. */
+async function whoRowsFor(
+  channel: string,
+  rooms: { members: (n: string) => string[] },
+  sessions: { get: (id: string) => unknown },
+  dbojs: {
+    queryOne: (q: { id: string }) => Promise<{
+      id: string;
+      flags?: unknown;
+      data?: { name?: string };
+    } | null | false | undefined>;
+  },
+): Promise<WhoRow[]> {
+  let sockets: string[] = [];
+  try {
+    sockets = rooms.members(channel);
+  } catch {
+    return [];
+  }
+  const playerIds = new Set<string>();
+  for (const socketId of sockets) {
+    const s = sessions.get(socketId) as
+      | { actorId?: string }
+      | undefined;
+    const actorId = s?.actorId;
+    if (actorId) playerIds.add(actorId);
+  }
+  const rows: WhoRow[] = [];
+  for (const id of playerIds) {
+    const dbObj = await dbojs.queryOne({ id });
+    if (!dbObj) continue;
+    const name = (dbObj.data?.name as string) || dbObj.id;
+    const isPlayer = String(dbObj.flags ?? "")
+      .split(/\s+/)
+      .includes("player");
+    rows.push({ name, status: "on", isPlayer });
+  }
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
 }

--- a/packages/channels/src/commands/verbs.ts
+++ b/packages/channels/src/commands/verbs.ts
@@ -29,20 +29,22 @@ import {
 addCmd({
   name: "@channel",
   pattern:
-    /^@?(?:channels?|clist)(?:\/(join|leave|list|full|headers))?\s*(.*)?$/i,
+    /^@?(?:channels?|clist|\+channels?)(?:\/(join|leave|list|full|headers))?\s*(.*)?$/i,
   lock: "connected",
   category: "Channel",
-  help: `@channel              List available channels.
+  help: `@channel / +channels     Channel hub (web UI on /play).
 @channel/join <chan>=<alias>  Join a channel with an alias.
 @channel/leave <alias>        Leave a channel.
 @clist                        List public channels and owners.
 @clist/full                   Name, flags, owner, users online.
 @clist/headers                List channels with custom headers.
 
-Aliases: @channels, @clist
+Web: click to join, mute, speak (prompt fill), who, leave.
+Aliases: @channels, @clist, +channel, +channels
 
 Examples:
   @channel
+  +channels
   @channel/join Public=pub
   @clist/full`,
   exec: execChannel,

--- a/packages/channels/src/middleware/matchChannel.ts
+++ b/packages/channels/src/middleware/matchChannel.ts
@@ -4,6 +4,11 @@ import type { ICoreContext } from "@ursamu/core";
 import type { IChannel, IChanEntry, IChanMessage } from "../types.ts";
 import { channelEvents } from "../channel-events.ts";
 import { channelAnnounces, broadcastAnnounce } from "../announce.ts";
+import {
+  channelTagFromHeader,
+  deliverChannelSpeech,
+  type ChanSpeechKind,
+} from "../chan-deliver.ts";
 
 const chans = new DBO<IChannel>(() =>
   getConfig<string>("plugins.channels.db", "server.chans"),
@@ -26,12 +31,24 @@ function moniker(obj: {
   );
 }
 
-function chanSend(
-  chanName: string,
-  header: string,
-  text: string,
-): void {
-  rooms.broadcast(chanName, `${header} ${text}`);
+function avatarHint(
+  id: string,
+  data?: Record<string, unknown>,
+): string | null {
+  if (!data) return null;
+  const img = data.image;
+  if (typeof img === "string" && /^https?:\/\//i.test(img.trim())) {
+    return img.trim();
+  }
+  if (typeof img === "string" && /\.(png|jpe?g|gif|webp)$/i.test(img)) {
+    return `/avatars/${img.replace(/^\/avatars\//, "")}`;
+  }
+  const ext = data.imageExt ?? data.avatarExt;
+  if (typeof ext === "string" && /^(png|jpe?g|gif|webp)$/i.test(ext)) {
+    const e = ext.toLowerCase() === "jpeg" ? "jpg" : ext.toLowerCase();
+    return `/avatars/${id}.${e}`;
+  }
+  return `/avatars/${id}`;
 }
 
 async function persistMessage(
@@ -194,7 +211,37 @@ export async function matchChannel(
   }
 
   if (msg.toLowerCase() === "who") {
-    const { players, objects } = await getChannelMembers(channel.channel);
+    const { players, objects } = await getChannelMembers(
+      channel.channel,
+    );
+    const rows = [
+      ...players.map((name) => ({
+        name,
+        status: "on",
+        isPlayer: true,
+      })),
+      ...objects.map((name) => ({
+        name,
+        status: "on",
+        isPlayer: false,
+      })),
+    ];
+    try {
+      const { emitChannelWho } = await import(
+        "../commands/chan-ui.ts"
+      );
+      if (
+        emitChannelWho(ctx.socketId, {
+          channel: channel.channel,
+          rows,
+          alias: channel.alias,
+        })
+      ) {
+        return true;
+      }
+    } catch {
+      /* fall through to text */
+    }
     send([ctx.socketId], "-- Players --");
     for (const p of players) {
       send([ctx.socketId], p);
@@ -209,28 +256,59 @@ export async function matchChannel(
 
   if (!channel.active) return false;
 
+  let kind: ChanSpeechKind = "say";
+  let speechText = msg;
+  let telnetBody: string;
+
   if (match[1] === ":") {
-    msg = `${titlePrefix}${displayName} ${match[2]}`;
+    kind = "pose";
+    speechText = String(match[2] ?? "").trim();
+    telnetBody =
+      `${titlePrefix}${displayName} ${speechText}`.trim();
   } else if (match[1] === ";") {
-    msg = `${titlePrefix}${displayName}${match[2]}`;
+    kind = "semi";
+    speechText = String(match[2] ?? "").trim();
+    telnetBody = `${titlePrefix}${displayName}${speechText}`;
   } else {
-    msg = `${titlePrefix}${displayName} says, "${msg}"`;
+    kind = "say";
+    speechText = msg;
+    telnetBody =
+      `${titlePrefix}${displayName} says, "${msg}"`;
   }
 
-  chanSend(chan.name, chan.header, msg);
+  const header = String(chan.header || "").trim();
+  const telnetLine = header
+    ? `${header} ${telnetBody}`
+    : telnetBody;
+  const tag = channelTagFromHeader(header, chan.name);
+  const bag = (en.data ?? {}) as Record<string, unknown>;
+
+  deliverChannelSpeech({
+    chanName: chan.name,
+    telnetLine,
+    chat: {
+      kind,
+      name: displayName,
+      text: speechText,
+      tag,
+      channel: chan.name,
+      actorId: en.id,
+      avatar: avatarHint(en.id, bag),
+    },
+  });
 
   channelEvents
     .emit("channel:message", {
       channelName: chan.name,
       senderId: en.id,
       senderName: moniker(en),
-      message: msg,
+      message: telnetBody,
       source: "game",
     })
     .catch((e: unknown) =>
       console.error("[channels] channel:message:", e)
     );
 
-  await persistMessage(chan, en.id, moniker(en), msg);
+  await persistMessage(chan, en.id, moniker(en), telnetBody);
   return true;
 }

--- a/packages/channels/tests/chan_deliver.test.ts
+++ b/packages/channels/tests/chan_deliver.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Channel delivery helpers.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  channelTagFromHeader,
+  plainChannelTag,
+} from "../src/chan-deliver.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("channelTagFromHeader: keeps color codes", OPTS, () => {
+  assertEquals(
+    channelTagFromHeader("%ch%cc[PUBLIC]%cn", "Public"),
+    "%ch%cc[PUBLIC]%cn",
+  );
+  assertEquals(
+    channelTagFromHeader("[PUBLIC]", "Public"),
+    "[PUBLIC]",
+  );
+});
+
+Deno.test("channelTagFromHeader: fallback", OPTS, () => {
+  assertEquals(channelTagFromHeader("", "Staff"), "Staff");
+});
+
+Deno.test("plainChannelTag: strips codes", OPTS, () => {
+  assertEquals(
+    plainChannelTag("%ch%cc[PUBLIC]%cn", "Public"),
+    "[PUBLIC]",
+  );
+});

--- a/packages/channels/tests/chan_ui.test.ts
+++ b/packages/channels/tests/chan_ui.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Channel web hub layout builders.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  buildWhoLayout,
+  prefersWebUi,
+  sendChannelHistoryUi,
+  sendChannelsHub,
+} from "../src/commands/chan-ui.ts";
+import type { IUrsamuSDK } from "@ursamu/mush";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function mockU(opts: {
+  web?: boolean;
+  staff?: boolean;
+  aliases?: Array<{
+    alias: string;
+    channel: string;
+    active?: boolean;
+    title?: string;
+  }>;
+} = {}) {
+  const layouts: unknown[] = [];
+  const sent: string[] = [];
+  const flags = new Set(["player", "connected"]);
+  if (opts.staff) {
+    flags.add("admin");
+  }
+  const u = {
+    clientType: opts.web === false ? "telnet" : "web",
+    me: {
+      id: "p1",
+      name: "Tester",
+      flags,
+      state: {
+        name: "Tester",
+        channels: opts.aliases ?? [
+          {
+            id: "public",
+            channel: "Public",
+            alias: "pub",
+            active: true,
+          },
+        ],
+      },
+    },
+    ui: {
+      layout: (p: unknown) => {
+        layouts.push(p);
+      },
+    },
+    send: (m: string) => {
+      sent.push(m);
+    },
+  };
+  return Object.assign(u as unknown as IUrsamuSDK, {
+    _layouts: layouts,
+    _sent: sent,
+  });
+}
+
+type Layout = {
+  meta: { type: string };
+  components: Array<{
+    type: string;
+    title?: string;
+    items?: Array<{
+      label?: string;
+      role?: string;
+      meta?: string;
+      sublabel?: string;
+      badge?: string;
+      action?: { cmd?: string; fill?: string };
+    }>;
+  }>;
+};
+
+function layoutsOf(u: IUrsamuSDK): Layout[] {
+  return (u as unknown as { _layouts: Layout[] })._layouts;
+}
+
+Deno.test("prefersWebUi: web + layout", OPTS, () => {
+  const u = mockU({ web: true });
+  assertEquals(prefersWebUi(u), true);
+  const t = mockU({ web: false });
+  assertEquals(prefersWebUi(t), false);
+});
+
+Deno.test("sendChannelsHub: dense rows + join", OPTS, () => {
+  const u = mockU({
+    web: true,
+    aliases: [{
+      alias: "pub",
+      channel: "Public",
+      active: true,
+      title: "Scout",
+    }],
+  });
+  sendChannelsHub(u, {
+    channels: [
+      {
+        id: "public",
+        name: "Public",
+        header: "[PUBLIC]",
+        alias: "pub",
+        online: 2,
+      },
+      {
+        id: "staff",
+        name: "Staff",
+        header: "[STAFF]",
+        alias: "st",
+        online: 0,
+      },
+    ],
+  });
+  const ls = layoutsOf(u);
+  assertEquals(ls.length, 1);
+  assertEquals(ls[0].meta.type, "channels-hub");
+  const comps = ls[0].components;
+  const lists = comps.filter((c) => c.type === "entity-list");
+  assertEquals(lists.length >= 2, true);
+
+  // Joined Public → fill speak; role on/off
+  const mine = lists[0];
+  const pubAlias = mine.items?.find((i) => i.label === "pub");
+  assertEquals(pubAlias?.action?.fill, "pub ");
+  assertEquals(pubAlias?.role, "on");
+  assertEquals(pubAlias?.meta, "Public");
+  assertEquals(
+    String(pubAlias?.sublabel || "").includes("Scout"),
+    true,
+  );
+
+  // Available: Staff join; Public not listed
+  const avail = lists.find((l) =>
+    String(l.title || "").includes("Available")
+  ) ?? lists[lists.length - 1];
+  const staff = avail.items?.find((i) => i.label === "Staff");
+  assertEquals(
+    staff?.action?.cmd,
+    "@channel/join Staff=st",
+  );
+  assertEquals(
+    avail.items?.find((i) => i.label === "Public"),
+    undefined,
+  );
+
+  // Alias tools use badge for alias name
+  const tools = comps.find((c) =>
+    c.type === "actions" &&
+    String(c.title || "").includes("Alias")
+  );
+  assertEquals(!!tools, true);
+  const mute = tools?.items?.find((i) =>
+    i.label === "mute" && i.badge === "pub"
+  );
+  assertEquals(mute?.action?.cmd, "pub off");
+});
+
+Deno.test("sendChannelsHub: list mode metaType", OPTS, () => {
+  const u = mockU({ web: true, staff: true });
+  sendChannelsHub(u, {
+    channels: [{
+      id: "public",
+      name: "Public",
+      header: "[P]",
+      alias: "pub",
+      online: 1,
+    }],
+    mode: "list",
+  });
+  const ls = layoutsOf(u);
+  assertEquals(ls[0].meta.type, "channels-list");
+});
+
+Deno.test("sendChannelsHub: telnet fallback text", OPTS, () => {
+  const u = mockU({ web: false });
+  sendChannelsHub(u, {
+    channels: [{
+      id: "public",
+      name: "Public",
+      header: "[P]",
+      alias: "pub",
+    }],
+  });
+  const sent = (u as unknown as { _sent: string[] })._sent;
+  assertEquals(sent.length, 1);
+  assertEquals(sent[0].includes("Public"), true);
+});
+
+Deno.test("buildWhoLayout: rows + actions", OPTS, () => {
+  const built = buildWhoLayout({
+    channel: "Public",
+    alias: "pub",
+    rows: [
+      { name: "Alice", status: "on", isPlayer: true },
+      { name: "Bot", status: "on", isPlayer: false },
+    ],
+  });
+  assertEquals(built.metaType, "channels-who");
+  const list = built.components.find((c) =>
+    (c as { type?: string }).type === "entity-list"
+  ) as { items?: Array<{ label?: string; meta?: string }> };
+  assertEquals(list.items?.length, 2);
+  assertEquals(list.items?.[0].label, "Alice");
+  assertEquals(list.items?.[1].meta, "obj");
+});
+
+Deno.test("sendChannelHistoryUi: panels", OPTS, () => {
+  const u = mockU({ web: true });
+  sendChannelHistoryUi(u, {
+    channel: "Public",
+    lines: [
+      {
+        timestamp: Date.UTC(2026, 0, 1, 12, 0, 0),
+        message: "Hello channel",
+        playerName: "Alice",
+      },
+    ],
+  });
+  const ls = layoutsOf(u);
+  assertEquals(ls[0].meta.type, "channels-history");
+  const panels = ls[0].components.filter((c) =>
+    c.type === "panel"
+  );
+  assertEquals(panels.length, 1);
+  assertEquals(
+    String((panels[0] as { content?: string }).content),
+    "Hello channel",
+  );
+});


### PR DESCRIPTION
## Summary
Cut **@ursamu/channels@1.2.4** with court/prod channel improvements:

- Dense `/play` hub (join/mute/who/leave), who + history layouts
- Web chat bubbles with colored channel badges
- Dual room join (name + id) for Discord inject delivery
- Staff REST: `{ items, channels }` list; `/messages` history alias

Monorepo was stuck at 1.1.0 while court ran JSR 1.2.3; this lands the full hub stack in-tree and bumps to 1.2.4.

## Test plan
- [x] `deno test packages/channels/tests` — 39 passed
- [ ] CI publish `@ursamu/channels@1.2.4` to JSR
- [ ] Court: pin `jsr:@ursamu/channels@1.2.4` + restart