### PR TITLE
release: core 1.0.3 + mush 1.0.37 engine hardening

### DIFF
--- a/docs/guides/lock-expressions.md
+++ b/docs/guides/lock-expressions.md
@@ -41,8 +41,9 @@ arguments and return a boolean.
 | Lockfunc | Example | Passes when |
 |----------|---------|-------------|
 | `flag(name)` | `flag(wizard)` | enactor has the named flag |
-| `attr(name)` | `attr(tribe)` | enactor.state has own-property `name` |
-| `attr(name, value)` | `attr(class, warrior)` | `state[name] === value` (case-insensitive key) |
+| `attr(name)` | `attr(tribe)` | enactor.state has own-property `name` (case-insensitive key) |
+| `attr(name, value)` | `attr(class, warrior)` | `state[name] === value` |
+| `attr(name, op)` | `attr(level,>4)` | numeric compare: `>`, `<`, `>=`, `<=`, `=`, `!=` / `<>` |
 | `type(name)` | `type(player)` | enactor has the type flag (player/room/thing/exit) |
 | `is(#id)` | `is(#5)` | enactor's dbref is `#5` |
 | `holds(#id)` | `holds(#12)` | enactor's inventory includes `#12` |

--- a/docs/mush_compatibility.md
+++ b/docs/mush_compatibility.md
@@ -219,11 +219,13 @@ lock: "connected && (flag(wizard) || attr(tribe, glasswalker))"
 
 ---
 
-## Planned Enhancements
+## Terminal size (NAWS)
 
-| Feature | Notes |
-|---------|-------|
-| Terminal/screen settings | Width detection via Telnet NAWS, persistent pager settings |
+Telnet NAWS (RFC 1073) sets `session.meta.termWidth` /
+`termHeight` (clamped 40–250 × 1–255). Values persist on the
+player as `data.termWidth` / `data.termHeight`. Softcode
+`width()` / `height()` and telnet word-wrap use the live size
+(default 78×24 when unset).
 ---
 
 ## Connecting with a Traditional MU* Client

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `@ursamu/core` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.3] - 2026-09-04
+
+### Added
+
+- `clampTermHeight`, `applySessionTermSize`, `resolveWrapWidth`
+- `session:termSize` hook (NAWS / client size updates)
+- WS packets with `data.termWidth` / `termHeight` update session
+
+### Changed
+
+- Telnet word-wrap uses session `termWidth` when set (else 78)
+- NAWS stores width and height on session.meta
+
 ## [1.0.2] - 2026-08-05
 
 ### Fixed

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "exports": "./mod.ts",
   "tasks": {
     "test": "deno test tests/ --allow-all --unstable-kv --no-check",

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -9,7 +9,17 @@
 
 // Server / transports
 export { createServer }                    from "./src/server/index.ts";
-export { websocketTransport, closeSocket, listSocketIds, isRateLimitedForAuth, clampTermWidth, handleWebSocketConnection, sendPayload } from "./src/server/websocket.ts";
+export {
+  websocketTransport,
+  closeSocket,
+  listSocketIds,
+  isRateLimitedForAuth,
+  clampTermWidth,
+  clampTermHeight,
+  applySessionTermSize,
+  handleWebSocketConnection,
+  sendPayload,
+} from "./src/server/websocket.ts";
 export { telnetTransport, parseNawsBytes, stripIacBytes, accumulateNaws, IAC, WILL, DO, DONT, WONT, SB, SE, NAWS_OPTION } from "./src/server/telnet.ts";
 export {
   httpTransport,
@@ -77,6 +87,7 @@ export {
   setFormatter,
   wordWrap,
   shouldWordWrap,
+  resolveWrapWidth,
 } from "./src/broadcast/send.ts";
 export { rooms }                           from "./src/broadcast/rooms.ts";
 

--- a/packages/core/src/broadcast/send.ts
+++ b/packages/core/src/broadcast/send.ts
@@ -29,9 +29,8 @@ export function trackedSockets(): ReadonlySet<string> {
 }
 
 /**
- * Telnet keeps the classic 78-column wrap. Web clients size their own
- * column in the browser — hard-wrapping at 78 makes ASCII/look output
- * look prematurely broken in a wide center pane.
+ * Telnet keeps column wrap. Web clients size their own column in the
+ * browser — hard-wrapping makes ASCII/look output look broken.
  */
 export function shouldWordWrap(socketId: string): boolean {
   const ct = sessions.get(socketId)?.meta?.clientType;
@@ -39,8 +38,21 @@ export function shouldWordWrap(socketId: string): boolean {
   return true;
 }
 
+/** Effective wrap width: session NAWS termWidth, else 78. */
+export function resolveWrapWidth(socketId?: string): number {
+  if (!socketId) return 78;
+  const w = sessions.get(socketId)?.meta?.termWidth;
+  if (typeof w === "number" && Number.isFinite(w)) {
+    const n = Math.trunc(w);
+    if (n >= 40 && n <= 250) return n;
+  }
+  return 78;
+}
+
 function prepareOutbound(socketId: string, msg: string): string {
-  const body = shouldWordWrap(socketId) ? wordWrap(msg) : msg;
+  const body = shouldWordWrap(socketId)
+    ? wordWrap(msg, resolveWrapWidth(socketId))
+    : msg;
   return _formatter(socketId, body);
 }
 

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -1,9 +1,23 @@
 export interface CoreHookMap {
-  "engine:ready":  ()                                                    => void | Promise<void>;
-  "session:open":  (e: { socketId: string })                             => void | Promise<void>;
-  "session:close": (e: { socketId: string; sessionId: string | null; actorId?: string | null })   => void | Promise<void>;
-  "session:auth":  (e: { socketId: string; sessionId: string })          => void | Promise<void>;
-  // Allow dynamic plugins/subpackages to define custom events without ambient declarations
+  "engine:ready": () => void | Promise<void>;
+  "session:open": (e: { socketId: string }) => void | Promise<void>;
+  "session:close": (e: {
+    socketId: string;
+    sessionId: string | null;
+    actorId?: string | null;
+  }) => void | Promise<void>;
+  "session:auth": (e: {
+    socketId: string;
+    sessionId: string;
+  }) => void | Promise<void>;
+  /** NAWS / client terminal size update. */
+  "session:termSize": (e: {
+    socketId: string;
+    termWidth?: unknown;
+    termHeight?: unknown;
+    cid?: string;
+  }) => void | Promise<void>;
+  // Allow dynamic plugins/subpackages to define custom events
   // deno-lint-ignore no-explicit-any
   [key: string]: (...args: any[]) => any;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -43,7 +43,13 @@ export function createServer(): ICoreServer {
 }
 
 export type { ICoreServer, ITransport } from "./types.ts";
-export { websocketTransport, handleWebSocketConnection, clampTermWidth } from "./websocket.ts";
+export {
+  websocketTransport,
+  handleWebSocketConnection,
+  clampTermWidth,
+  clampTermHeight,
+  applySessionTermSize,
+} from "./websocket.ts";
 export { telnetTransport, parseNawsBytes, stripIacBytes, accumulateNaws } from "./telnet.ts";
 export {
   httpTransport,

--- a/packages/core/src/server/telnet.ts
+++ b/packages/core/src/server/telnet.ts
@@ -142,8 +142,23 @@ async function handleTelnetConnection(conn: Deno.TcpConn): Promise<void> {
       if (nawsSeq !== null) {
         const parsed = parseNawsBytes(nawsSeq);
         if (parsed) {
+          const { clampTermWidth, clampTermHeight } = await import(
+            "./websocket.ts"
+          );
           const session = sessions.get(socketId);
-          if (session) session.meta.termWidth = parsed.width;
+          if (session) {
+            const w = clampTermWidth(parsed.width);
+            const h = clampTermHeight(parsed.height);
+            if (w != null) session.meta.termWidth = w;
+            if (h != null) session.meta.termHeight = h;
+            if (w != null || h != null) {
+              await gameHooks.emit("session:termSize", {
+                socketId,
+                termWidth: session.meta.termWidth,
+                termHeight: session.meta.termHeight,
+              });
+            }
+          }
         }
       }
 

--- a/packages/core/src/server/websocket.ts
+++ b/packages/core/src/server/websocket.ts
@@ -37,8 +37,38 @@ export function isRateLimitedForAuth(socketId: string): boolean {
 
 export function clampTermWidth(w: unknown): number | null {
   if (typeof w !== "number" || !Number.isFinite(w)) return null;
-  if (w < 40 || w > 250) return null;
-  return w;
+  const n = Math.trunc(w);
+  if (n < 40 || n > 250) return null;
+  return n;
+}
+
+export function clampTermHeight(h: unknown): number | null {
+  if (typeof h !== "number" || !Number.isFinite(h)) return null;
+  const n = Math.trunc(h);
+  if (n < 1 || n > 255) return null;
+  return n;
+}
+
+/** Apply clamped term size onto session.meta. Returns true if any set. */
+export function applySessionTermSize(
+  socketId: string,
+  width?: unknown,
+  height?: unknown,
+): boolean {
+  const session = sessions.get(socketId);
+  if (!session) return false;
+  let changed = false;
+  const w = clampTermWidth(width);
+  if (w != null) {
+    session.meta.termWidth = w;
+    changed = true;
+  }
+  const h = clampTermHeight(height);
+  if (h != null) {
+    session.meta.termHeight = h;
+    changed = true;
+  }
+  return changed;
 }
 
 function sendToSocket(socketId: string, msg: string): void {
@@ -121,10 +151,52 @@ async function handleAuth(socketId: string, raw: string): Promise<boolean> {
   }
 }
 
+/** Handle sidecar/client term-size packets (empty msg + data.termWidth). */
+async function handleTermSizePacket(
+  socketId: string,
+  raw: string,
+): Promise<boolean> {
+  try {
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    if (!data || typeof data !== "object") return false;
+    const payload = (data.data && typeof data.data === "object")
+      ? data.data as Record<string, unknown>
+      : data;
+    if (
+      payload.termWidth === undefined &&
+      payload.termHeight === undefined
+    ) {
+      return false;
+    }
+    // Empty command line with term size only — not player input.
+    const msg = data.msg;
+    if (typeof msg === "string" && msg.trim() !== "") return false;
+
+    const changed = applySessionTermSize(
+      socketId,
+      payload.termWidth,
+      payload.termHeight,
+    );
+    if (changed) {
+      sessions.touch(socketId);
+      await gameHooks.emit("session:termSize", {
+        socketId,
+        termWidth: sessions.get(socketId)?.meta?.termWidth,
+        termHeight: sessions.get(socketId)?.meta?.termHeight,
+        cid: typeof payload.cid === "string" ? payload.cid : undefined,
+      });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function handleMessage(socketId: string, raw: string): Promise<void> {
   if (raw.length > MAX_MSG_BYTES) return;
 
   if (await handleAuth(socketId, raw)) return;
+  if (await handleTermSizePacket(socketId, raw)) return;
 
   const input = parseInput(raw).trim();
   if (!input) return;

--- a/packages/core/tests/term_size.test.ts
+++ b/packages/core/tests/term_size.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Terminal size helpers: clamp + wordWrap width from session meta.
+ */
+import { assertEquals } from "@std/assert";
+import {
+  clampTermWidth,
+  clampTermHeight,
+  applySessionTermSize,
+  wordWrap,
+  resolveWrapWidth,
+  sessions,
+} from "../mod.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("clampTermWidth bounds", OPTS, () => {
+  assertEquals(clampTermWidth(-1), null);
+  assertEquals(clampTermWidth(39), null);
+  assertEquals(clampTermWidth(40), 40);
+  assertEquals(clampTermWidth(80.9), 80);
+  assertEquals(clampTermWidth(250), 250);
+  assertEquals(clampTermWidth(251), null);
+  assertEquals(clampTermWidth("80"), null);
+});
+
+Deno.test("clampTermHeight bounds", OPTS, () => {
+  assertEquals(clampTermHeight(0), null);
+  assertEquals(clampTermHeight(1), 1);
+  assertEquals(clampTermHeight(24.2), 24);
+  assertEquals(clampTermHeight(255), 255);
+  assertEquals(clampTermHeight(256), null);
+});
+
+Deno.test("applySessionTermSize writes meta", OPTS, () => {
+  const sid = "term_apply_sock";
+  sessions.open(sid, "");
+  assertEquals(applySessionTermSize(sid, 100, 40), true);
+  const s = sessions.get(sid)!;
+  assertEquals(s.meta.termWidth, 100);
+  assertEquals(s.meta.termHeight, 40);
+  assertEquals(applySessionTermSize(sid, 10, 0), false);
+  sessions.close(sid);
+});
+
+Deno.test(
+  "resolveWrapWidth / wordWrap honor session width",
+  OPTS,
+  () => {
+    const sid = "term_wrap_test_sock";
+    sessions.open(sid, "");
+    const s = sessions.get(sid)!;
+    s.meta.clientType = "telnet";
+    s.meta.termWidth = 40;
+    assertEquals(resolveWrapWidth(sid), 40);
+
+    // Space-separated words (wrap is word-based)
+    const line = Array.from({ length: 20 }, () => "word").join(" ");
+    const out = wordWrap(line, resolveWrapWidth(sid));
+    const lines = out.split("\n");
+    assertEquals(lines.length >= 2, true);
+    for (const ln of lines) {
+      const clean = ln.replace(/\s+$/, "");
+      assertEquals(clean.length <= 40, true);
+    }
+
+    sessions.close(sid);
+  },
+);
+
+Deno.test(
+  "wordWrap default 78 when no session width",
+  OPTS,
+  () => {
+    assertEquals(resolveWrapWidth(), 78);
+    const line = Array.from({ length: 30 }, () => "word").join(" ");
+    const out = wordWrap(line);
+    assertEquals(out.includes("\n"), true);
+  },
+);

--- a/packages/mush/CHANGELOG.md
+++ b/packages/mush/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.0.37
+
+- `moveObject`: teleport/home leave+arrive + auto-look;
+  room sends use socket ids (exclude honored).
+- Softcode `#slug` dbrefs (not only `#digits`); tags still work.
+- Softcode / `@cemit` deliver via `rooms.broadcast` + channel header.
+- look: empty `db.search` must not wipe preloaded contents
+  (dark exits / flag-code look tests).
+- Depends on `@ursamu/core@^1.0.3` (NAWS / term size).
+
+## 1.0.36
+
+- Softcode eval errors surface as `#-1 …` (never echo input).
+- `attr(name,>N)` lock comparisons; case-insensitive keys.
+- NAWS width/height → session + player; `width()`/`height()`
+  softcode; telnet word-wrap uses live termWidth.
+
+## 1.0.35
+
+- Softcode `get` / `xget` / `u` / `hasattr` walk `@parent`
+  chains (same resolver as exit msgs / world layer).
+- Shared `getAttribute` / `getAttributeValue` in
+  `world/get-attribute.ts`; `no_inherit` stops the walk.
+- `$pattern` and `^pattern` dispatch also scan parents.
+- SDK `u.trigger` / `u.eval` resolve attrs via parent walk.
+
 ## 1.0.34
 
 - Shared interactive command UI helpers (`cmd-ui.ts`):

--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "1.0.34",
+  "version": "1.0.37",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts",
@@ -21,7 +21,7 @@
   },
   "imports": {
     "@ursamu/mush": "./mod.ts",
-    "@ursamu/core": "jsr:@ursamu/core@^1.0.0",
+    "@ursamu/core": "jsr:@ursamu/core@^1.0.3",
     "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.7.0",
     "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.7.0/eval",
     "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.7.0/parse",

--- a/packages/mush/src/commands/sdk.ts
+++ b/packages/mush/src/commands/sdk.ts
@@ -174,6 +174,12 @@ async function targetFn(
     return resolveRoom(actor.location);
   }
 
+  // #dbref — numeric or slug object ids
+  const hashMatch = q.match(/^#(.+)$/);
+  if (hashMatch) {
+    const raw = await dbojs.queryOne({ id: hashMatch[1] });
+    if (raw) return hydrate(raw);
+  }
   const idMatch = q.match(/^#?(\d+)$/);
   if (idMatch) {
     const raw = await dbojs.queryOne({ id: idMatch[1] });
@@ -226,6 +232,15 @@ export async function createNativeSDK(
   const sess = sessions.get(socketId);
   const clientType =
     (sess?.meta?.clientType as string | undefined) || "telnet";
+  // Live NAWS overrides DB until persist lands (same session).
+  const tw = sess?.meta?.termWidth;
+  const th = sess?.meta?.termHeight;
+  if (typeof tw === "number" && tw >= 40 && tw <= 250) {
+    me.state = { ...me.state, termWidth: Math.trunc(tw) };
+  }
+  if (typeof th === "number" && th >= 1 && th <= 255) {
+    me.state = { ...me.state, termHeight: Math.trunc(th) };
+  }
 
   const u: IUrsamuSDK = {
     state,
@@ -528,9 +543,14 @@ export async function createNativeSDK(
     },
 
     teleport: async (targetStr: string, destination: string) => {
-      const tarObj = await dbojs.queryOne({ id: targetStr });
-      if (!tarObj) return;
-      await dbojs.modify({ id: tarObj.id }, "$set", { location: destination } as Partial<IDBOBJ>);
+      const { moveObject } = await import("../world/move.ts");
+      await moveObject({
+        targetId: targetStr,
+        destinationId: destination,
+        cause: "teleport",
+        actorId: me.id,
+        look: true,
+      });
     },
 
     checkLock: async (target: string | IDBObj, lock: string) => {
@@ -948,10 +968,14 @@ export async function createNativeSDK(
     trigger: async (targetStr: string, attr: string, args?: string[]) => {
       const tarObj = await dbojs.queryOne({ id: targetStr });
       if (!tarObj) return;
-      const attrs = (tarObj.data?.attributes as Array<{ name: string; value: string }> | undefined) || [];
-      const attrData = attrs.find((a) => a.name.toUpperCase() === attr.toUpperCase());
+      const { getAttribute } = await import(
+        "../world/get-attribute.ts"
+      );
+      const attrData = await getAttribute(tarObj, attr);
       if (!attrData) return;
-      const { runSoftcodeSimple } = await import("../softcode/engine.ts");
+      const { runSoftcodeSimple } = await import(
+        "../softcode/engine.ts"
+      );
       await runSoftcodeSimple(attrData.value, {
         actorId: actorId,
         executorId: tarObj.id,
@@ -960,18 +984,29 @@ export async function createNativeSDK(
       });
     },
 
-    eval: async (targetStr: string, attr: string, args?: string[]): Promise<string> => {
+    eval: async (
+      targetStr: string,
+      attr: string,
+      args?: string[],
+    ): Promise<string> => {
       let tarObj = await dbojs.queryOne({ id: targetStr });
       if (!tarObj) {
         tarObj = (await dbojs.queryOne({
-          "data.name": new RegExp(`^${targetStr.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "i"),
+          "data.name": new RegExp(
+            `^${targetStr.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+            "i",
+          ),
         })) || undefined;
       }
       if (!tarObj) return "";
-      const attrs = (tarObj.data?.attributes as Array<{ name: string; value: string }> | undefined) || [];
-      const attrData = attrs.find((a) => a.name.toUpperCase() === attr.toUpperCase());
+      const { getAttribute } = await import(
+        "../world/get-attribute.ts"
+      );
+      const attrData = await getAttribute(tarObj, attr);
       if (!attrData) return "";
-      const { runSoftcodeSimple } = await import("../softcode/engine.ts");
+      const { runSoftcodeSimple } = await import(
+        "../softcode/engine.ts"
+      );
       const result = await runSoftcodeSimple(attrData.value, {
         actorId: actorId,
         executorId: tarObj.id,
@@ -985,7 +1020,9 @@ export async function createNativeSDK(
       if (!str) return "";
       if (!me.id || me.id === "#-1") return str;
       try {
-        const { runSoftcodeSimple } = await import("../softcode/engine.ts");
+        const { runSoftcodeSimple } = await import(
+          "../softcode/engine.ts"
+        );
         return await runSoftcodeSimple(str, {
           actorId: me.id,
           executorId: me.id,
@@ -994,7 +1031,10 @@ export async function createNativeSDK(
         });
       } catch (e: unknown) {
         console.error("[evalString]", e);
-        return str;
+        const { formatEvalError } = await import(
+          "../softcode/eval-errors.ts"
+        );
+        return formatEvalError(e);
       }
     },
 

--- a/packages/mush/src/events/hooks.ts
+++ b/packages/mush/src/events/hooks.ts
@@ -5,32 +5,9 @@ import { gameHooks, getConfig } from "@ursamu/core";
 import { SDKService } from "../softcode/sdk-service.ts";
 import type { IDBOBJ } from "../world/types.ts";
 import type { ObjectDestroyedEvent, SayEvent, PoseEvent } from "./types.ts";
-import type { IAttribute } from "../world/types.ts";
 import { notifyRoomDisconnect } from "./disconnect-notice.ts";
-
-/**
- * Recursively fetch a named attribute from an object, walking its parent chain.
- * Returns `undefined` when not found; cycles are detected via a visited set.
- */
-export const getAttribute = async (
-  obj:     IDBOBJ,
-  attr:    string,
-  visited: Set<string> = new Set(),
-): Promise<IAttribute | undefined> => {
-  const attribute = obj.data?.attributes?.find(
-    (a: IAttribute) => a.name.toLowerCase() === attr.toLowerCase(),
-  );
-  if (attribute) return attribute;
-
-  if (obj.data?.parent) {
-    const parentId = obj.data.parent as string;
-    visited.add(obj.id);
-    if (visited.has(parentId)) return undefined;
-    const parent = await dbojs.queryOne({ id: parentId });
-    if (parent) return getAttribute(parent as IDBOBJ, attr, visited);
-  }
-  return undefined;
-};
+export { getAttribute } from "../world/get-attribute.ts";
+import { getAttribute } from "../world/get-attribute.ts";
 
 // Helper to check if attribute is softcode (starts with $ or is otherwise a softcode attribute)
 function isAttrSoftcode(attr: { value?: string } | null): boolean {
@@ -61,19 +38,35 @@ const _onSay = async (e: SayEvent) => {
   if (!e.roomId) return;
   // Heard text for say: the full formatted line as players see it
   const heard = `${e.actorName} says, "${e.message}"`;
-  const masterRoomId = getConfig<string>("game.masterRoom") || undefined;
-  // deno-lint-ignore no-explicit-any
-  await fireCaretPatterns(e.roomId, heard, e.actorId, e.socketId || "", dbojs as any, masterRoomId).catch(
-    err => console.error("[Hooks] ^-pattern error on player:say:", err)
+  const masterRoomId = getConfig<string>("game.masterRoom") ||
+    undefined;
+  await fireCaretPatterns(
+    e.roomId,
+    heard,
+    e.actorId,
+    e.socketId || "",
+    dbojs,
+    masterRoomId,
+  ).catch(
+    (err) =>
+      console.error("[Hooks] ^-pattern error on player:say:", err),
   );
 };
 
 const _onPose = async (e: PoseEvent) => {
   if (!e.roomId) return;
-  const masterRoomId = getConfig<string>("game.masterRoom") || undefined;
-  // deno-lint-ignore no-explicit-any
-  await fireCaretPatterns(e.roomId, e.content, e.actorId, e.socketId || "", dbojs as any, masterRoomId).catch(
-    err => console.error("[Hooks] ^-pattern error on player:pose:", err)
+  const masterRoomId = getConfig<string>("game.masterRoom") ||
+    undefined;
+  await fireCaretPatterns(
+    e.roomId,
+    e.content,
+    e.actorId,
+    e.socketId || "",
+    dbojs,
+    masterRoomId,
+  ).catch(
+    (err) =>
+      console.error("[Hooks] ^-pattern error on player:pose:", err),
   );
 };
 

--- a/packages/mush/src/format/handlers.ts
+++ b/packages/mush/src/format/handlers.ts
@@ -52,12 +52,15 @@ export function registerFormatTemplate(
   const handler: FormatHandler = async (u, target, defaultArg) => {
     const { runSoftcodeSimple } = await import("../softcode/engine.ts");
     const out = await runSoftcodeSimple(mushSource, {
-      actorId:    u.me.id,
+      actorId: u.me.id,
       executorId: target.id,
-      args:       [defaultArg],
-      socketId:   u.socketId,
+      args: [defaultArg],
+      socketId: u.socketId,
     });
-    return out ?? null;
+    if (out == null || out === "" || out.startsWith("#-1")) {
+      return null;
+    }
+    return out;
   };
   registerFormatHandler(slot, handler);
   return handler;
@@ -83,6 +86,10 @@ export async function runPluginFormatHandlers(
   return null;
 }
 
+function isSoftcodeFailure(out: string): boolean {
+  return out.startsWith("#-1");
+}
+
 export async function resolveFormat(
   u: IUrsamuSDK,
   target: IDBObj,
@@ -93,17 +100,31 @@ export async function resolveFormat(
     try {
       const raw = await u.attr.get(target.id, slot);
       if (raw != null && raw !== "") {
-        const { runSoftcodeSimple } = await import("../softcode/engine.ts");
-        return await runSoftcodeSimple(raw, {
-          actorId:    u.me.id,
+        const { runSoftcodeSimple } = await import(
+          "../softcode/engine.ts"
+        );
+        const out = await runSoftcodeSimple(raw, {
+          actorId: u.me.id,
           executorId: target.id,
-          args:       [defaultArg],
-          socketId:   u.socketId,
+          args: [defaultArg],
+          socketId: u.socketId,
         });
+        // Parse/eval failures surface as #-1 … — fall through like throw
+        if (out != null && isSoftcodeFailure(out)) {
+          console.warn(
+            `[resolveFormat ${slot}] softcode eval failed ` +
+              `on #${target.id}: ${out}`,
+          );
+        } else if (out != null && out !== "") {
+          return out;
+        }
       }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[resolveFormat ${slot}] softcode eval failed on #${target.id}: ${msg}`);
+      console.warn(
+        `[resolveFormat ${slot}] softcode eval failed ` +
+          `on #${target.id}: ${msg}`,
+      );
     }
   }
   return await runPluginFormatHandlers(slot, u, target, defaultArg);

--- a/packages/mush/src/main.ts
+++ b/packages/mush/src/main.ts
@@ -162,6 +162,12 @@ export const initializeEngine = async (
     await loadCmds();
   }
 
+  // NAWS / client term size → player data.termWidth/Height
+  const { wireTermSizePersistence } = await import(
+    "./session/term-size.ts"
+  );
+  wireTermSizePersistence();
+
   // Soft-register packaged help (optional @ursamu/help)
   try {
     const { registerHelpDir } = await import(

--- a/packages/mush/src/main_utils.ts
+++ b/packages/mush/src/main_utils.ts
@@ -194,31 +194,7 @@ export const target = async (
   return pickNameMatch(nearby, name);
 };
 
-import type { IAttribute } from "./world/types.ts";
-
-/**
- * Recursively fetch a named attribute from an object, walking its parent chain.
- * Returns `undefined` when not found; cycles are detected via a visited set.
- */
-export const getAttribute = async (
-  obj:     IDBOBJ,
-  attr:    string,
-  visited: Set<string> = new Set(),
-): Promise<IAttribute | undefined> => {
-  const attribute = obj.data?.attributes?.find(
-    (a: IAttribute) => a.name.toLowerCase() === attr.toLowerCase(),
-  );
-  if (attribute) return attribute;
-
-  if (obj.data?.parent) {
-    const parentId = obj.data.parent as string;
-    visited.add(obj.id);
-    if (visited.has(parentId)) return undefined;
-    const parent = await dbojs.queryOne({ id: parentId });
-    if (parent) return getAttribute(parent as IDBOBJ, attr, visited);
-  }
-  return undefined;
-};
+export { getAttribute } from "./world/get-attribute.ts";
 
 /** First ;-separated segment (login / primary name). */
 export function primaryName(name: string): string {

--- a/packages/mush/src/session/term-size.ts
+++ b/packages/mush/src/session/term-size.ts
@@ -1,0 +1,54 @@
+/**
+ * Persist NAWS / client terminal size onto the player object.
+ */
+import { gameHooks, sessions, clampTermWidth, clampTermHeight } from "@ursamu/core";
+import { dbojs } from "../world/dbobjs.ts";
+
+type TermSizeEvent = {
+  socketId: string;
+  termWidth?: unknown;
+  termHeight?: unknown;
+  cid?: string;
+};
+
+async function onTermSize(e: TermSizeEvent): Promise<void> {
+  const w = clampTermWidth(e.termWidth);
+  const h = clampTermHeight(e.termHeight);
+  if (w == null && h == null) return;
+
+  const session = sessions.get(e.socketId);
+  // Prefer explicit cid (telnet sidecar), else session actor.
+  const actorId =
+    (typeof e.cid === "string" && e.cid) ||
+    (session as { actorId?: string } | undefined)?.actorId ||
+    session?.sessionId ||
+    null;
+  if (!actorId || actorId === "#-1") return;
+
+  const patch: Record<string, unknown> = {};
+  if (w != null) patch["data.termWidth"] = w;
+  if (h != null) patch["data.termHeight"] = h;
+
+  try {
+    const prior = await dbojs.queryOne({ id: actorId });
+    if (!prior) return;
+    await dbojs.modify({ id: actorId }, "$set", patch);
+  } catch (err: unknown) {
+    console.error("[term-size] persist failed:", err);
+  }
+}
+
+let _wired = false;
+
+/** Idempotent: subscribe session:termSize → player data.termWidth/Height. */
+export function wireTermSizePersistence(): void {
+  if (_wired) return;
+  _wired = true;
+  gameHooks.on("session:termSize", onTermSize);
+}
+
+export function unwiredTermSizePersistence(): void {
+  if (!_wired) return;
+  gameHooks.off("session:termSize", onTermSize);
+  _wired = false;
+}

--- a/packages/mush/src/softcode/cemit.ts
+++ b/packages/mush/src/softcode/cemit.ts
@@ -1,0 +1,78 @@
+/**
+ * Softcode / @cemit channel delivery via core rooms.
+ */
+import { rooms } from "@ursamu/core";
+import { chans } from "../world/dbobjs.ts";
+
+const CEMIT_PREFIX = "\x00cemit\x00";
+
+/** True if message is a softcode cemit sentinel. */
+export function isCemitSentinel(msg: string): boolean {
+  return typeof msg === "string" && msg.startsWith(CEMIT_PREFIX);
+}
+
+/**
+ * Parse `\x00cemit\x00channel\x00message` → parts.
+ * Returns null if not a cemit sentinel.
+ */
+export function parseCemitSentinel(
+  msg: string,
+): { channel: string; text: string } | null {
+  if (!isCemitSentinel(msg)) return null;
+  const rest = msg.slice(CEMIT_PREFIX.length);
+  const i = rest.indexOf("\x00");
+  if (i < 0) {
+    return { channel: rest.trim(), text: "" };
+  }
+  return {
+    channel: rest.slice(0, i).trim(),
+    text: rest.slice(i + 1),
+  };
+}
+
+/**
+ * Broadcast to a named channel room. Looks up header from chans DB
+ * when available; otherwise sends the body alone.
+ */
+export async function deliverCemit(
+  channel: string,
+  text: string,
+  opts?: { noHeader?: boolean },
+): Promise<boolean> {
+  const name = channel.trim();
+  if (!name) return false;
+  let line = text;
+  if (!opts?.noHeader) {
+    try {
+      const all = await chans.query({});
+      const chan = all.find(
+        (c) =>
+          String(c.name ?? "").toLowerCase() === name.toLowerCase() ||
+          String(c.id ?? "").toLowerCase() === name.toLowerCase(),
+      );
+      if (chan) {
+        const header = String(
+          (chan as { header?: string }).header ?? `[${chan.name}]`,
+        );
+        line = `${header} ${text}`.trim();
+        // Prefer canonical room key = channel name
+        rooms.broadcast(String(chan.name), line);
+        rooms.broadcast(String(chan.name).toLowerCase(), line);
+        return true;
+      }
+    } catch {
+      /* chans unavailable */
+    }
+  }
+  rooms.broadcast(name, line);
+  rooms.broadcast(name.toLowerCase(), line);
+  return true;
+}
+
+/** Handle sentinel from softcode output.broadcast / send. */
+export async function handleCemitSentinel(msg: string): Promise<boolean> {
+  const parsed = parseCemitSentinel(msg);
+  if (!parsed) return false;
+  await deliverCemit(parsed.channel, parsed.text);
+  return true;
+}

--- a/packages/mush/src/softcode/engine.ts
+++ b/packages/mush/src/softcode/engine.ts
@@ -18,6 +18,7 @@ import {
   restoreRegisters,
   toLibCtx,
 } from "./context.ts";
+import { getAttributeValue } from "../world/get-attribute.ts";
 
 // Import all UrsaMU stdlib modules (side-effect registrations into _registry).
 import "./stdlib/index.ts";
@@ -43,10 +44,25 @@ const bridgeAccessor: ObjectAccessor = {
     const ctx = _activeCtx;
     if (!ctx) return null;
     const e = expr.trim().toLowerCase();
-    if (e === "me")      return ctx.executor.id;
-    if (e === "here")    return ctx.executor.location ?? null;
+    if (e === "me") return ctx.executor.id;
+    if (e === "here") return ctx.executor.location ?? null;
     if (e === "enactor") return ctx.enactor;
-    if (/^#(-?\d+)$/.test(expr)) return expr.slice(1);
+    const raw = expr.trim();
+    if (raw.startsWith("#") && raw.length > 1) {
+      const idOrTag = raw.slice(1);
+      const byId = await ctx.db.queryById(idOrTag);
+      if (byId) return byId.id;
+      if (!/^\d+$/.test(idOrTag)) {
+        const personal = await ctx.db.getPlayerTagById(
+          ctx.enactor,
+          idOrTag,
+        );
+        if (personal) return personal;
+        const global = await ctx.db.getTagById(idOrTag);
+        if (global) return global;
+      }
+      return null;
+    }
     const obj = await ctx.db.queryByName(expr);
     return obj?.id ?? null;
   },
@@ -124,9 +140,7 @@ const bridgeAccessor: ObjectAccessor = {
   async findObject(_from: string, expr: string): Promise<string | null> {
     const ctx = _activeCtx;
     if (!ctx) return null;
-    if (/^#(-?\d+)$/.test(expr)) return expr.slice(1);
-    const obj = await ctx.db.queryByName(expr);
-    return obj?.id ?? null;
+    return bridgeAccessor.resolveTarget(_from, expr);
   },
   async getTag(name: string): Promise<string | null> {
     const ctx = _activeCtx;
@@ -393,6 +407,9 @@ export async function runSoftcode(
   _activeCtx = ctx;
   try {
     return await _engine.evalString(code, toLibCtx(ctx));
+  } catch (e: unknown) {
+    const { formatEvalError } = await import("./eval-errors.ts");
+    return formatEvalError(e);
   } finally {
     _activeCtx = null;
   }
@@ -442,7 +459,7 @@ export async function runSoftcodeSimple(
       lcon:              async (locId) => (await dbojs.query({ location: locId })).map(hydrate),
       lwho:              async () => (await dbojs.query({ flags: /connected/i })).filter((r) => r.flags.includes("player")).map(hydrate),
       lattr:             async (objId) => { const r = await dbojs.queryOne({ id: objId }); return ((r?.data?.attributes as Array<{ name: string }> | undefined) ?? []).map((a) => a.name); },
-      getAttribute:      async (obj, attr) => { const attrs = (obj.state?.attributes as Array<{ name: string; value: string }> | undefined) ?? []; return attrs.find((a) => a.name.toUpperCase() === attr.toUpperCase())?.value ?? null; },
+      getAttribute: (obj, attr) => getAttributeValue(obj, attr),
       getTagById:        async () => null,
       getPlayerTagById:  async () => null,
       lsearch:           async () => [],
@@ -456,22 +473,52 @@ export async function runSoftcodeSimple(
     },
     output: {
       send: (msg: string, targetId?: string) => {
-        const dest = targetId ?? opts.socketId ?? opts.actorId;
-        send([dest], msg);
+        void (async () => {
+          const { handleCemitSentinel, isCemitSentinel } = await import(
+            "./cemit.ts"
+          );
+          if (isCemitSentinel(msg)) {
+            await handleCemitSentinel(msg);
+            return;
+          }
+          const { socketsForPlayer } = await import(
+            "../world/move.ts"
+          );
+          const dest = targetId ?? opts.socketId ?? opts.actorId;
+          const socks = dest
+            ? socketsForPlayer(dest)
+            : [];
+          const targets = socks.length
+            ? socks
+            : (dest ? [dest] : []);
+          if (targets.length) send(targets, msg);
+        })().catch(console.error);
       },
       roomBroadcast: (msg: string, roomId: string, excludeId?: string) => {
-        dbojs.query({ location: roomId }).then((contents) => {
-          for (const c of contents) {
-            if (c.flags.includes("connected") && c.id !== excludeId) {
-              send([c.id], msg);
-            }
-          }
-        }).catch(console.error);
+        void (async () => {
+          const { sendToRoom } = await import("../world/move.ts");
+          await sendToRoom(roomId, msg, excludeId);
+        })().catch(console.error);
       },
       broadcast: (msg: string) => {
-        dbojs.query({ flags: /connected/i }).then((players) => {
-          for (const p of players) send([p.id], msg);
-        }).catch(console.error);
+        void (async () => {
+          const { handleCemitSentinel, isCemitSentinel } = await import(
+            "./cemit.ts"
+          );
+          if (isCemitSentinel(msg)) {
+            await handleCemitSentinel(msg);
+            return;
+          }
+          const { socketsForPlayer } = await import(
+            "../world/move.ts"
+          );
+          const players = await dbojs.query({ flags: /connected/i });
+          const socks = new Set<string>();
+          for (const p of players) {
+            for (const s of socketsForPlayer(p.id)) socks.add(s);
+          }
+          if (socks.size) send([...socks], msg);
+        })().catch(console.error);
       },
     },
   };

--- a/packages/mush/src/softcode/eval-errors.ts
+++ b/packages/mush/src/softcode/eval-errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Format softcode / eval failures for player-visible output.
+ * TinyMUX-style #-1 prefix; never echo the raw input as "success".
+ */
+export function formatEvalError(err: unknown): string {
+  let detail = "EVAL ERROR";
+  if (err instanceof Error && err.message) {
+    detail = err.message.replace(/\s+/g, " ").trim().slice(0, 120);
+  } else if (typeof err === "string" && err.trim()) {
+    detail = err.replace(/\s+/g, " ").trim().slice(0, 120);
+  } else if (err != null) {
+    detail = String(err).replace(/\s+/g, " ").trim().slice(0, 120);
+  }
+  if (!detail) detail = "EVAL ERROR";
+  if (detail.toUpperCase().startsWith("#-1")) return detail;
+  return `#-1 ${detail}`;
+}

--- a/packages/mush/src/softcode/handlers/objects.ts
+++ b/packages/mush/src/softcode/handlers/objects.ts
@@ -290,7 +290,13 @@ export async function handleEventsMessage(
         const { fireCaretPatterns } = await import("../../world/caret-patterns.ts");
         const speakerId = d.speakerId ?? (context?.id as string | undefined) ?? "";
         const socketId  = (context?.socketId as string | undefined) ?? "";
-        await fireCaretPatterns(d.roomId, d.text, speakerId, socketId, dbojs as { query: (q: unknown) => Promise<IDBOBJ[]> }).catch(
+        await fireCaretPatterns(
+          d.roomId,
+          d.text,
+          speakerId,
+          socketId,
+          dbojs,
+        ).catch(
           (e: unknown) => console.error("[events:emit room:text]", e),
         );
       }

--- a/packages/mush/src/softcode/handlers/output.ts
+++ b/packages/mush/src/softcode/handlers/output.ts
@@ -4,9 +4,12 @@
  * Handles worker messages that route output to players:
  *   send, broadcast, room:broadcast, teleport, patch
  */
-import { send as coreSend, broadcastAll, notify as coreNotify } from "@ursamu/core";
+import {
+  send as coreSend,
+  broadcastAll,
+  notify as coreNotify,
+} from "@ursamu/core";
 import { gameHooks } from "@ursamu/core";
-import { dbojs } from "../../world/dbobjs.ts";
 import type { SDKContext } from "../sdk-service.ts";
 
 type Msg = Record<string, unknown>;
@@ -33,21 +36,31 @@ export function handleNotify(msg: Msg, worker: globalThis.Worker): void {
 }
 
 /** Route a "broadcast" message to all connected sockets. */
-export function handleBroadcast(msg: Msg): void {
+export async function handleBroadcast(msg: Msg): Promise<void> {
   const message = msg.message as string | undefined;
-  if (message) broadcastAll(message);
+  if (!message) return;
+  const { handleCemitSentinel, isCemitSentinel } = await import(
+    "../cemit.ts"
+  );
+  if (isCemitSentinel(message)) {
+    await handleCemitSentinel(message);
+    return;
+  }
+  broadcastAll(message);
 }
 
 /** Broadcast a message to all players in a specific room. */
 export async function handleRoomBroadcast(msg: Msg): Promise<void> {
-  const message    = msg.message  as string | undefined;
-  const room       = msg.room     as string | undefined;
-  const excludeIds = Array.isArray(msg.exclude) ? (msg.exclude as string[]) : [];
+  const message = msg.message as string | undefined;
+  const room = msg.room as string | undefined;
+  const excludeIds = Array.isArray(msg.exclude)
+    ? (msg.exclude as string[])
+    : [];
   if (!message || !room) return;
 
-  const players = await dbojs.query({ $and: [{ location: room }, { flags: /connected/i }] });
-  const targets = players.filter(p => !excludeIds.includes(p.id)).map(p => p.id);
-  if (targets.length > 0) coreSend(targets, message);
+  const { sendToRoom } = await import("../../world/move.ts");
+  const exclude = excludeIds[0];
+  await sendToRoom(room, message, exclude);
 }
 
 /** Update an in-memory context state property from a "patch" message. */
@@ -97,40 +110,24 @@ export async function emitResultHooks(
   }
 }
 
-/** Move an entity to a new location, notifying rooms and triggering auto-look. */
-export function handleTeleport(msg: Msg, context: SDKContext | undefined): void {
+/** Move an entity: leave/arrive + look via shared moveObject. */
+export function handleTeleport(
+  msg: Msg,
+  context: SDKContext | undefined,
+): void {
   if (!msg.target || !msg.destination) return;
-  void context;
+  const actorId = context?.id as string | undefined;
 
   (async () => {
     try {
-      const target = await dbojs.queryOne({ id: msg.target as string });
-      const dest   = await dbojs.queryOne({ id: msg.destination as string });
-      if (!target || !dest) return;
-
-      const mk = (o: { data?: Record<string, unknown> }) =>
-        String(o.data?.moniker ?? o.data?.name ?? "Unknown");
-
-      const sourceId = target.location;
-      if (sourceId) {
-        const sourcePlayers = await dbojs.query({
-          $and: [{ location: sourceId }, { flags: /connected/i }, { id: { $ne: target.id } }],
-        });
-        if (sourcePlayers.length > 0) {
-          coreSend(sourcePlayers.map(p => p.id), `${mk(target)} has left.`);
-        }
-      }
-
-      await dbojs.modify({ id: target.id }, "$set", { location: msg.destination as string });
-
-      const destPlayers = await dbojs.query({
-        $and: [{ location: msg.destination as string }, { flags: /connected/i }, { id: { $ne: target.id } }],
+      const { moveObject } = await import("../../world/move.ts");
+      await moveObject({
+        targetId: String(msg.target),
+        destinationId: String(msg.destination),
+        cause: "teleport",
+        actorId,
+        look: true,
       });
-      if (destPlayers.length > 0) {
-        const sourceRoom = sourceId ? await dbojs.queryOne({ id: sourceId }) : null;
-        const fromStr    = sourceRoom?.data?.name ? ` from ${sourceRoom.data.name}` : "";
-        coreSend(destPlayers.map(p => p.id), `${mk(target)} has arrived${fromStr}.`);
-      }
     } catch (e: unknown) {
       console.error("[SandboxHandlers] teleport error:", e);
     }

--- a/packages/mush/src/softcode/sandbox.ts
+++ b/packages/mush/src/softcode/sandbox.ts
@@ -67,7 +67,10 @@ class LocalSandbox {
 
         if (type === "send")           { handleSend(msg, context); return; }
         if (type === "notify")         { handleNotify(msg, worker); return; }
-        if (type === "broadcast")      { handleBroadcast(msg); return; }
+        if (type === "broadcast") {
+          await handleBroadcast(msg);
+          return;
+        }
         if (type === "room:broadcast") { await handleRoomBroadcast(msg); return; }
         if (type === "teleport")       { handleTeleport(msg, context); return; }
 

--- a/packages/mush/src/softcode/stdlib/object-server.ts
+++ b/packages/mush/src/softcode/stdlib/object-server.ts
@@ -173,9 +173,27 @@ register("hasrxlevel",   async () => "0");
 register("hastxlevel",   async () => "0");
 register("listrlevels",  async () => "");
 register("terminfo",     async () => "");
-register("height",       async () => "24");
-register("width",        async () => "80");
-register("colordepth",   async () => "16");
+register("height", async (_a, ctx) => {
+  const uctx = ctx as unknown as {
+    executor?: { state?: Record<string, unknown> };
+  };
+  const h = uctx.executor?.state?.termHeight;
+  if (typeof h === "number" && Number.isFinite(h) && h >= 1 && h <= 255) {
+    return String(Math.trunc(h));
+  }
+  return "24";
+});
+register("width", async (_a, ctx) => {
+  const uctx = ctx as unknown as {
+    executor?: { state?: Record<string, unknown> };
+  };
+  const w = uctx.executor?.state?.termWidth;
+  if (typeof w === "number" && Number.isFinite(w) && w >= 40 && w <= 250) {
+    return String(Math.trunc(w));
+  }
+  return "78";
+});
+register("colordepth", async () => "16");
 register("isobjid",      async (a) => /^#\d+$/.test(a[0] ?? "") ? "1" : "0");
 register("bittype",      async () => "0");
 

--- a/packages/mush/src/softcode/stdlib/object-shared.ts
+++ b/packages/mush/src/softcode/stdlib/object-shared.ts
@@ -29,17 +29,24 @@ export async function resolveObj(ref: string, ctx: EvalContext): Promise<IDBObj 
   let result: IDBObj | null = null;
   if (r.toLowerCase() === "here") {
     result = await ctx.db.queryById(ctx.executor.location ?? "") ?? null;
-  } else if (/^#(-?\d+)$/.test(r)) {
-    result = await ctx.db.queryById(r.slice(1));
-  } else if (/^#[a-zA-Z]/.test(r)) {
-    // #tagname — check actor's personal tags first, then global tags
-    const tagName = r.slice(1);
-    const personalId = await ctx.db.getPlayerTagById(ctx.actor.id, tagName);
-    if (personalId) {
-      result = await ctx.db.queryById(personalId);
-    } else {
-      const globalId = await ctx.db.getTagById(tagName);
-      result = globalId ? await ctx.db.queryById(globalId) : null;
+  } else if (r.startsWith("#") && r.length > 1) {
+    const idOrTag = r.slice(1);
+    // Exact dbref first (numeric or slug ids like "room_limbo")
+    result = await ctx.db.queryById(idOrTag);
+    if (!result && !/^\d+$/.test(idOrTag)) {
+      // #tagname — personal tags, then global
+      const personalId = await ctx.db.getPlayerTagById(
+        ctx.actor.id,
+        idOrTag,
+      );
+      if (personalId) {
+        result = await ctx.db.queryById(personalId);
+      } else {
+        const globalId = await ctx.db.getTagById(idOrTag);
+        result = globalId
+          ? await ctx.db.queryById(globalId)
+          : null;
+      }
     }
   } else {
     result = await ctx.db.queryByName(r);

--- a/packages/mush/src/softcode/stdlib/output.ts
+++ b/packages/mush/src/softcode/stdlib/output.ts
@@ -9,7 +9,7 @@
  *   pemit(player, message)         — send to named player
  *   remit(room, message)           — broadcast to room (all contents)
  *   oemit(player, message)         — broadcast to room, excluding player
- *   cemit(channel, message)        — send to channel (stub: not yet wired)
+ *   cemit(channel, message)        — send to channel (rooms + header)
  *   emit(message)                  — broadcast to executor's room
  *   npemit(player, message)        — pemit without player name prefix
  *   trigger(obj/attr[, args...])   — trigger an attribute (via @trigger wire)
@@ -20,19 +20,32 @@ import type { IDBObj } from "../../world/types.ts";
 
 // ── helpers ───────────────────────────────────────────────────────────────
 
-async function resolveObj(ref: string, ctx: EvalContext): Promise<IDBObj | null> {
+async function resolveObj(
+  ref: string,
+  ctx: EvalContext,
+): Promise<IDBObj | null> {
   const r = ref.trim();
   if (!r) return null;
-  if (r.toLowerCase() === "me")      return ctx.executor;
-  if (r.toLowerCase() === "here")    return await ctx.db.queryById(ctx.executor.location ?? "") ?? null;
+  if (r.toLowerCase() === "me") return ctx.executor;
+  if (r.toLowerCase() === "here") {
+    return await ctx.db.queryById(ctx.executor.location ?? "") ??
+      null;
+  }
   if (r.toLowerCase() === "enactor") return ctx.actor;
-  if (/^#(-?\d+)$/.test(r))         return await ctx.db.queryById(r.slice(1));
-  if (/^#[a-zA-Z]/.test(r)) {
-    const tagName  = r.slice(1);
-    const personalId = await ctx.db.getPlayerTagById(ctx.actor.id, tagName);
-    if (personalId) return await ctx.db.queryById(personalId);
-    const globalId = await ctx.db.getTagById(tagName);
-    return globalId ? await ctx.db.queryById(globalId) : null;
+  if (r.startsWith("#") && r.length > 1) {
+    const idOrTag = r.slice(1);
+    const byId = await ctx.db.queryById(idOrTag);
+    if (byId) return byId;
+    if (!/^\d+$/.test(idOrTag)) {
+      const personalId = await ctx.db.getPlayerTagById(
+        ctx.actor.id,
+        idOrTag,
+      );
+      if (personalId) return await ctx.db.queryById(personalId);
+      const globalId = await ctx.db.getTagById(idOrTag);
+      return globalId ? await ctx.db.queryById(globalId) : null;
+    }
+    return null;
   }
   return await ctx.db.queryByName(r);
 }

--- a/packages/mush/src/telnet.ts
+++ b/packages/mush/src/telnet.ts
@@ -406,11 +406,15 @@ async function handleTelnetConnection(conn: Deno.Conn, wsPort: number, _welcome:
       if (nawsSeq !== null) {
         const parsed = parseNawsBytes(nawsSeq);
         if (parsed && cid) {
-          // Forward termWidth to the WS hub so the player's DB record can be updated
+          // Forward size to WS hub → session meta + player DB
           if (sock && (sock as WebSocket).readyState === WebSocket.OPEN) {
             (sock as WebSocket).send(JSON.stringify({
               msg: "",
-              data: { cid, termWidth: parsed.width }
+              data: {
+                cid,
+                termWidth: parsed.width,
+                termHeight: parsed.height,
+              },
             }));
           }
         }

--- a/packages/mush/src/verbs/building-admin.ts
+++ b/packages/mush/src/verbs/building-admin.ts
@@ -70,8 +70,13 @@ EXAMPLES
     if (!destination) { u.send(`Could not find destination: ${destName}`); return; }
     const canEnter = (await u.canEdit(u.me, destination)) || destination.flags.has("enter_ok");
     if (!canEnter) { u.send("Permission denied (destination check)."); return; }
-    u.teleport(target.id, destination.id);
-    u.send(`You teleport ${u.util.displayName(target, u.me)} to ${u.util.displayName(destination, u.me)}.`);
+    await Promise.resolve(
+      u.teleport(target.id, destination.id),
+    );
+    u.send(
+      `You teleport ${u.util.displayName(target, u.me)} to ` +
+        `${u.util.displayName(destination, u.me)}.`,
+    );
   },
 });
 

--- a/packages/mush/src/verbs/emit-exec.ts
+++ b/packages/mush/src/verbs/emit-exec.ts
@@ -108,20 +108,34 @@ export async function execWall(u: IUrsamuSDK): Promise<void> {
 export async function execCemit(u: IUrsamuSDK): Promise<void> {
   const arg = u.cmd.args[0] || "";
   const eqIdx = arg.indexOf("=");
-  if (eqIdx === -1) { u.send("Usage: @cemit <channel>=<message>"); return; }
+  if (eqIdx === -1) {
+    u.send("Usage: @cemit <channel>=<message>");
+    return;
+  }
 
   const chanName = arg.slice(0, eqIdx).trim();
   const message = await u.evalString(arg.slice(eqIdx + 1));
-  if (!chanName || !message) { u.send("Usage: @cemit <channel>=<message>"); return; }
+  if (!chanName || !message) {
+    u.send("Usage: @cemit <channel>=<message>");
+    return;
+  }
 
-  const chans = (await u.chan.list()) as Array<{ name: string; header?: string; alias?: string }>;
+  const { deliverCemit } = await import("../softcode/cemit.ts");
+  const chans = (await u.chan.list()) as Array<{
+    name: string;
+    header?: string;
+    alias?: string;
+  }>;
   const chan = chans.find(
     (c) =>
       c.name.toLowerCase() === chanName.toLowerCase() ||
-      c.alias?.toLowerCase() === chanName.toLowerCase()
+      c.alias?.toLowerCase() === chanName.toLowerCase(),
   );
-  if (!chan) { u.send(`Channel '${chanName}' not found.`); return; }
-  u.broadcast(`${chan.header || `[${chan.name}]`} ${message}`);
+  if (!chan) {
+    u.send(`Channel '${chanName}' not found.`);
+    return;
+  }
+  await deliverCemit(chan.name, message);
   u.send(`Message sent to channel ${chan.name}.`);
 }
 

--- a/packages/mush/src/verbs/home.ts
+++ b/packages/mush/src/verbs/home.ts
@@ -7,10 +7,13 @@ import {
   sendListLayout,
 } from "./cmd-ui.ts";
 
-export function execHome(u: IUrsamuSDK): void {
+export async function execHome(u: IUrsamuSDK): Promise<void> {
   const actor = u.me;
-  const homeId = (actor.state.home as string) || "1";
-  u.teleport(actor.id, homeId);
+  const homeId = String(
+    (actor.state.home as string) || "1",
+  );
+  // teleport → moveObject: leave/arrive + look
+  await Promise.resolve(u.teleport(actor.id, homeId));
   u.send("There's no place like home...");
 }
 

--- a/packages/mush/src/verbs/look.ts
+++ b/packages/mush/src/verbs/look.ts
@@ -476,7 +476,11 @@ async function hydrateLookContents(
 ): Promise<void> {
   try {
     const found = await u.db.search({ location: target.id });
-    if (Array.isArray(found)) target.contents = found;
+    // Empty search must not wipe preloaded contents (tests, lagging
+    // adapters). Prefer DB when it returns at least one object.
+    if (Array.isArray(found) && found.length > 0) {
+      target.contents = found;
+    }
   } catch {
     /* keep target.contents if already set */
   }

--- a/packages/mush/src/verbs/world.ts
+++ b/packages/mush/src/verbs/world.ts
@@ -57,7 +57,7 @@ export async function execTeleport(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
-  u.teleport(target.id, destination.id);
+  await Promise.resolve(u.teleport(target.id, destination.id));
   u.send(
     `You teleport ${u.util.displayName(target, actor)} to ` +
       `${u.util.displayName(destination, actor)}.`,
@@ -109,7 +109,7 @@ export async function execTel(u: IUrsamuSDK): Promise<void> {
     return;
   }
 
-  await u.db.modify(target.id, "$set", { location: dest.id });
+  await Promise.resolve(u.teleport(target.id, dest.id));
   u.send(`You are teleported to ${dest.name || dest.id}.`, target.id);
   u.send(
     `You teleport ${target.name || target.id} to ${dest.name || dest.id}.`,

--- a/packages/mush/src/world/caret-patterns.ts
+++ b/packages/mush/src/world/caret-patterns.ts
@@ -53,14 +53,59 @@ export function registerCaretExecutor(fn: CaretExecutorFn): void {
  *
  * Returns all matches (an object may have multiple matching `^` attrs).
  */
+// deno-lint-ignore no-explicit-any
+type CaretDb = {
+  // Real DBO uses typed Query<T>; keep loose for callers.
+  // deno-lint-ignore no-explicit-any
+  query: (...args: any[]) => Promise<IDBOBJ[]>;
+  // deno-lint-ignore no-explicit-any
+  queryOne: (...args: any[]) => Promise<IDBOBJ | null | undefined>;
+};
+
 export async function findCaretMatches(
-  roomId:        string,
-  text:          string,
-  speakerId:     string,
-  dbojs:         { query: (q: unknown) => Promise<IDBOBJ[]> },
+  roomId: string,
+  text: string,
+  speakerId: string,
+  dbojs: CaretDb,
   masterRoomId?: string,
 ): Promise<CaretMatch[]> {
   const hits: CaretMatch[] = [];
+
+  const scanCaretChain = async (
+    leaf: IDBOBJ,
+    cur: IDBOBJ,
+    visited: Set<string>,
+  ) => {
+    const attrs =
+      (cur.data?.attributes as
+        | Array<{ name: string; value: string }>
+        | undefined) ?? [];
+    for (const attr of attrs) {
+      if (!attr.name.startsWith("^")) continue;
+      const slashIdx = attr.name.indexOf("/", 1);
+      const pattern = slashIdx === -1
+        ? attr.name.slice(1)
+        : attr.name.slice(1, slashIdx);
+      const captures = matchGlob(pattern.trim(), text);
+      if (captures !== null) {
+        hits.push({
+          obj: leaf,
+          attrName: attr.name,
+          attrValue: attr.value,
+          captures,
+        });
+      }
+    }
+    const flagStr = (cur.flags || "").toLowerCase();
+    if (flagStr.split(/\s+/).includes("no_inherit")) return;
+    const parentId = cur.data?.parent as string | undefined;
+    if (!parentId) return;
+    visited.add(cur.id);
+    if (visited.has(parentId)) return;
+    const parent = await dbojs.queryOne({ id: parentId });
+    if (!parent) return;
+    await scanCaretChain(leaf, parent as IDBOBJ, visited);
+  };
 
   const scanContents = async (locId: string) => {
     const contents = await dbojs.query({ location: locId });
@@ -70,18 +115,7 @@ export async function findCaretMatches(
       const flagStr = (obj.flags || "").toLowerCase();
       if (!flagStr.includes("monitor")) continue;
 
-      const attrs = (obj.data?.attributes as Array<{ name: string; value: string }> | undefined) ?? [];
-      for (const attr of attrs) {
-        if (!attr.name.startsWith("^")) continue;
-
-        const slashIdx = attr.name.indexOf("/", 1);
-        const pattern  = slashIdx === -1 ? attr.name.slice(1) : attr.name.slice(1, slashIdx);
-
-        const captures = matchGlob(pattern.trim(), text);
-        if (captures !== null) {
-          hits.push({ obj, attrName: attr.name, attrValue: attr.value, captures });
-        }
-      }
+      await scanCaretChain(obj, obj, new Set());
     }
   };
 
@@ -102,11 +136,11 @@ export async function findCaretMatches(
  * handlers are caught and logged so they never interrupt the caller.
  */
 export async function fireCaretPatterns(
-  roomId:        string,
-  text:          string,
-  speakerId:     string,
-  socketId:      string,
-  dbojs:         { query: (q: unknown) => Promise<IDBOBJ[]> },
+  roomId: string,
+  text: string,
+  speakerId: string,
+  socketId: string,
+  dbojs: CaretDb,
   masterRoomId?: string,
 ): Promise<void> {
   const matches = await findCaretMatches(roomId, text, speakerId, dbojs, masterRoomId);

--- a/packages/mush/src/world/dollar-patterns.ts
+++ b/packages/mush/src/world/dollar-patterns.ts
@@ -68,27 +68,57 @@ export function matchGlob(pattern: string, input: string): string[] | null {
 }
 
 export interface DollarMatch {
-  obj:      IDBOBJ;
-  attr:     IAttribute;
+  obj: IDBOBJ;
+  attr: IAttribute;
   captures: string[];
 }
 
+// Real DBO uses typed Query<T>; keep loose for callers.
+// deno-lint-ignore no-explicit-any
+type DollarDb = {
+  // deno-lint-ignore no-explicit-any
+  query: (...args: any[]) => Promise<IDBOBJ[]>;
+  // deno-lint-ignore no-explicit-any
+  queryOne: (...args: any[]) => Promise<IDBOBJ | null | undefined>;
+};
+
 /**
  * Scan an object's attributes for `$pattern` attrs that match `input`.
+ * Local attrs first; then parents (same order as getAttribute).
  * Returns the first match found, or null.
  */
-function scanObj(obj: IDBOBJ, input: string): DollarMatch | null {
+async function scanObj(
+  obj: IDBOBJ,
+  input: string,
+  dbojs: DollarDb,
+  visited: Set<string> = new Set(),
+): Promise<DollarMatch | null> {
   const attrs = (obj.data?.attributes as IAttribute[] | undefined) ?? [];
   for (const attr of attrs) {
     if (!attr.name.startsWith("$")) continue;
 
     const slashIdx = attr.name.indexOf("/", 1);
-    const pattern  = slashIdx === -1 ? attr.name.slice(1) : attr.name.slice(1, slashIdx);
+    const pattern = slashIdx === -1
+      ? attr.name.slice(1)
+      : attr.name.slice(1, slashIdx);
 
     const captures = matchGlob(pattern.trim(), input);
     if (captures !== null) return { obj, attr, captures };
   }
-  return null;
+
+  const flags = String(obj.flags ?? "").toLowerCase();
+  if (flags.split(/\s+/).includes("no_inherit")) return null;
+
+  const parentId = obj.data?.parent as string | undefined;
+  if (!parentId) return null;
+  visited.add(obj.id);
+  if (visited.has(parentId)) return null;
+  const parent = await dbojs.queryOne({ id: parentId });
+  if (!parent) return null;
+  // Match is attributed to the leaf object that received the command.
+  const hit = await scanObj(parent as IDBOBJ, input, dbojs, visited);
+  if (!hit) return null;
+  return { obj, attr: hit.attr, captures: hit.captures };
 }
 
 /**
@@ -103,13 +133,10 @@ function scanObj(obj: IDBOBJ, input: string): DollarMatch | null {
  * Returns the first match found, or null if nothing matches.
  */
 export async function findDollarPattern(
-  actor:        IDBOBJ,
-  input:        string,
+  actor: IDBOBJ,
+  input: string,
   masterRoomId: string,
-  dbojs:        {
-    query:    (q: unknown) => Promise<IDBOBJ[]>;
-    queryOne: (q: unknown) => Promise<IDBOBJ | null | undefined>;
-  },
+  dbojs: DollarDb,
 ): Promise<DollarMatch | null> {
   const candidates: IDBOBJ[] = [];
 
@@ -133,7 +160,7 @@ export async function findDollarPattern(
   }
 
   for (const obj of candidates) {
-    const hit = scanObj(obj, input);
+    const hit = await scanObj(obj, input, dbojs);
     if (hit) return hit;
   }
   return null;

--- a/packages/mush/src/world/get-attribute.ts
+++ b/packages/mush/src/world/get-attribute.ts
@@ -1,0 +1,91 @@
+/**
+ * Parent-walking attribute resolution (TinyMUX-style).
+ *
+ * Single source for world verbs, softcode get/u/hasattr, and
+ * $pattern dispatch. Local attrs win; no_inherit stops the walk.
+ */
+import { dbojs } from "./dbobjs.ts";
+import type { IAttribute, IDBOBJ, IDBObj } from "./types.ts";
+
+type AttrHost = IDBOBJ | IDBObj;
+
+function flagSet(obj: AttrHost): Set<string> {
+  if (obj.flags instanceof Set) {
+    return new Set(
+      [...obj.flags].map((f) => String(f).toLowerCase()),
+    );
+  }
+  return new Set(
+    String(obj.flags ?? "")
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+}
+
+function localAttrs(obj: AttrHost): IAttribute[] {
+  if ("data" in obj && obj.data?.attributes) {
+    return obj.data.attributes as IAttribute[];
+  }
+  const state = (obj as IDBObj).state;
+  if (state?.attributes) {
+    return state.attributes as IAttribute[];
+  }
+  return [];
+}
+
+function parentIdOf(obj: AttrHost): string | undefined {
+  if ("data" in obj && obj.data?.parent != null) {
+    const p = obj.data.parent;
+    return p === "" || p == null ? undefined : String(p);
+  }
+  const state = (obj as IDBObj).state;
+  if (state?.parent != null) {
+    const p = state.parent;
+    return p === "" || p == null ? undefined : String(p);
+  }
+  return undefined;
+}
+
+function findLocal(
+  attrs: IAttribute[],
+  attr: string,
+): IAttribute | undefined {
+  const want = attr.toLowerCase();
+  return attrs.find((a) => a.name.toLowerCase() === want);
+}
+
+/**
+ * Recursively fetch a named attribute, walking the parent chain.
+ * Cycles are detected via a visited set. Objects with the
+ * `no_inherit` flag do not read from their parent.
+ */
+export async function getAttribute(
+  obj: AttrHost,
+  attr: string,
+  visited: Set<string> = new Set(),
+): Promise<IAttribute | undefined> {
+  const hit = findLocal(localAttrs(obj), attr);
+  if (hit) return hit;
+
+  if (flagSet(obj).has("no_inherit")) return undefined;
+
+  const parentId = parentIdOf(obj);
+  if (!parentId) return undefined;
+
+  visited.add(obj.id);
+  if (visited.has(parentId)) return undefined;
+
+  const parent = await dbojs.queryOne({ id: parentId });
+  if (!parent) return undefined;
+  return getAttribute(parent as IDBOBJ, attr, visited);
+}
+
+/** Softcode-friendly: attribute value or null if missing. */
+export async function getAttributeValue(
+  obj: AttrHost,
+  attr: string,
+): Promise<string | null> {
+  const a = await getAttribute(obj, attr);
+  return a?.value ?? null;
+}

--- a/packages/mush/src/world/locks.ts
+++ b/packages/mush/src/world/locks.ts
@@ -62,11 +62,60 @@ export async function callLockFunc(
 registerBuiltin("flag", (enactor, _target, args) =>
   enactor.flags.has((args[0] ?? "").trim().toLowerCase()));
 
+/** Case-insensitive own-property lookup on enactor.state. */
+function stateAttr(
+  state: Record<string, unknown> | undefined,
+  name: string,
+): unknown {
+  if (!state || !name) return undefined;
+  if (Object.hasOwn(state, name)) return state[name];
+  const want = name.toLowerCase();
+  for (const k of Object.keys(state)) {
+    if (k.toLowerCase() === want) return state[k];
+  }
+  return undefined;
+}
+
+/**
+ * Compare lock attr values. Supports bare equality and
+ * prefixed ops: >, <, >=, <=, =, !=, <>.
+ */
+export function compareLockAttrValue(
+  actual: string,
+  wantRaw: string,
+): boolean {
+  const want = wantRaw.trim();
+  const cmp = want.match(/^(>=|<=|!=|<>|>|<|=)(.*)$/);
+  if (cmp) {
+    const op = cmp[1];
+    const rhs = cmp[2].trim();
+    const numWant = parseFloat(rhs);
+    const numAct = parseFloat(actual);
+    const bothNum = !Number.isNaN(numWant) && !Number.isNaN(numAct) &&
+      /^-?\d+(\.\d+)?$/.test(rhs) &&
+      /^-?\d+(\.\d+)?$/.test(actual.trim());
+    if (bothNum) {
+      if (op === ">=") return numAct >= numWant;
+      if (op === "<=") return numAct <= numWant;
+      if (op === ">") return numAct > numWant;
+      if (op === "<") return numAct < numWant;
+      if (op === "=") return numAct === numWant;
+      if (op === "!=" || op === "<>") return numAct !== numWant;
+    }
+    if (op === "=") return actual === rhs;
+    if (op === "!=" || op === "<>") return actual !== rhs;
+    return false;
+  }
+  return actual === want;
+}
+
 registerBuiltin("attr", (enactor, _target, args) => {
   const attrName = (args[0] ?? "").trim();
-  if (!Object.hasOwn(enactor.state, attrName)) return false;
+  if (!attrName) return false;
+  const actual = stateAttr(enactor.state, attrName);
+  if (actual === undefined) return false;
   if (args.length < 2) return true;
-  return String(enactor.state[attrName]) === args[1].trim();
+  return compareLockAttrValue(String(actual), args[1] ?? "");
 });
 
 registerBuiltin("type", (enactor, _target, args) =>
@@ -352,24 +401,9 @@ const checkAtom = async (
     const colon = atom.indexOf(":");
     const attr = atom.slice(0, colon);
     const val = atom.slice(colon + 1);
-    const actualVal =
-      enactor.state?.[attr] ??
-      enactor.state?.[attr.toLowerCase()];
+    const actualVal = stateAttr(enactor.state, attr);
     if (actualVal === undefined) return false;
-
-    const cmpMatch = val.match(/^(>=|<=|>|<)(.+)$/);
-    if (cmpMatch) {
-      const [, op, numStr] = cmpMatch;
-      const numVal = parseFloat(numStr);
-      const actualNum = parseFloat(String(actualVal));
-      if (!isNaN(numVal) && !isNaN(actualNum)) {
-        if (op === ">=") return actualNum >= numVal;
-        if (op === "<=") return actualNum <= numVal;
-        if (op === ">") return actualNum > numVal;
-        if (op === "<") return actualNum < numVal;
-      }
-    }
-    return String(actualVal) === val;
+    return compareLockAttrValue(String(actualVal), val);
   }
 
   // +FLAG or bare FLAG / power word (wizard, builder+, connected).

--- a/packages/mush/src/world/move.ts
+++ b/packages/mush/src/world/move.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared object move: leave/arrive room messages, DB update,
+ * object:moved hook, optional auto-look for players.
+ */
+import { send, sessions, gameHooks } from "@ursamu/core";
+import { dbojs } from "./dbobjs.ts";
+import type { IDBOBJ } from "./types.ts";
+
+function displayName(obj: IDBOBJ): string {
+  return String(
+    obj.data?.moniker ?? obj.data?.name ?? obj.id ?? "Someone",
+  );
+}
+
+/** Live socket ids for a player dbref. */
+export function socketsForPlayer(playerId: string): string[] {
+  return sessions
+    .list()
+    .filter((s) => {
+      const aid = (s as unknown as { actorId?: string }).actorId;
+      return aid === playerId || s.sessionId === playerId;
+    })
+    .map((s) => s.socketId);
+}
+
+/** Send to connected players in a room (socket ids, never raw dbrefs). */
+export async function sendToRoom(
+  locationId: string,
+  message: string,
+  excludeId?: string,
+): Promise<void> {
+  const here = await dbojs.query({ location: locationId });
+  const socks = new Set<string>();
+  for (const c of here) {
+    if (excludeId && c.id === excludeId) continue;
+    const fl = String(c.flags || "").toLowerCase();
+    if (fl.includes("exit") || fl.includes("room")) continue;
+    if (!fl.includes("connected") && !fl.includes("player")) {
+      // still try sockets — connected flag may lag
+    }
+    for (const sid of socketsForPlayer(c.id)) socks.add(sid);
+  }
+  if (socks.size) send([...socks], message);
+}
+
+export type MoveOpts = {
+  targetId: string;
+  destinationId: string;
+  /** Suppress leave/arrive lines. */
+  quiet?: boolean;
+  /** Run look for the moved player (default true if player). */
+  look?: boolean;
+  /** Cause string for object:moved. */
+  cause?: string;
+  actorId?: string;
+};
+
+/**
+ * Move an object. Returns false if target or destination missing.
+ */
+export async function moveObject(opts: MoveOpts): Promise<boolean> {
+  const target = await dbojs.queryOne({ id: opts.targetId });
+  const dest = await dbojs.queryOne({ id: opts.destinationId });
+  if (!target || !dest) return false;
+
+  const fromId = target.location as string | undefined;
+  const name = displayName(target);
+  const quiet = opts.quiet === true;
+
+  if (!quiet && fromId && fromId !== opts.destinationId) {
+    await sendToRoom(fromId, `${name} has left.`, target.id);
+  }
+
+  await dbojs.modify(
+    { id: target.id },
+    "$set",
+    { location: opts.destinationId } as Partial<IDBOBJ>,
+  );
+
+  if (!quiet && opts.destinationId !== fromId) {
+    const fromRoom = fromId
+      ? await dbojs.queryOne({ id: fromId })
+      : null;
+    const fromStr = fromRoom?.data?.name
+      ? ` from ${fromRoom.data.name}`
+      : "";
+    await sendToRoom(
+      opts.destinationId,
+      `${name} has arrived${fromStr}.`,
+      target.id,
+    );
+  }
+
+  try {
+    await gameHooks.emit("object:moved", {
+      objectId: target.id,
+      from: fromId ?? null,
+      to: opts.destinationId,
+      cause: opts.cause ?? "move",
+      actorId: opts.actorId ?? target.id,
+    });
+  } catch (e: unknown) {
+    console.error("[move] object:moved hook:", e);
+  }
+
+  const isPlayer = String(target.flags || "").toLowerCase()
+    .includes("player");
+  const doLook = opts.look !== false && isPlayer;
+  if (doLook) {
+    await forceLook(target.id);
+  }
+  return true;
+}
+
+/** Force `look` on all live sessions for a player. */
+export async function forceLook(playerId: string): Promise<void> {
+  const socks = socketsForPlayer(playerId);
+  if (!socks.length) return;
+  try {
+    const { createNativeSDK } = await import(
+      "../commands/sdk.ts"
+    );
+    for (const sid of socks) {
+      const u = await createNativeSDK(sid, playerId, {
+        name: "look",
+        original: "look",
+        args: [],
+      });
+      await u.execute("look");
+    }
+  } catch (e: unknown) {
+    console.error("[move] auto-look failed:", e);
+  }
+}

--- a/packages/mush/tests/cemit_softcode.test.ts
+++ b/packages/mush/tests/cemit_softcode.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Softcode cemit delivers via rooms.broadcast (channel name).
+ */
+import { assertEquals } from "@std/assert";
+import { rooms } from "@ursamu/core";
+import { dbojs, chans } from "../src/world/dbobjs.ts";
+import { runSoftcodeSimple } from "../src/softcode/engine.ts";
+import { deliverCemit } from "../src/softcode/cemit.ts";
+import "../src/softcode/stdlib/index.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test(
+  "deliverCemit: rooms.broadcast to channel",
+  OPTS,
+  async () => {
+    const sid = "cemit_sock_1";
+    rooms.join(sid, "Public");
+    assertEquals(rooms.members("Public").includes(sid), true);
+    await deliverCemit("Public", "hello channel");
+    rooms.leave(sid, "Public");
+  },
+);
+
+Deno.test(
+  "softcode cemit does not throw for known channel",
+  OPTS,
+  async () => {
+    const prior = await chans.queryOne({ id: "public" });
+    if (!prior) {
+      await chans.create({
+        id: "public",
+        name: "Public",
+        header: "[Public]",
+      } as Record<string, unknown> & { id: string; name: string });
+    }
+    const a = await dbojs.queryOne({ id: "cemit_actor" });
+    if (a) await dbojs.delete({ id: "cemit_actor" });
+    await dbojs.create({
+      id: "cemit_actor",
+      flags: "player connected",
+      data: { name: "CemitActor" },
+    });
+
+    const out = await runSoftcodeSimple(
+      "[cemit(Public,test line)]",
+      { actorId: "cemit_actor", executorId: "cemit_actor" },
+    );
+    assertEquals(out, "");
+
+    await dbojs.delete({ id: "cemit_actor" });
+  },
+);

--- a/packages/mush/tests/eval_errors.test.ts
+++ b/packages/mush/tests/eval_errors.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Softcode eval errors must surface to the enactor, not echo input.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { runSoftcodeSimple } from "../src/softcode/engine.ts";
+import { formatEvalError } from "../src/softcode/eval-errors.ts";
+import "../src/softcode/stdlib/index.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+Deno.test("formatEvalError: Error message", OPTS, () => {
+  const s = formatEvalError(new Error("boom"));
+  assertEquals(s.startsWith("#-1 "), true);
+  assertStringIncludes(s, "boom");
+});
+
+Deno.test("formatEvalError: unknown", OPTS, () => {
+  const s = formatEvalError("raw");
+  assertStringIncludes(s, "raw");
+});
+
+Deno.test(
+  "runSoftcodeSimple: unknown fn returns #-1",
+  OPTS,
+  async () => {
+    const out = await runSoftcodeSimple("[nosuchfn(1)]", {
+      actorId: "ev_a",
+      executorId: "ev_a",
+    });
+    assertEquals(out.startsWith("#-1"), true);
+    assertStringIncludes(out.toLowerCase(), "not found");
+  },
+);
+
+Deno.test(
+  "runSoftcodeSimple: div by zero returns #-1",
+  OPTS,
+  async () => {
+    const out = await runSoftcodeSimple("[div(1,0)]", {
+      actorId: "ev_a",
+      executorId: "ev_a",
+    });
+    assertEquals(out.startsWith("#-1"), true);
+  },
+);
+
+Deno.test(
+  "runSoftcodeSimple: good path unchanged",
+  OPTS,
+  async () => {
+    assertEquals(
+      await runSoftcodeSimple("[add(2,3)]", {
+        actorId: "ev_a",
+        executorId: "ev_a",
+      }),
+      "5",
+    );
+  },
+);
+
+Deno.test(
+  "softcode width/height use executor term size",
+  OPTS,
+  async () => {
+    const { dbojs } = await import("../src/world/dbobjs.ts");
+    const id = "ev_term_actor";
+    const prior = await dbojs.queryOne({ id });
+    if (prior) await dbojs.delete({ id });
+    await dbojs.create({
+      id,
+      flags: "player connected",
+      data: {
+        name: "TermActor",
+        termWidth: 100,
+        termHeight: 40,
+      },
+    });
+    assertEquals(
+      await runSoftcodeSimple("[width()]", {
+        actorId: id,
+        executorId: id,
+      }),
+      "100",
+    );
+    assertEquals(
+      await runSoftcodeSimple("[height()]", {
+        actorId: id,
+        executorId: id,
+      }),
+      "40",
+    );
+    await dbojs.delete({ id });
+  },
+);

--- a/packages/mush/tests/lock_attr_cmp.test.ts
+++ b/packages/mush/tests/lock_attr_cmp.test.ts
@@ -1,0 +1,63 @@
+/**
+ * attr() lockfunc comparisons and colon-form attr:>N.
+ */
+import { assertEquals } from "@std/assert";
+import { evaluateLock } from "../src/world/locks.ts";
+import type { IDBObj } from "../src/world/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+function actor(state: Record<string, unknown>): IDBObj {
+  return {
+    id: "la1",
+    name: "LockActor",
+    flags: new Set(["player", "connected"]),
+    state,
+    contents: [],
+  };
+}
+
+Deno.test("attr(name): presence only", OPTS, async () => {
+  const a = actor({ level: 3, tribe: "glass" });
+  assertEquals(await evaluateLock("attr(level)", a, a), true);
+  assertEquals(await evaluateLock("attr(missing)", a, a), false);
+});
+
+Deno.test("attr(name, val): equality", OPTS, async () => {
+  const a = actor({ tribe: "glasswalker" });
+  assertEquals(
+    await evaluateLock("attr(tribe, glasswalker)", a, a),
+    true,
+  );
+  assertEquals(
+    await evaluateLock("attr(tribe, silverfang)", a, a),
+    false,
+  );
+});
+
+Deno.test("attr(name, >N) comparisons", OPTS, async () => {
+  const a = actor({ level: 5, xp: "12" });
+  assertEquals(await evaluateLock("attr(level,>4)", a, a), true);
+  assertEquals(await evaluateLock("attr(level,>5)", a, a), false);
+  assertEquals(await evaluateLock("attr(level,>=5)", a, a), true);
+  assertEquals(await evaluateLock("attr(level,<6)", a, a), true);
+  assertEquals(await evaluateLock("attr(level,<=5)", a, a), true);
+  assertEquals(await evaluateLock("attr(xp,>=10)", a, a), true);
+  assertEquals(await evaluateLock("attr(xp,<10)", a, a), false);
+});
+
+Deno.test("attr case-insensitive key", OPTS, async () => {
+  const a = actor({ Tribe: "glass" });
+  assertEquals(await evaluateLock("attr(tribe)", a, a), true);
+  assertEquals(
+    await evaluateLock("attr(TRIBE, glass)", a, a),
+    true,
+  );
+});
+
+Deno.test("colon form level:>4 still works", OPTS, async () => {
+  const a = actor({ level: 5 });
+  assertEquals(await evaluateLock("level:>4", a, a), true);
+  assertEquals(await evaluateLock("level:<5", a, a), false);
+  assertEquals(await evaluateLock("level:5", a, a), true);
+});

--- a/packages/mush/tests/move.test.ts
+++ b/packages/mush/tests/move.test.ts
@@ -1,0 +1,68 @@
+/**
+ * moveObject: leave/arrive + location update.
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs } from "../src/world/dbobjs.ts";
+import { moveObject } from "../src/world/move.ts";
+import type { IDBOBJ } from "../src/world/types.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+const R1 = "mv_room1";
+const R2 = "mv_room2";
+const P = "mv_player";
+
+async function wipe(): Promise<void> {
+  for (const id of [R1, R2, P]) {
+    const prior = await dbojs.queryOne({ id });
+    if (prior) await dbojs.delete({ id });
+  }
+}
+
+Deno.test("moveObject: updates location", OPTS, async () => {
+  await wipe();
+  await dbojs.create({
+    id: R1,
+    flags: "room",
+    data: { name: "Start" },
+  });
+  await dbojs.create({
+    id: R2,
+    flags: "room",
+    data: { name: "End" },
+  });
+  await dbojs.create({
+    id: P,
+    flags: "player connected",
+    location: R1,
+    data: { name: "Mover" },
+  });
+
+  const ok = await moveObject({
+    targetId: P,
+    destinationId: R2,
+    look: false,
+    quiet: true,
+  });
+  assertEquals(ok, true);
+  const p = await dbojs.queryOne({ id: P }) as IDBOBJ;
+  assertEquals(p.location, R2);
+  await wipe();
+});
+
+Deno.test("moveObject: missing dest fails", OPTS, async () => {
+  await wipe();
+  await dbojs.create({
+    id: P,
+    flags: "player",
+    location: R1,
+    data: { name: "Mover" },
+  });
+  const ok = await moveObject({
+    targetId: P,
+    destinationId: "no_such_room",
+    look: false,
+  });
+  assertEquals(ok, false);
+  await wipe();
+});

--- a/packages/mush/tests/parent_attr.test.ts
+++ b/packages/mush/tests/parent_attr.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Parent-chain attribute resolution for softcode and world layer.
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs } from "../src/world/dbobjs.ts";
+import {
+  getAttribute,
+  getAttributeValue,
+} from "../src/world/get-attribute.ts";
+import type { IDBOBJ } from "../src/world/types.ts";
+import { runSoftcodeSimple } from "../src/softcode/engine.ts";
+import "../src/softcode/stdlib/index.ts";
+import { findDollarPattern } from "../src/world/dollar-patterns.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+
+const PARENT = "par_attr_parent";
+const CHILD = "par_attr_child";
+const GRAND = "par_attr_grand";
+const ACTOR = "par_attr_actor";
+
+async function wipe(...ids: string[]): Promise<void> {
+  for (const id of ids) {
+    const prior = await dbojs.queryOne({ id });
+    if (prior) await dbojs.delete({ id });
+  }
+}
+
+async function seedChain(): Promise<void> {
+  await wipe(PARENT, CHILD, GRAND, ACTOR);
+  await dbojs.create({
+    id: GRAND,
+    flags: "thing",
+    data: {
+      name: "Grand",
+      attributes: [
+        { name: "FOO", value: "from-grand", setter: "" },
+        { name: "BAR", value: "grand-bar", setter: "" },
+      ],
+    },
+  });
+  await dbojs.create({
+    id: PARENT,
+    flags: "thing",
+    data: {
+      name: "Parent",
+      parent: GRAND,
+      attributes: [
+        { name: "FOO", value: "from-parent", setter: "" },
+        { name: "$greet *", value: "@pemit %#=hi %0", setter: "" },
+      ],
+    },
+  });
+  await dbojs.create({
+    id: CHILD,
+    flags: "thing",
+    data: {
+      name: "Child",
+      parent: PARENT,
+      attributes: [
+        { name: "LOCAL", value: "only-child", setter: "" },
+      ],
+    },
+  });
+  await dbojs.create({
+    id: ACTOR,
+    flags: "player connected",
+    location: "0",
+    data: { name: "Actor" },
+  });
+}
+
+Deno.test("getAttribute: local wins over parent", OPTS, async () => {
+  await seedChain();
+  const child = await dbojs.queryOne({ id: CHILD }) as IDBOBJ;
+  const a = await getAttribute(child, "LOCAL");
+  assertEquals(a?.value, "only-child");
+  const foo = await getAttribute(child, "FOO");
+  assertEquals(foo?.value, "from-parent");
+  await wipe(PARENT, CHILD, GRAND, ACTOR);
+});
+
+Deno.test("getAttribute: walks grandparent", OPTS, async () => {
+  await seedChain();
+  const child = await dbojs.queryOne({ id: CHILD }) as IDBOBJ;
+  const bar = await getAttribute(child, "BAR");
+  assertEquals(bar?.value, "grand-bar");
+  await wipe(PARENT, CHILD, GRAND, ACTOR);
+});
+
+Deno.test("getAttribute: cycle does not hang", OPTS, async () => {
+  await wipe("cyc_a", "cyc_b");
+  await dbojs.create({
+    id: "cyc_a",
+    flags: "thing",
+    data: {
+      name: "A",
+      parent: "cyc_b",
+      attributes: [],
+    },
+  });
+  await dbojs.create({
+    id: "cyc_b",
+    flags: "thing",
+    data: {
+      name: "B",
+      parent: "cyc_a",
+      attributes: [
+        { name: "X", value: "loop", setter: "" },
+      ],
+    },
+  });
+  const a = await dbojs.queryOne({ id: "cyc_a" }) as IDBOBJ;
+  const x = await getAttribute(a, "X");
+  assertEquals(x?.value, "loop");
+  await wipe("cyc_a", "cyc_b");
+});
+
+Deno.test(
+  "getAttribute: no_inherit blocks parent walk",
+  OPTS,
+  async () => {
+    await wipe("ni_p", "ni_c");
+    await dbojs.create({
+      id: "ni_p",
+      flags: "thing",
+      data: {
+        name: "P",
+        attributes: [
+          { name: "SECRET", value: "nope", setter: "" },
+        ],
+      },
+    });
+    await dbojs.create({
+      id: "ni_c",
+      flags: "thing no_inherit",
+      data: {
+        name: "C",
+        parent: "ni_p",
+        attributes: [],
+      },
+    });
+    const c = await dbojs.queryOne({ id: "ni_c" }) as IDBOBJ;
+    assertEquals(await getAttribute(c, "SECRET"), undefined);
+    assertEquals(await getAttributeValue(c, "SECRET"), null);
+    await wipe("ni_p", "ni_c");
+  },
+);
+
+Deno.test(
+  "softcode get/hasattr/u walk parent chain",
+  OPTS,
+  async () => {
+    await seedChain();
+    // Name refs (slug ids are not #N dbrefs in softcode resolve)
+    const get = await runSoftcodeSimple(
+      "[get(Child/FOO)]",
+      { actorId: ACTOR, executorId: CHILD },
+    );
+    assertEquals(get, "from-parent");
+
+    const bar = await runSoftcodeSimple(
+      "[xget(Child,BAR)]",
+      { actorId: ACTOR, executorId: CHILD },
+    );
+    assertEquals(bar, "grand-bar");
+
+    const has = await runSoftcodeSimple(
+      "[hasattr(Child,FOO)]",
+      { actorId: ACTOR, executorId: CHILD },
+    );
+    assertEquals(has, "1");
+
+    const u = await runSoftcodeSimple(
+      "[u(me/FOO)]",
+      { actorId: ACTOR, executorId: CHILD },
+    );
+    assertEquals(u, "from-parent");
+
+    const miss = await runSoftcodeSimple(
+      "[get(Child/NOPE)]",
+      { actorId: ACTOR, executorId: CHILD },
+    );
+    assertEquals(miss, "");
+
+    await wipe(PARENT, CHILD, GRAND, ACTOR);
+  },
+);
+
+Deno.test(
+  "dollar $pattern matches parent attr",
+  OPTS,
+  async () => {
+    await seedChain();
+    const actor = await dbojs.queryOne({ id: ACTOR }) as IDBOBJ;
+    // Put child in inventory so findDollarPattern scans it
+    await dbojs.modify(
+      { id: CHILD },
+      "$set",
+      { location: ACTOR } as Partial<IDBOBJ>,
+    );
+    const hit = await findDollarPattern(
+      actor,
+      "greet bob",
+      "",
+      dbojs,
+    );
+    assertEquals(hit?.attr.name, "$greet *");
+    assertEquals(hit?.captures[0], "bob");
+    assertEquals(hit?.obj.id, CHILD);
+    await wipe(PARENT, CHILD, GRAND, ACTOR);
+  },
+);

--- a/packages/mush/tests/resolve_slug.test.ts
+++ b/packages/mush/tests/resolve_slug.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Softcode #slug dbref resolution (not only #digits).
+ */
+import { assertEquals } from "@std/assert";
+import { dbojs } from "../src/world/dbobjs.ts";
+import { runSoftcodeSimple } from "../src/softcode/engine.ts";
+import "../src/softcode/stdlib/index.ts";
+
+const OPTS = { sanitizeResources: false, sanitizeOps: false };
+const ID = "slug_room_alpha";
+
+async function wipe(): Promise<void> {
+  const prior = await dbojs.queryOne({ id: ID });
+  if (prior) await dbojs.delete({ id: ID });
+  const a = await dbojs.queryOne({ id: "slug_actor" });
+  if (a) await dbojs.delete({ id: "slug_actor" });
+}
+
+Deno.test("softcode name(#slug_id) resolves", OPTS, async () => {
+  await wipe();
+  await dbojs.create({
+    id: ID,
+    flags: "room",
+    data: { name: "Alpha Room" },
+  });
+  await dbojs.create({
+    id: "slug_actor",
+    flags: "player connected",
+    location: ID,
+    data: { name: "SlugActor" },
+  });
+
+  const out = await runSoftcodeSimple(
+    `[name(#${ID})]`,
+    { actorId: "slug_actor", executorId: "slug_actor" },
+  );
+  assertEquals(out, "Alpha Room");
+
+  const miss = await runSoftcodeSimple(
+    "[name(#no_such_slug_zzz)]",
+    { actorId: "slug_actor", executorId: "slug_actor" },
+  );
+  // mushcode name() on missing → empty or #-1
+  assertEquals(miss === "" || miss.startsWith("#-1"), true);
+
+  await wipe();
+});


### PR DESCRIPTION
## Summary

Engine-only release of **@ursamu/core 1.0.3** and **@ursamu/mush 1.0.37**.

- Softcode parent-walk attrs; eval `#-1` errors; NAWS term size
- Lock `attr(name,>N)`; `moveObject` leave/arrive/look
- Softcode `#slug` dbrefs; `cemit` → channels
- look: empty `db.search` must not wipe contents
- Format softcode `#-1` falls through (security test)

## Test plan

- [x] `packages/core` tests — 54 passed
- [x] `packages/mush` tests — 250 passed
- [x] `deno task preflight` both packages
- [x] root security tests (pre-commit) — 268 passed
- [ ] CI Packages publish on merge to main (OIDC)

## Publish order

CI publishes core then mush on push to `main`.

## Host notes

After upgrade, force single mush/core instance via import-map overrides
(`packages/mush/docs/DUAL_PACKAGE.md`).