### PR TITLE
fix(cli): 0.1.5 pin mush 1.0.38 / core 1.0.5 on create

### DIFF
--- a/.github/workflows/packages-ci.yml
+++ b/.github/workflows/packages-ci.yml
@@ -233,3 +233,21 @@ jobs:
         with: { deno-version: v2.x }
       - name: Publish
         run: deno publish --allow-slow-types --no-check --allow-dirty
+
+  publish-cli:
+    name: Publish @ursamu/cli to JSR
+    runs-on: ubuntu-latest
+    needs: [core, mush]
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with: { deno-version: v2.x }
+      - name: Publish
+        run: deno publish --allow-slow-types --no-check --allow-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ repo is the monorepo that publishes those packages.
 ### New
 
 - **JSR create path** — scaffold with
-  `deno run -A jsr:@ursamu/cli@0.1.4/create my-game`.
+  `deno run -A jsr:@ursamu/cli@0.1.5/create my-game`.
   Default plugins include help, channels, builder, bbs,
   mail, wiki, staff web, and the public site (`/play`).
   `--local` still links a monorepo checkout.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![ursamu header](https://raw.githubusercontent.com/ursamu/ursamu/main/ursamu_github_banner.png)
 
 [![JSR](https://jsr.io/badges/@ursamu/mush)](https://jsr.io/@ursamu/mush)
-[![CLI](https://img.shields.io/badge/cli-0.1.4-blue)](https://jsr.io/@ursamu/cli)
+[![CLI](https://img.shields.io/badge/cli-0.1.5-blue)](https://jsr.io/@ursamu/cli)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Deno](https://img.shields.io/badge/deno-2.x-black)](https://deno.land)
 
@@ -19,13 +19,15 @@ Need Deno 2.x: <https://deno.land>
 ## Make a game
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create my-game
+deno run -A --minimum-dependency-age=0 \
+  jsr:@ursamu/cli@0.1.5/create my-game
 cd my-game
 deno task start
 ```
 
-If Deno refuses a just-published CLI version, add
-`--minimum-dependency-age=0` to the `deno run` line.
+`--minimum-dependency-age=0` allows brand-new JSR
+publishes (Deno defaults to a 24h gate). New games pin
+`@ursamu/mush@1.0.38` and `@ursamu/core@1.0.5`.
 
 | Open this | What it is |
 |-----------|------------|

--- a/docs/child-games/index.md
+++ b/docs/child-games/index.md
@@ -16,7 +16,7 @@ project, including daemon scripts, telnet sidecar, and a `.env` with a
 fresh JWT secret (v2.4.0):
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create my-game
+deno run -A jsr:@ursamu/cli@0.1.5/create my-game
 cd my-game
 ```
 
@@ -91,9 +91,9 @@ remain legacy-compatible.
 Install or update from the CLI:
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/plugin install <url> [--ref <ref>]
-deno run -A jsr:@ursamu/cli@0.1.4/plugin update
-deno run -A jsr:@ursamu/cli@0.1.4/plugin list
+deno run -A jsr:@ursamu/cli@0.1.5/plugin install <url> [--ref <ref>]
+deno run -A jsr:@ursamu/cli@0.1.5/plugin update
+deno run -A jsr:@ursamu/cli@0.1.5/plugin list
 ```
 
 ## Local script overrides
@@ -122,8 +122,8 @@ project-specific mechanics as their own.
 ## Updating the engine
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/update         # latest stable
-deno run -A jsr:@ursamu/cli@0.1.4/update main    # specific branch
+deno run -A jsr:@ursamu/cli@0.1.5/update         # latest stable
+deno run -A jsr:@ursamu/cli@0.1.5/update main    # specific branch
 ```
 
 The updater rewrites the import map and re-runs `ensurePlugins`. Restart

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -12,7 +12,7 @@ run it with `deno run`.
 Pin a known release in scripts and docs:
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/<export> …
+deno run -A jsr:@ursamu/cli@0.1.5/<export> …
 ```
 
 | Export | Entry | Use |
@@ -30,8 +30,8 @@ deno run -A jsr:@ursamu/cli@0.1.4/<export> …
 ### New game project
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create <project-name>
-deno run -A jsr:@ursamu/cli@0.1.4/create <project-name> --local
+deno run -A jsr:@ursamu/cli@0.1.5/create <project-name>
+deno run -A jsr:@ursamu/cli@0.1.5/create <project-name> --local
 ```
 
 Creates a directory with a supervised UrsaMU game:
@@ -49,7 +49,7 @@ Creates a directory with a supervised UrsaMU game:
 ### In-tree plugin
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create plugin <name>
+deno run -A jsr:@ursamu/cli@0.1.5/create plugin <name>
 ```
 
 Run from a game project root. Options:
@@ -66,7 +66,7 @@ Run from a game project root. Options:
 ## Interactive menu
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/ursamu
+deno run -A jsr:@ursamu/cli@0.1.5/ursamu
 ```
 
 Create games/plugins, manage packages, update the engine, and edit
@@ -79,13 +79,13 @@ shell scripts from a simple numbered menu.
 Manage git-based entries in `plugins.manifest.json` (when used):
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/plugin list
-deno run -A jsr:@ursamu/cli@0.1.4/plugin install <github-url>
-deno run -A jsr:@ursamu/cli@0.1.4/plugin install <github-url> --ref v1.2.0
-deno run -A jsr:@ursamu/cli@0.1.4/plugin update <name>
-deno run -A jsr:@ursamu/cli@0.1.4/plugin remove <name>
-deno run -A jsr:@ursamu/cli@0.1.4/plugin info <name>
-deno run -A jsr:@ursamu/cli@0.1.4/plugin search <query>
+deno run -A jsr:@ursamu/cli@0.1.5/plugin list
+deno run -A jsr:@ursamu/cli@0.1.5/plugin install <github-url>
+deno run -A jsr:@ursamu/cli@0.1.5/plugin install <github-url> --ref v1.2.0
+deno run -A jsr:@ursamu/cli@0.1.5/plugin update <name>
+deno run -A jsr:@ursamu/cli@0.1.5/plugin remove <name>
+deno run -A jsr:@ursamu/cli@0.1.5/plugin info <name>
+deno run -A jsr:@ursamu/cli@0.1.5/plugin search <query>
 ```
 
 Most new games load official packages via **JSR** in
@@ -105,8 +105,8 @@ clone failures, or semver conflicts. See
 Bump the engine import in an existing game:
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/update
-deno run -A jsr:@ursamu/cli@0.1.4/update --dry-run
+deno run -A jsr:@ursamu/cli@0.1.5/update
+deno run -A jsr:@ursamu/cli@0.1.5/update --dry-run
 ```
 
 ---
@@ -114,7 +114,7 @@ deno run -A jsr:@ursamu/cli@0.1.4/update --dry-run
 ## scripts
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/scripts list
+deno run -A jsr:@ursamu/cli@0.1.5/scripts list
 ```
 
 Lists registered script names/aliases (engine + plugins).
@@ -136,9 +136,9 @@ deno task config --set game.name "My Game"
 ## Optional global install
 
 ```bash
-deno install -Ag -n ursamu jsr:@ursamu/cli@0.1.4/ursamu
+deno install -Ag -n ursamu jsr:@ursamu/cli@0.1.5/ursamu
 # or create only:
-deno install -Ag -n ursamu-create jsr:@ursamu/cli@0.1.4/create
+deno install -Ag -n ursamu-create jsr:@ursamu/cli@0.1.5/create
 ```
 
 Then: `ursamu` / `ursamu-create my-game`.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -354,10 +354,10 @@ UrsaMU is a JSR package — your game project depends on a version pinned in
 
 ```bash
 # Preview what would change
-deno run -A jsr:@ursamu/cli@0.1.4/update --dry-run
+deno run -A jsr:@ursamu/cli@0.1.5/update --dry-run
 
 # Apply the update
-deno run -A jsr:@ursamu/cli@0.1.4/update
+deno run -A jsr:@ursamu/cli@0.1.5/update
 ```
 
 After updating, restart the servers:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -17,7 +17,7 @@ claim the first staff account on the web portal.
 ## Method 1: Scaffold from JSR (recommended)
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create my-game
+deno run -A --minimum-dependency-age=0 jsr:@ursamu/cli@0.1.5/create my-game
 cd my-game
 deno task start
 ```
@@ -37,13 +37,13 @@ When `@ursamu/site` is selected, config sets
 Optional: interactive menu and package picker:
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/ursamu
+deno run -A jsr:@ursamu/cli@0.1.5/ursamu
 ```
 
 Engine-dev mode (link imports to a local monorepo checkout):
 
 ```bash
-deno run -A jsr:@ursamu/cli@0.1.4/create my-game --local
+deno run -A --minimum-dependency-age=0 jsr:@ursamu/cli@0.1.5/create my-game --local
 ```
 
 > **Imports:** game code uses `jsr:@ursamu/mush`. The legacy package

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ templateEngine: [vto, md]
 
 <!-- ── HERO ───────────────────────────────────────────────────────── -->
 <div class="home-hero animate-in">
-  <p class="home-hero__chip">mush 1.0.35 · cli 0.1.4 · MIT</p>
+  <p class="home-hero__chip">mush 1.0.38 · cli 0.1.5 · MIT</p>
   <h1>A Modern MUSH Server</h1>
   <p class="home-hero__lede">
     High-performance MU* engine in <strong>TypeScript</strong> and
@@ -30,7 +30,7 @@ templateEngine: [vto, md]
   <div class="home-stack__code">
     <div class="home-stack__code-bar">Terminal</div>
     <pre class="home-stack__pre"><span class="cmt"># Scaffold a game (engine + portal stack)</span>
-<span class="cmd">deno run -A jsr:@ursamu/cli@0.1.4/create my-game</span>
+<span class="cmd">deno run -A jsr:@ursamu/cli@0.1.5/create my-game</span>
 <span class="cmd">cd my-game</span>
 <span class="cmd">deno task start</span>
 <span class="cmt"># http://localhost:4203/  ·  /play  ·  /admin/</span></pre>

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.5
+
+- New games pin `@ursamu/mush@1.0.38` and
+  `@ursamu/core@1.0.5` (engine release).
+- Dual-package import-map overrides so plugin range
+  rewrites share one mush/core instance.
+- Scaffold peers: pglite, zod, bcrypt, mushcode ^0.7,
+  help/register, dotenv.
+- `minimumDependencyAge: "0"` in game `deno.json` so
+  brand-new JSR versions resolve immediately.
+- `server` / `telnet` / `run.sh` pass
+  `--minimum-dependency-age=0`.
+- Drop fragile `./node_modules/@types/node` types path.
+
+## 0.1.4
+
+- Prior release.

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@ursamu/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": {
     ".": "./mod.ts",
     "./templates": "./src/create-templates.ts",
@@ -38,7 +38,9 @@
       "templates",
       "mod.ts",
       "deno.json",
-      "README.md"
+      "README.md",
+      "CHANGELOG.md",
+      "LICENSE"
     ],
     "exclude": [
       "tests"

--- a/packages/cli/src/create-project.ts
+++ b/packages/cli/src/create-project.ts
@@ -316,9 +316,9 @@ export async function scaffoldProject(
     "@std/testing": "jsr:@std/testing@^1.0.17",
     "@std/testing/bdd": "jsr:@std/testing@^1.0.17/bdd",
     "@std/testing/mock": "jsr:@std/testing@^1.0.17/mock",
-    "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.6.0",
-    "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.6.0/eval",
-    "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.6.0/parse",
+    "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.7.0",
+    "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.7.0/eval",
+    "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.7.0/parse",
     "@ursamu/parser": "npm:@ursamu/parser@1.2.4",
     "@digibear/tags": "npm:@digibear/tags@1.0.0",
     "bcrypt": "npm:bcryptjs@2.4.3",
@@ -336,19 +336,45 @@ export async function scaffoldProject(
     "sucrase": "npm:sucrase@^3.35.0",
   };
 
+  // Engine pins: keep in sync with published @ursamu/mush + core.
+  // Dual-package override keys force plugin range rewrites onto one
+  // mush/core instance (see packages/mush/docs/DUAL_PACKAGE.md).
+  const MUSH = "jsr:@ursamu/mush@1.0.38";
+  const CORE = "jsr:@ursamu/core@1.0.5";
   const jsrImports: Record<string, string> = {
-    "ursamu":                  "jsr:@ursamu/mush@^1.0.30",
-    "@ursamu/mush":            "jsr:@ursamu/mush@^1.0.30",
-    "@ursamu/mush/app":        "jsr:@ursamu/mush@^1.0.30/app",
-    "@ursamu/core":            "jsr:@ursamu/core@^1.0.2",
-    "@ursamu/ursamu":          "jsr:@ursamu/mush@^1.0.30",
-    "@ursamu/ursamu/app":      "jsr:@ursamu/mush@^1.0.30/app",
-    "@std/path":               "jsr:@std/path@^0.224.0",
-    "@std/assert":             "jsr:@std/assert@^0.224.0",
-    "@std/fs":                 "jsr:@std/fs@^0.224.0",
-    "@electric-sql/pglite":    "npm:@electric-sql/pglite@^0.5.2",
-    "@nicia-ai/typegraph":     "npm:@nicia-ai/typegraph@^0.31.0",
-    "@nicia-ai/typegraph/postgres/pglite": "npm:@nicia-ai/typegraph@^0.31.0/postgres/pglite",
+    "ursamu": MUSH,
+    "@ursamu/mush": MUSH,
+    "@ursamu/mush/app": `${MUSH}/app`,
+    "@ursamu/core": CORE,
+    "@ursamu/ursamu": MUSH,
+    "@ursamu/ursamu/app": `${MUSH}/app`,
+    "@std/path": "jsr:@std/path@^0.224.0",
+    "@std/assert": "jsr:@std/assert@^0.224.0",
+    "@std/fs": "jsr:@std/fs@^0.224.0",
+    "@std/dotenv": "jsr:@std/dotenv@^0.224.0",
+    "dotenv": "jsr:@std/dotenv@^0.224.0",
+    "dotenv/load": "jsr:@std/dotenv@^0.224.0/load",
+    "@electric-sql/pglite": "npm:@electric-sql/pglite@^0.5.2",
+    "@nicia-ai/typegraph": "npm:@nicia-ai/typegraph@^0.31.0",
+    "@nicia-ai/typegraph/postgres/pglite":
+      "npm:@nicia-ai/typegraph@^0.31.0/postgres/pglite",
+    "zod": "npm:zod@4.4.3",
+    "bcrypt": "npm:bcryptjs@2.4.3",
+    "@ursamu/parser": "npm:@ursamu/parser@1.2.4",
+    "@digibear/tags": "npm:@digibear/tags@1.0.0",
+    "djwt": "jsr:@zaubrik/djwt@^3.0.2",
+    "quickjs-emscripten": "npm:quickjs-emscripten@0.29.0",
+    "sucrase": "npm:sucrase@^3.35.0",
+    "@ursamu/mushcode": "jsr:@ursamu/mushcode@^0.7.0",
+    "@ursamu/mushcode/eval": "jsr:@ursamu/mushcode@^0.7.0/eval",
+    "@ursamu/mushcode/parse": "jsr:@ursamu/mushcode@^0.7.0/parse",
+    // Dual-instance force (plugin publish rewrites)
+    "jsr:@ursamu/mush@^1.0.0": MUSH,
+    "jsr:@ursamu/mush@^1.0.30": MUSH,
+    "jsr:@ursamu/mush@^0.1.1": MUSH,
+    "jsr:@ursamu/mush@^0.2.0": MUSH,
+    "jsr:@ursamu/core@^1.0.0": CORE,
+    "jsr:@ursamu/core@^1.0.2": CORE,
   };
 
   function getLocalPath(pkgName: string, engineRelPath: string): string {
@@ -374,16 +400,25 @@ export async function scaffoldProject(
     const matchedOpt = optionalPackages.find((o) => o.pkgName === pkgName);
     if (isLocal) {
       localImports[pkgName] = getLocalPath(pkgName, engineRelPath);
+      if (pkgName === "@ursamu/help") {
+        localImports["@ursamu/help/register"] =
+          `${engineRelPath}/packages/help/register.ts`;
+      }
     } else if (matchedOpt) {
       jsrImports[pkgName] = matchedOpt.jsrUrl;
+      if (pkgName === "@ursamu/help") {
+        jsrImports["@ursamu/help/register"] =
+          "jsr:@ursamu/help@^1.2.0/register";
+      }
     }
   }
   const denoJson = JSON.stringify({
     nodeModulesDir: "auto",
+    // Allow brand-new JSR publishes (Deno default is 24h age gate).
+    minimumDependencyAge: "0",
     tasks: GAME_PROJECT_TASKS,
     compilerOptions: {
       lib: ["deno.window", "deno.unstable"],
-      types: ["./node_modules/@types/node/index.d.ts"],
     },
     imports: isLocal ? localImports : jsrImports,
   }, null, 2);

--- a/packages/cli/src/game-project-tasks.ts
+++ b/packages/cli/src/game-project-tasks.ts
@@ -4,6 +4,10 @@
  * Used by both `create.ts` (initial scaffold) and `update.ts` (task sync on upgrade)
  * so there is a single source of truth for what tasks a game project should have.
  */
+const DENO_RUN =
+  "deno run -A --minimum-dependency-age=0 " +
+  "--unstable-detect-cjs --unstable-kv --unstable-net";
+
 export const GAME_PROJECT_TASKS: Record<string, string> = {
   "start": "bash ./scripts/run.sh",
   "daemon": "bash ./scripts/daemon.sh",
@@ -11,15 +15,17 @@ export const GAME_PROJECT_TASKS: Record<string, string> = {
   "restart": "bash ./scripts/restart.sh",
   "status": "bash ./scripts/status.sh",
   "logs": "tail -f logs/main.log logs/telnet.log",
-  "update": "deno run -A --minimum-dependency-age=0 jsr:@ursamu/ursamu/cli update",
+  "update":
+    "deno run -A --minimum-dependency-age=0 jsr:@ursamu/cli@0.1.5/update",
   "safe-update": "bash ./scripts/safe-update.sh",
   "safe-update:reboot": "bash ./scripts/safe-update.sh --reboot",
-  "server":
-    "deno run -A --watch --unstable-detect-cjs --unstable-kv --unstable-net ./src/main.ts",
-  "telnet":
-    "deno run -A --unstable-detect-cjs --unstable-kv --unstable-net ./src/telnet.ts",
-  "test": "deno test --allow-all --unstable-kv --no-check",
-  "showcase": "deno run -A ./src/cli/showcase.ts",
+  "server": `${DENO_RUN} --watch ./src/main.ts`,
+  "telnet": `${DENO_RUN} ./src/telnet.ts`,
+  "test":
+    "deno test --allow-all --unstable-kv --no-check " +
+    "--minimum-dependency-age=0",
+  "showcase":
+    "deno run -A --minimum-dependency-age=0 ./src/cli/showcase.ts",
 };
 
 /** Default plugins.manifest.json written into new projects and restored by update. */

--- a/packages/cli/templates/game-scripts/run.sh
+++ b/packages/cli/templates/game-scripts/run.sh
@@ -11,7 +11,7 @@ mkdir -p run logs
 ursamu_free_ports
 sleep 1
 
-DENO_FLAGS="--allow-all --unstable-detect-cjs --unstable-kv --unstable-net"
+DENO_FLAGS="--allow-all --minimum-dependency-age=0 --unstable-detect-cjs --unstable-kv --unstable-net"
 ursamu_find_supervisor
 
 ursamu_print_access


### PR DESCRIPTION
## Summary
- New games pin **mush 1.0.38** + **core 1.0.5**
- Dual-instance import-map overrides
- `minimumDependencyAge: 0` + start flags so fresh JSR works
- Peers (pglite, mushcode 0.7, help/register, …)
- CI now publishes `@ursamu/cli` on main

## Test plan
- [x] `create pin-check --non-interactive` asserts pins
- [x] pre-commit security suite
- [ ] Packages CI publish-cli on merge