### PR TITLE
release: core 1.0.5 + mush 1.0.38 (JSR collision fix)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `@ursamu/core` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.5] - 2026-09-04
+
+Re-cut of NAWS/term-size APIs (1.0.3 was already on JSR).
+
 ## [1.0.3] - 2026-09-04
 
 ### Added

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/core",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "exports": "./mod.ts",
   "tasks": {
     "test": "deno test tests/ --allow-all --unstable-kv --no-check",

--- a/packages/mush/CHANGELOG.md
+++ b/packages/mush/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.38
+
+- Depend on `@ursamu/core@^1.0.5` (NAWS APIs actually on JSR).
+
 ## 1.0.37
 
 - `moveObject`: teleport/home leave+arrive + auto-look;

--- a/packages/mush/deno.json
+++ b/packages/mush/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/mush",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "exports": {
     ".": "./mod.ts",
     "./app": "./src/app.ts",
@@ -21,7 +21,7 @@
   },
   "imports": {
     "@ursamu/mush": "./mod.ts",
-    "@ursamu/core": "jsr:@ursamu/core@^1.0.3",
+    "@ursamu/core": "jsr:@ursamu/core@^1.0.5",
     "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.7.0",
     "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.7.0/eval",
     "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.7.0/parse",


### PR DESCRIPTION
## Summary
`@ursamu/core@1.0.3` already existed on JSR (Aug). Re-cut as **1.0.5** so NAWS APIs actually publish. **mush 1.0.38** pins `core@^1.0.5`.

## Test plan
- [x] pre-commit security suite
- [ ] Packages CI publish on merge