### PR TITLE
fix(test): Stub @update git/cache so CI does not segfault

### DIFF
--- a/packages/mush/src/sys/codebase-update.ts
+++ b/packages/mush/src/sys/codebase-update.ts
@@ -37,6 +37,19 @@ export type UpdateOutcome = {
   cached?: boolean;
 };
 
+type UpdateRunner = (
+  opts?: UpdateOptions,
+) => Promise<UpdateOutcome>;
+
+let updateRunner: UpdateRunner | undefined;
+
+/** Tests replace the live git/cache path. */
+export function setCodebaseUpdateRunner(
+  fn?: UpdateRunner,
+): void {
+  updateRunner = fn;
+}
+
 export {
   applyEngineOverrides,
   bumpUrsamuImports,
@@ -377,6 +390,7 @@ async function reportLockedUrsamu(
 export async function runCodebaseUpdate(
   opts: UpdateOptions = {},
 ): Promise<UpdateOutcome> {
+  if (updateRunner) return updateRunner(opts);
   const cwd = opts.cwd ?? Deno.cwd();
   const lines: string[] = [];
   const log = opts.log;

--- a/tests/update_script.test.ts
+++ b/tests/update_script.test.ts
@@ -1,26 +1,39 @@
 /**
  * tests/update_script.test.ts
  *
- * Tests for the @update command
- * (packages/mush/src/verbs/auth.ts — execUpdate).
- *
- * execUpdate:
- *  1. Checks admin/wizard/superuser flag — rejects others.
- *  2. Broadcasts an update message to u.here.
- *  3. Calls runCodebaseUpdate (dynamic import — tested via
- *     checking the broadcast fired and sys.reboot was called
- *     when the import is mocked to succeed).
- *  4. On success, calls u.sys.reboot({ update: false }).
- *
- * Because runCodebaseUpdate is a real sys call we cannot easily
- * stub it in pure Deno tests. We test the observable surface:
- * permission guard, broadcast content, and reboot on success.
+ * Tests for the @update command (execUpdate).
+ * Live git/deno-cache is stubbed — nested `deno cache`
+ * inside `deno test` segfaults CI (exit 139).
  */
-import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import type { IUrsamuSDK } from "@ursamu/mush";
 import { execUpdate } from "@ursamu/mush";
+import {
+  setCodebaseUpdateRunner,
+} from "../packages/mush/src/sys/codebase-update.ts";
 
 const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function stubCached() {
+  return Promise.resolve({
+    ok: true,
+    lines: [],
+    bumped: [],
+    pulled: false,
+    cached: true,
+  });
+}
+
+async function withUpdateStub(
+  fn: () => Promise<void>,
+): Promise<void> {
+  setCodebaseUpdateRunner(stubCached);
+  try {
+    await fn();
+  } finally {
+    setCodebaseUpdateRunner();
+  }
+}
 
 // ─── mock factory ─────────────────────────────────────────────────────────────
 
@@ -95,35 +108,43 @@ Deno.test(
 Deno.test(
   "@update — admin flag triggers broadcast",
   OPTS,
-  async () => {
-    const { sdk, broadcasts } = makeSDK(["player", "admin"], "");
-    await execUpdate(sdk as unknown as IUrsamuSDK);
-
-    // broadcast fires synchronously before sys call
-    assertEquals(broadcasts.length, 1);
-  },
+  () =>
+    withUpdateStub(async () => {
+      const { sdk, broadcasts } = makeSDK(
+        ["player", "admin"],
+        "",
+      );
+      await execUpdate(sdk as unknown as IUrsamuSDK);
+      assertEquals(broadcasts.length, 1);
+    }),
 );
 
 Deno.test(
   "@update — wizard flag triggers broadcast",
   OPTS,
-  async () => {
-    const { sdk, broadcasts } = makeSDK(["player", "wizard"], "");
-    await execUpdate(sdk as unknown as IUrsamuSDK);
-
-    assertEquals(broadcasts.length, 1);
-  },
+  () =>
+    withUpdateStub(async () => {
+      const { sdk, broadcasts } = makeSDK(
+        ["player", "wizard"],
+        "",
+      );
+      await execUpdate(sdk as unknown as IUrsamuSDK);
+      assertEquals(broadcasts.length, 1);
+    }),
 );
 
 Deno.test(
   "@update — superuser flag triggers broadcast",
   OPTS,
-  async () => {
-    const { sdk, broadcasts } = makeSDK(["player", "superuser"], "");
-    await execUpdate(sdk as unknown as IUrsamuSDK);
-
-    assertEquals(broadcasts.length, 1);
-  },
+  () =>
+    withUpdateStub(async () => {
+      const { sdk, broadcasts } = makeSDK(
+        ["player", "superuser"],
+        "",
+      );
+      await execUpdate(sdk as unknown as IUrsamuSDK);
+      assertEquals(broadcasts.length, 1);
+    }),
 );
 
 // ─── broadcast content ───────────────────────────────────────────────────────
@@ -131,28 +152,38 @@ Deno.test(
 Deno.test(
   "@update — broadcast message includes actor name",
   OPTS,
-  async () => {
-    const { sdk, broadcasts } = makeSDK(["admin"], "");
-    await execUpdate(sdk as unknown as IUrsamuSDK);
-
-    assertEquals(broadcasts.length >= 1, true);
-    assertEquals(broadcasts[0].includes("TestPlayer"), true);
-  },
+  () =>
+    withUpdateStub(async () => {
+      const { sdk, broadcasts } = makeSDK(["admin"], "");
+      await execUpdate(sdk as unknown as IUrsamuSDK);
+      assertEquals(broadcasts.length >= 1, true);
+      assertEquals(broadcasts[0].includes("TestPlayer"), true);
+    }),
 );
 
 Deno.test(
   "@update — broadcast message includes update context text",
   OPTS,
-  async () => {
-    const { sdk, broadcasts } = makeSDK(["wizard"], "");
-    await execUpdate(sdk as unknown as IUrsamuSDK);
+  () =>
+    withUpdateStub(async () => {
+      const { sdk, broadcasts } = makeSDK(["wizard"], "");
+      await execUpdate(sdk as unknown as IUrsamuSDK);
+      assertEquals(broadcasts.length >= 1, true);
+      const lower = broadcasts[0].toLowerCase();
+      const hasContext = lower.includes("update") ||
+        lower.includes("restart") ||
+        lower.includes("reboot");
+      assertEquals(hasContext, true);
+    }),
+);
 
-    assertEquals(broadcasts.length >= 1, true);
-    // Message contains something indicating update/restart activity
-    const lower = broadcasts[0].toLowerCase();
-    const hasContext = lower.includes("update") ||
-      lower.includes("restart") ||
-      lower.includes("reboot");
-    assertEquals(hasContext, true);
-  },
+Deno.test(
+  "@update — cached stub calls sys.reboot",
+  OPTS,
+  () =>
+    withUpdateStub(async () => {
+      const ctx = makeSDK(["admin"], "");
+      await execUpdate(ctx.sdk as unknown as IUrsamuSDK);
+      assertEquals(ctx.rebootCalled, true);
+    }),
 );


### PR DESCRIPTION
@update tests were running a live git pull + deno cache --reload
inside deno test. Nested Deno on GitHub Actions dies with
SIGSEGV (exit 139) in tests/update_script.test.ts, which
failed both CI and the Tests workflow after 3.1.0.

Add setCodebaseUpdateRunner so tests stub that path. Privilege
and broadcast assertions stay; the suite now finishes in ~11ms.